### PR TITLE
Add hand sorting and tests

### DIFF
--- a/src/components/Player.test.ts
+++ b/src/components/Player.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { createInitialPlayerState, drawTiles, discardTile } from './Player';
+import { createInitialPlayerState, drawTiles, discardTile, sortHand } from './Player';
 import { generateTileWall } from './TileWall';
+import { Tile, PlayerState } from '../types/mahjong';
 
 // Unit tests for Player helper functions
 
@@ -15,9 +16,22 @@ describe('drawTiles', () => {
     expect(updated.hand).toHaveLength(4);
     // wall should lose 4 tiles
     expect(remaining).toHaveLength(wall.length - 4);
-    // drawn tiles should be first 4 from original wall
-    expect(updated.hand).toEqual(wall.slice(0, 4));
+    // hand should be sorted
+    expect(updated.hand).toEqual(sortHand(wall.slice(0, 4)));
     expect(remaining).toEqual(wall.slice(4));
+  });
+
+  it('sorts the hand by suit and rank', () => {
+    const customWall: Tile[] = [
+      { suit: 'sou', rank: 3, id: 's1' },
+      { suit: 'man', rank: 1, id: 'm1' },
+      { suit: 'pin', rank: 2, id: 'p1' },
+      { suit: 'dragon', rank: 1, id: 'd1' },
+      { suit: 'wind', rank: 3, id: 'w1' },
+    ];
+    const player = createInitialPlayerState('Alice', false);
+    const result = drawTiles(player, customWall, customWall.length);
+    expect(result.player.hand).toEqual(sortHand(customWall));
   });
 });
 
@@ -32,6 +46,21 @@ describe('discardTile', () => {
 
     expect(updated.hand).toHaveLength(4);
     expect(updated.hand.find(t => t.id === tileToDiscard.id)).toBeUndefined();
+    expect(updated.hand).toEqual(
+      sortHand(drawn.hand.filter(t => t.id !== tileToDiscard.id))
+    );
     expect(updated.discard[updated.discard.length - 1]).toEqual(tileToDiscard);
+  });
+
+  it('keeps the hand sorted after discarding', () => {
+    const hand: Tile[] = [
+      { suit: 'sou', rank: 3, id: 's1' },
+      { suit: 'man', rank: 1, id: 'm1' },
+      { suit: 'pin', rank: 2, id: 'p1' },
+      { suit: 'wind', rank: 3, id: 'w1' },
+    ];
+    const player: PlayerState = { ...createInitialPlayerState('Bob', false), hand };
+    const updated = discardTile(player, 's1');
+    expect(updated.hand).toEqual(sortHand(hand.filter(t => t.id !== 's1')));
   });
 });

--- a/src/components/Player.ts
+++ b/src/components/Player.ts
@@ -1,5 +1,20 @@
 import { PlayerState, Tile } from '../types/mahjong';
 
+export function sortHand(hand: Tile[]): Tile[] {
+  const order: Record<Tile['suit'], number> = {
+    man: 0,
+    pin: 1,
+    sou: 2,
+    wind: 3,
+    dragon: 4,
+  };
+  return [...hand].sort((a, b) => {
+    const diff = order[a.suit] - order[b.suit];
+    if (diff !== 0) return diff;
+    return a.rank - b.rank;
+  });
+}
+
 export function createInitialPlayerState(name: string, isAI: boolean): PlayerState {
   return {
     hand: [],
@@ -17,7 +32,7 @@ export function drawTiles(player: PlayerState, wall: Tile[], count: number): { p
   return {
     player: {
       ...player,
-      hand: [...player.hand, ...drawn],
+      hand: sortHand([...player.hand, ...drawn]),
     },
     wall: wall.slice(count),
   };
@@ -31,7 +46,7 @@ export function discardTile(player: PlayerState, tileId: string): PlayerState {
   newHand.splice(idx, 1);
   return {
     ...player,
-    hand: newHand,
+    hand: sortHand(newHand),
     discard: [...player.discard, tile],
   };
 }


### PR DESCRIPTION
## Summary
- ensure tiles are kept sorted by adding `sortHand`
- use `sortHand` in draw and discard functions
- verify sorting behavior with new unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68564b52ffcc832ab158a93f97b01b63