### PR TITLE
Add GitHub Pages preview job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,44 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  deploy-preview:
+    needs: build-and-test
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+      - name: Deploy preview to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+        with:
+          preview: true
+

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ npm run preview
 - **push/PR時に自動ビルド・テスト**  
 - 成功時 `dist` アーティファクトをダウンロード可能
 - mainブランチpush時に **GitHub Pagesへ自動デプロイ**
-- 公開URL例：  
+- PR作成時は **Pagesプレビュー** を自動発行（`steps.deployment.outputs.page_url` を確認）
+- 公開URL例：
   `https://kotarotanabe.github.io/MyCodexSample/`
 
 ### 成果物をダウンロードして動作確認


### PR DESCRIPTION
## Summary
- add deploy-preview job for pull requests
- detail preview URL output in README

## Testing
- `npm run lint`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685635d11c40832ab70427db3d83d717