### PR TITLE
Add Chiitoitsu and Kokushi detection

### DIFF
--- a/src/score/yaku.test.ts
+++ b/src/score/yaku.test.ts
@@ -41,6 +41,35 @@ describe('Yaku detection', () => {
     const yaku = detectYaku(hand);
     expect(yaku.some(y => y.name === 'Yakuhai')).toBe(true);
   });
+
+  it('detects Chiitoitsu', () => {
+    const hand: Tile[] = [
+      t('man',1,'m1a'),t('man',1,'m1b'),
+      t('man',2,'m2a'),t('man',2,'m2b'),
+      t('pin',3,'p3a'),t('pin',3,'p3b'),
+      t('pin',4,'p4a'),t('pin',4,'p4b'),
+      t('sou',5,'s5a'),t('sou',5,'s5b'),
+      t('sou',6,'s6a'),t('sou',6,'s6b'),
+      t('dragon',1,'d1a'),t('dragon',1,'d1b'),
+    ];
+    expect(isWinningHand(hand)).toBe(true);
+    const yaku = detectYaku(hand);
+    expect(yaku.some(y => y.name === 'Chiitoitsu')).toBe(true);
+  });
+
+  it('detects Kokushi Musou', () => {
+    const hand: Tile[] = [
+      t('man',1,'m1a'),t('man',9,'m9a'),
+      t('pin',1,'p1a'),t('pin',9,'p9a'),
+      t('sou',1,'s1a'),t('sou',9,'s9a'),
+      t('wind',1,'e'),t('wind',2,'s'),t('wind',3,'w'),t('wind',4,'n'),
+      t('dragon',1,'d1a'),t('dragon',2,'d2a'),t('dragon',3,'d3a'),
+      t('man',1,'m1b'),
+    ];
+    expect(isWinningHand(hand)).toBe(true);
+    const yaku = detectYaku(hand);
+    expect(yaku.some(y => y.name === 'Kokushi Musou')).toBe(true);
+  });
 });
 
 describe('Scoring', () => {

--- a/src/score/yaku.ts
+++ b/src/score/yaku.ts
@@ -24,6 +24,38 @@ export function isTanyao(tiles: Tile[]): boolean {
   );
 }
 
+function isChiitoitsu(tiles: Tile[]): boolean {
+  if (tiles.length !== 14) return false;
+  const counts = countTiles(tiles);
+  const keys = Object.keys(counts);
+  if (keys.length !== 7) return false;
+  return keys.every(k => counts[k] === 2);
+}
+
+function isKokushi(tiles: Tile[]): boolean {
+  if (tiles.length !== 14) return false;
+  const yaochu = [
+    'man-1', 'man-9', 'pin-1', 'pin-9', 'sou-1', 'sou-9',
+    'wind-1', 'wind-2', 'wind-3', 'wind-4',
+    'dragon-1', 'dragon-2', 'dragon-3',
+  ];
+  const counts = countTiles(tiles);
+  // must consist solely of yaochu tiles
+  if (Object.keys(counts).some(k => !yaochu.includes(k))) return false;
+  let pairFound = false;
+  for (const key of yaochu) {
+    const c = counts[key] || 0;
+    if (c === 0) return false;
+    if (c === 2) {
+      if (pairFound) return false;
+      pairFound = true;
+    } else if (c > 2) {
+      return false;
+    }
+  }
+  return pairFound;
+}
+
 function countDragonTriplets(counts: Record<string, number>): number {
   let yakuhai = 0;
   for (let r = 1; r <= 3; r++) {
@@ -73,6 +105,7 @@ function canFormSets(counts: Record<string, number>, memo = new Map<string, bool
 
 export function isWinningHand(tiles: Tile[]): boolean {
   if (tiles.length !== 14) return false;
+  if (isChiitoitsu(tiles) || isKokushi(tiles)) return true;
   const counts = countTiles(tiles);
   const tileKeys = Object.keys(counts);
   for (const key of tileKeys) {
@@ -91,6 +124,12 @@ export function isWinningHand(tiles: Tile[]): boolean {
 export function detectYaku(tiles: Tile[]): Yaku[] {
   const result: Yaku[] = [];
   const counts = countTiles(tiles);
+  if (isChiitoitsu(tiles)) {
+    result.push({ name: 'Chiitoitsu', han: 2 });
+  }
+  if (isKokushi(tiles)) {
+    result.push({ name: 'Kokushi Musou', han: 13 });
+  }
   if (isTanyao(tiles)) {
     result.push({ name: 'Tanyao', han: 1 });
   }


### PR DESCRIPTION
## Summary
- detect Chiitoitsu and Kokushi Musou in `isWinningHand`
- award new yaku in `detectYaku`
- test seven pairs and thirteen orphans wins

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68565b20a600832ab623d65065c858a0