### PR TITLE
Improve board and UI layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,9 +3,9 @@ import { GameController } from './components/GameController';
 
 function App() {
   return (
-    <div className="min-h-screen bg-green-100 flex items-center justify-center">
-      <div className="w-full max-w-4xl mx-auto">
-        <h1 className="text-2xl font-bold my-4 text-center">麻雀 Web アプリ（1人用デモ）</h1>
+    <div className="min-h-screen bg-green-100 flex items-center justify-center py-8">
+      <div className="w-full max-w-4xl mx-auto px-4 space-y-6">
+        <h1 className="text-2xl font-bold text-center">麻雀 Web アプリ（1人用デモ）</h1>
         <GameController />
       </div>
     </div>

--- a/src/components/ScoreBoard.tsx
+++ b/src/components/ScoreBoard.tsx
@@ -4,15 +4,15 @@ import { PlayerState } from '../types/mahjong';
 export const ScoreBoard: React.FC<{ players: PlayerState[]; kyoku: number }> = ({ players, kyoku }) => {
   const kyokuStr = ['東1局', '東2局', '東3局', '東4局', '南1局', '南2局', '南3局', '南4局'][kyoku - 1] || '';
   return (
-    <div className="flex justify-between items-center p-2 bg-gray-100 rounded">
+    <div className="flex justify-between items-center p-4 bg-gray-200 rounded-lg shadow">
       <span className="font-bold">{kyokuStr}</span>
-      <div className="flex gap-4">
+      <div className="flex gap-2">
         {players.map(p => (
-          <span key={p.name}>
+          <span key={p.name} className="bg-white rounded px-2 py-1 shadow">
             {p.name}: <span className="font-mono">{p.score}</span>
           </span>
         ))}
       </div>
     </div>
   );
-};
+}; 

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -14,24 +14,22 @@ export const UIBoard: React.FC<UIBoardProps> = ({ players, onDiscard, isMyTurn }
     return null;
   }
   return (
-    <div className="w-full flex flex-col items-center">
+    <div className="w-full grid grid-cols-4 gap-2">
       {/* 上部：AIの捨て牌 */}
-      <div className="flex justify-between w-full mb-4">
-        {players.slice(1).map(ai => (
-          <div key={ai.name} className="flex flex-col items-center">
-            <div className="text-sm">{ai.name}</div>
-            <div className="flex gap-1">
-              {ai.discard.map(tile => (
-                <TileView key={tile.id} tile={tile} />
-              ))}
-            </div>
+      {players.slice(1).map(ai => (
+        <div key={ai.name} className="flex flex-col items-center">
+          <div className="text-sm mb-1">{ai.name}</div>
+          <div className="flex gap-1">
+            {ai.discard.map(tile => (
+              <TileView key={tile.id} tile={tile} />
+            ))}
           </div>
-        ))}
-      </div>
+        </div>
+      ))}
       {/* 自分の手牌 */}
-      <div className="flex flex-col items-center mt-6">
-        <div className="text-lg">あなたの手牌</div>
-        <div className="flex gap-2 mt-2">
+      <div className="col-span-4 flex flex-col items-center mt-4">
+        <div className="text-lg mb-1">あなたの手牌</div>
+        <div className="grid grid-cols-12 gap-2">
           {players[0].hand.map(tile => (
             <button
               key={tile.id}


### PR DESCRIPTION
## Summary
- use grid utilities to organize tile areas in `UIBoard`
- style `ScoreBoard` with rounded panels and backgrounds
- center page content and add padding in `App`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68563f3f3fa4832ab3929c2cd8d7606b