### PR TITLE
Add dora indicator display

### DIFF
--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Tile, PlayerState } from '../types/mahjong';
-import { generateTileWall } from './TileWall';
+import { generateTileWall, drawDoraIndicator } from './TileWall';
 import { createInitialPlayerState, drawTiles, discardTile } from './Player';
 import { UIBoard } from './UIBoard';
 import { ScoreBoard } from './ScoreBoard';
@@ -11,6 +11,7 @@ export const GameController: React.FC = () => {
   // ゲーム状態
   const [wall, setWall] = useState<Tile[]>([]);
   const [players, setPlayers] = useState<PlayerState[]>([]);
+  const [dora, setDora] = useState<Tile[]>([]);
   const [turn, setTurn] = useState(0); // 0:自分, 1-3:AI
   const [phase, setPhase] = useState<GamePhase>('init');
   const [message, setMessage] = useState<string>('');
@@ -31,6 +32,9 @@ export const GameController: React.FC = () => {
   useEffect(() => {
     if (phase === 'init') {
       let wall = generateTileWall();
+      const doraResult = drawDoraIndicator(wall, 1);
+      const doraTiles = doraResult.dora;
+      wall = doraResult.wall;
       let p: PlayerState[] = [
         createInitialPlayerState('あなた', false),
         createInitialPlayerState('AI東家', true),
@@ -45,6 +49,7 @@ export const GameController: React.FC = () => {
       }
       setPlayers(p);
       setWall(wall);
+      setDora(doraTiles);
       setTurn(0);
       setKyoku(1);
       setMessage('配牌が完了しました。あなたのターンです。');
@@ -108,6 +113,7 @@ export const GameController: React.FC = () => {
       <ScoreBoard players={players} kyoku={kyoku} />
       <UIBoard
         players={players}
+        dora={dora}
         onDiscard={handleDiscard}
         isMyTurn={turn === 0}
       />

--- a/src/components/TileWall.test.ts
+++ b/src/components/TileWall.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { generateTileWall } from './TileWall';
+import { generateTileWall, drawDoraIndicator } from './TileWall';
 
 // Simple unit test to ensure tile wall has correct number of tiles
 
@@ -9,5 +9,15 @@ describe('generateTileWall', () => {
     expect(wall).toHaveLength(136);
     const ids = new Set(wall.map(t => t.id));
     expect(ids.size).toBe(wall.length);
+  });
+});
+
+describe('drawDoraIndicator', () => {
+  it('removes indicator tiles from the wall', () => {
+    const wall = generateTileWall();
+    const original = [...wall];
+    const { dora, wall: remaining } = drawDoraIndicator(wall, 1);
+    expect(dora).toEqual(original.slice(0, 1));
+    expect(remaining).toEqual(original.slice(1));
   });
 });

--- a/src/components/TileWall.ts
+++ b/src/components/TileWall.ts
@@ -40,6 +40,15 @@ export function generateTileWall(): Tile[] {
   return shuffle(tiles);
 }
 
+// ドラ表示牌を取り出す
+export function drawDoraIndicator(
+  wall: Tile[],
+  count = 1,
+): { dora: Tile[]; wall: Tile[] } {
+  const indicators = wall.slice(0, count);
+  return { dora: indicators, wall: wall.slice(count) };
+}
+
 // シャッフル
 function shuffle<T>(array: T[]): T[] {
   let arr = [...array];

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -3,13 +3,14 @@ import { PlayerState, Tile, Suit } from '../types/mahjong';
 
 interface UIBoardProps {
   players: PlayerState[];
+  dora: Tile[];
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
   onDiscard: (tileId: string) => void;
   isMyTurn: boolean;
 }
 
 // 簡易UI：自分の手牌＋捨て牌、AIの捨て牌のみ表示
-export const UIBoard: React.FC<UIBoardProps> = ({ players, onDiscard, isMyTurn }) => {
+export const UIBoard: React.FC<UIBoardProps> = ({ players, dora, onDiscard, isMyTurn }) => {
   if (players.length === 0) {
     return null;
   }
@@ -26,6 +27,15 @@ export const UIBoard: React.FC<UIBoardProps> = ({ players, onDiscard, isMyTurn }
           </div>
         </div>
       ))}
+      {/* ドラ表示 */}
+      <div className="col-span-4 flex flex-col items-center mt-2">
+        <div className="text-sm mb-1">ドラ表示</div>
+        <div className="flex gap-1">
+          {dora.map(tile => (
+            <TileView key={tile.id} tile={tile} />
+          ))}
+        </div>
+      </div>
       {/* 自分の手牌 */}
       <div className="col-span-4 flex flex-col items-center mt-4">
         <div className="text-lg mb-1">あなたの手牌</div>


### PR DESCRIPTION
## Summary
- add `drawDoraIndicator` helper
- store dora indicator tile in `GameController`
- show dora in `UIBoard`
- cover dora draw logic with tests

## Testing
- `npx -y vitest run` *(fails: Cannot find module 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_68564b515e60832ab3cd57777aff8e91