### PR TITLE
Show drawn tile separately

### DIFF
--- a/src/components/Player.test.ts
+++ b/src/components/Player.test.ts
@@ -20,6 +20,7 @@ describe('drawTiles', () => {
     // hand should be sorted
     expect(updated.hand).toEqual(sortHand(wall.slice(0, 4)));
     expect(remaining).toEqual(wall.slice(4));
+    expect(updated.drawnTile).toBeNull();
   });
 
   it('sorts the hand by suit and rank', () => {
@@ -33,6 +34,14 @@ describe('drawTiles', () => {
     const player = createInitialPlayerState('Alice', false);
     const result = drawTiles(player, customWall, customWall.length);
     expect(result.player.hand).toEqual(sortHand(customWall));
+    expect(result.player.drawnTile).toBeNull();
+  });
+
+  it('records the last drawn tile when drawing a single tile', () => {
+    const wall = generateTileWall();
+    const player = createInitialPlayerState('Alice', false);
+    const { player: updated } = drawTiles(player, wall, 1);
+    expect(updated.drawnTile).toEqual(updated.hand[0]);
   });
 });
 
@@ -51,6 +60,7 @@ describe('discardTile', () => {
       sortHand(drawn.hand.filter(t => t.id !== tileToDiscard.id))
     );
     expect(updated.discard[updated.discard.length - 1]).toEqual(tileToDiscard);
+    expect(updated.drawnTile).toBeNull();
   });
 
   it('keeps the hand sorted after discarding', () => {

--- a/src/components/Player.ts
+++ b/src/components/Player.ts
@@ -24,6 +24,7 @@ export function createInitialPlayerState(name: string, isAI: boolean): PlayerSta
     isRiichi: false,
     name,
     isAI,
+    drawnTile: null,
   };
 }
 
@@ -34,6 +35,7 @@ export function drawTiles(player: PlayerState, wall: Tile[], count: number): { p
     player: {
       ...player,
       hand: sortHand([...player.hand, ...drawn]),
+      drawnTile: count === 1 ? drawn[0] : null,
     },
     wall: wall.slice(count),
   };
@@ -49,5 +51,6 @@ export function discardTile(player: PlayerState, tileId: string): PlayerState {
     ...player,
     hand: sortHand(newHand),
     discard: [...player.discard, tile],
+    drawnTile: null,
   };
 }

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -49,18 +49,36 @@ export const UIBoard: React.FC<UIBoardProps> = ({ players, dora, onDiscard, isMy
           向聴数: {shanten.value}
           {shanten.isChiitoi && shanten.value >= 0 && ' (七対子向聴)'}
         </div>
-        <div className="grid grid-cols-12 gap-2">
-          {players[0].hand.map(tile => (
-            <button
-              key={tile.id}
-              className={`border rounded bg-white px-2 py-1 hover:bg-blue-100 ${isMyTurn ? '' : 'opacity-50 pointer-events-none'}`}
-              onClick={() => onDiscard(tile.id)}
-              disabled={!isMyTurn}
-            >
-              <TileView tile={tile} />
-            </button>
-          ))}
-        </div>
+        {(() => {
+          const my = players[0];
+          const handTiles = my.drawnTile
+            ? my.hand.filter(t => t.id !== my.drawnTile?.id)
+            : my.hand;
+          return (
+            <div className="flex gap-2 items-center">
+              {handTiles.map(tile => (
+                <button
+                  key={tile.id}
+                  className={`border rounded bg-white px-2 py-1 hover:bg-blue-100 ${isMyTurn ? '' : 'opacity-50 pointer-events-none'}`}
+                  onClick={() => onDiscard(tile.id)}
+                  disabled={!isMyTurn}
+                >
+                  <TileView tile={tile} />
+                </button>
+              ))}
+              {my.drawnTile && (
+                <button
+                  key={my.drawnTile.id}
+                  className={`border rounded bg-white px-2 py-1 hover:bg-blue-100 ml-4 ${isMyTurn ? '' : 'opacity-50 pointer-events-none'}`}
+                  onClick={() => onDiscard(my.drawnTile.id)}
+                  disabled={!isMyTurn}
+                >
+                  <TileView tile={my.drawnTile} />
+                </button>
+              )}
+            </div>
+          );
+        })()}
         <div className="flex gap-1 mt-2">
           {players[0].discard.map(tile => (
             <TileView

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -70,7 +70,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({ players, dora, onDiscard, isMy
                 <button
                   key={my.drawnTile.id}
                   className={`border rounded bg-white px-2 py-1 hover:bg-blue-100 ml-4 ${isMyTurn ? '' : 'opacity-50 pointer-events-none'}`}
-                  onClick={() => onDiscard(my.drawnTile.id)}
+                  onClick={() => onDiscard(my.drawnTile!.id)}
                   disabled={!isMyTurn}
                 >
                   <TileView tile={my.drawnTile} />

--- a/src/types/mahjong.ts
+++ b/src/types/mahjong.ts
@@ -23,4 +23,5 @@ export interface PlayerState {
   isRiichi: boolean;
   name: string;
   isAI: boolean;
+  drawnTile: Tile | null;
 }


### PR DESCRIPTION
## Summary
- track the last drawn tile in PlayerState
- display newly drawn tile at the end of the player's hand
- adjust helper functions and tests for new drawnTile state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856597661ec832ab498cfdbf06d2d16