### PR TITLE
Fix AI discard layout

### DIFF
--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -22,7 +22,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({ players, dora, onDiscard, isMy
       {players.slice(1).map(ai => (
         <div key={ai.name} className="flex flex-col items-center">
           <div className="text-sm mb-1">{ai.name}</div>
-          <div className="flex gap-1">
+          <div className="grid grid-cols-6 gap-1">
             {ai.discard.map(tile => (
               <TileView
                 key={tile.id}


### PR DESCRIPTION
## Summary
- adjust CPU discard pile to wrap every six tiles

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68565abea554832ab82c516d09d649b7