### PR TITLE
Add shonpai discard tracking

### DIFF
--- a/src/components/DiscardUtil.ts
+++ b/src/components/DiscardUtil.ts
@@ -1,0 +1,11 @@
+import { Tile } from '../types/mahjong';
+
+export function incrementDiscardCount(
+  record: Record<string, number>,
+  tile: Tile,
+): { record: Record<string, number>; isShonpai: boolean } {
+  const key = `${tile.suit}-${tile.rank}`;
+  const count = (record[key] ?? 0) + 1;
+  const newRecord = { ...record, [key]: count };
+  return { record: newRecord, isShonpai: count === 1 };
+}

--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -4,6 +4,7 @@ import { generateTileWall, drawDoraIndicator } from './TileWall';
 import { createInitialPlayerState, drawTiles, discardTile } from './Player';
 import { UIBoard } from './UIBoard';
 import { ScoreBoard } from './ScoreBoard';
+import { incrementDiscardCount } from './DiscardUtil';
 
 type GamePhase = 'init' | 'playing' | 'end';
 
@@ -16,6 +17,8 @@ export const GameController: React.FC = () => {
   const [phase, setPhase] = useState<GamePhase>('init');
   const [message, setMessage] = useState<string>('');
   const [kyoku, setKyoku] = useState<number>(1); // 東1局など
+  const [discardCounts, setDiscardCounts] = useState<Record<string, number>>({});
+  const [lastDiscard, setLastDiscard] = useState<{ tileId: string; isShonpai: boolean } | null>(null);
 
   const turnRef = useRef(turn);
   const playersRef = useRef<PlayerState[]>(players);
@@ -51,6 +54,8 @@ export const GameController: React.FC = () => {
       setWall(wall);
       setDora(doraTiles);
       setTurn(0);
+      setDiscardCounts({});
+      setLastDiscard(null);
       setKyoku(1);
       setMessage('配牌が完了しました。あなたのターンです。');
       setPhase('playing');
@@ -78,6 +83,11 @@ export const GameController: React.FC = () => {
   const handleDiscard = (tileId: string) => {
     const idx = turnRef.current;
     let p = [...playersRef.current];
+    const tile = p[idx].hand.find(t => t.id === tileId);
+    if (!tile) return;
+    const result = incrementDiscardCount(discardCounts, tile);
+    setDiscardCounts(result.record);
+    setLastDiscard({ tileId, isShonpai: result.isShonpai });
     p[idx] = discardTile(p[idx], tileId);
     setPlayers(p);
     playersRef.current = p;
@@ -116,6 +126,7 @@ export const GameController: React.FC = () => {
         dora={dora}
         onDiscard={handleDiscard}
         isMyTurn={turn === 0}
+        lastDiscard={lastDiscard}
       />
       <div className="mt-2">{message}</div>
       {phase === 'end' && (

--- a/src/components/Player.test.ts
+++ b/src/components/Player.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { incrementDiscardCount } from './DiscardUtil';
 import { createInitialPlayerState, drawTiles, discardTile, sortHand } from './Player';
 import { generateTileWall } from './TileWall';
 import { Tile, PlayerState } from '../types/mahjong';
@@ -62,5 +63,27 @@ describe('discardTile', () => {
     const player: PlayerState = { ...createInitialPlayerState('Bob', false), hand };
     const updated = discardTile(player, 's1');
     expect(updated.hand).toEqual(sortHand(hand.filter(t => t.id !== 's1')));
+  });
+});
+
+describe('incrementDiscardCount', () => {
+  it('increments counts and identifies shonpai', () => {
+    const tile: Tile = { suit: 'man', rank: 1, id: 'm1' };
+    let record: Record<string, number> = {};
+    let result = incrementDiscardCount(record, tile);
+    record = result.record;
+    expect(result.isShonpai).toBe(true);
+    expect(record['man-1']).toBe(1);
+
+    result = incrementDiscardCount(record, tile);
+    record = result.record;
+    expect(result.isShonpai).toBe(false);
+    expect(record['man-1']).toBe(2);
+
+    // reset for new round
+    record = {};
+    result = incrementDiscardCount(record, tile);
+    expect(result.isShonpai).toBe(true);
+    expect(result.record['man-1']).toBe(1);
   });
 });

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -7,10 +7,11 @@ interface UIBoardProps {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
   onDiscard: (tileId: string) => void;
   isMyTurn: boolean;
+  lastDiscard: { tileId: string; isShonpai: boolean } | null;
 }
 
 // 簡易UI：自分の手牌＋捨て牌、AIの捨て牌のみ表示
-export const UIBoard: React.FC<UIBoardProps> = ({ players, dora, onDiscard, isMyTurn }) => {
+export const UIBoard: React.FC<UIBoardProps> = ({ players, dora, onDiscard, isMyTurn, lastDiscard }) => {
   if (players.length === 0) {
     return null;
   }
@@ -22,7 +23,11 @@ export const UIBoard: React.FC<UIBoardProps> = ({ players, dora, onDiscard, isMy
           <div className="text-sm mb-1">{ai.name}</div>
           <div className="flex gap-1">
             {ai.discard.map(tile => (
-              <TileView key={tile.id} tile={tile} />
+              <TileView
+                key={tile.id}
+                tile={tile}
+                isShonpai={lastDiscard?.tileId === tile.id && lastDiscard.isShonpai}
+              />
             ))}
           </div>
         </div>
@@ -53,7 +58,11 @@ export const UIBoard: React.FC<UIBoardProps> = ({ players, dora, onDiscard, isMy
         </div>
         <div className="flex gap-1 mt-2">
           {players[0].discard.map(tile => (
-            <TileView key={tile.id} tile={tile} />
+            <TileView
+              key={tile.id}
+              tile={tile}
+              isShonpai={lastDiscard?.tileId === tile.id && lastDiscard.isShonpai}
+            />
           ))}
         </div>
       </div>
@@ -62,7 +71,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({ players, dora, onDiscard, isMy
 };
 
 // 牌表示（簡易）
-export const TileView: React.FC<{ tile: Tile }> = ({ tile }) => {
+export const TileView: React.FC<{ tile: Tile; isShonpai?: boolean }> = ({ tile, isShonpai }) => {
   const suitMap: Record<string, string> = { man: '萬', pin: '筒', sou: '索', wind: '', dragon: '' };
   const honorMap: Record<string, Record<number, string>> = {
     wind: { 1: '東', 2: '南', 3: '西', 4: '北' },
@@ -126,6 +135,7 @@ export const TileView: React.FC<{ tile: Tile }> = ({ tile }) => {
       <span className="font-emoji">
         {emojiMap[tile.suit]?.[tile.rank] ?? kanji}
       </span>
+      {isShonpai && <span className="text-yellow-500 ml-0.5">★</span>}
     </span>
   );
 };


### PR DESCRIPTION
## Summary
- track each discarded tile type in `GameController`
- mark the most recent discard as shonpai when appropriate
- display a star next to shonpai tiles in the UI
- expose a helper to increment discard counts and test it

## Testing
- `npm run type-check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68565127a5d4832a9facbc2cfbac8582