### PR TITLE
Fix dealer's starting hand

### DIFF
--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -59,6 +59,10 @@ export const GameController: React.FC = () => {
         p[i] = result.player;
         wall = result.wall;
       }
+      // 親の14牌目を配る
+      const extra = drawTiles(p[0], wall, 1);
+      p[0] = extra.player;
+      wall = extra.wall;
       setPlayers(p);
       setWall(wall);
       setDora(doraTiles);

--- a/src/components/Player.test.ts
+++ b/src/components/Player.test.ts
@@ -87,3 +87,25 @@ describe('incrementDiscardCount', () => {
     expect(result.record['man-1']).toBe(1);
   });
 });
+
+describe('initial hand distribution', () => {
+  it('gives the dealer 14 tiles after the initial draw', () => {
+    let wall = generateTileWall();
+    const players: PlayerState[] = [
+      createInitialPlayerState('you', false),
+      createInitialPlayerState('AI1', true),
+      createInitialPlayerState('AI2', true),
+      createInitialPlayerState('AI3', true),
+    ];
+    for (let i = 0; i < 4; i++) {
+      const result = drawTiles(players[i], wall, 13);
+      players[i] = result.player;
+      wall = result.wall;
+    }
+    const extra = drawTiles(players[0], wall, 1);
+    players[0] = extra.player;
+    wall = extra.wall;
+
+    expect(players[0].hand).toHaveLength(14);
+  });
+});


### PR DESCRIPTION
## Summary
- include the dealer's 14th tile during game initialization
- add test covering initial 14-tile hand

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685657962300832ab67452fb133dca93