### PR TITLE
Update emoji font to CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/fonts/emoji.css" />
     <title>Mahjong App</title>
   </head>
   <body>

--- a/public/fonts/emoji.css
+++ b/public/fonts/emoji.css
@@ -1,0 +1,8 @@
+@font-face {
+  font-family: 'Noto Color Emoji';
+  src: url('https://raw.githubusercontent.com/googlefonts/noto-emoji/main/fonts/NotoColorEmoji.ttf') format('truetype');
+}
+
+.font-emoji {
+  font-family: 'Noto Color Emoji', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif;
+}


### PR DESCRIPTION
## Summary
- add emoji stylesheet referencing a CDN-hosted font
- link emoji stylesheet from `index.html`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68564605fad4832a86aea161a72bcec7