### PR TITLE
Fix blank screen due to undefined player state

### DIFF
--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -10,6 +10,9 @@ interface UIBoardProps {
 
 // 簡易UI：自分の手牌＋捨て牌、AIの捨て牌のみ表示
 export const UIBoard: React.FC<UIBoardProps> = ({ players, onDiscard, isMyTurn }) => {
+  if (players.length === 0) {
+    return null;
+  }
   return (
     <div className="w-full flex flex-col items-center">
       {/* 上部：AIの捨て牌 */}


### PR DESCRIPTION
## Summary
- prevent `UIBoard` from accessing an empty player list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68563326e390832abd3320dcbe3a5575