### PR TITLE
Implement fu calculation

### DIFF
--- a/src/score/score.ts
+++ b/src/score/score.ts
@@ -1,10 +1,119 @@
 import { Tile } from '../types/mahjong';
 import { Yaku } from './yaku';
 
+function tileKey(t: Tile): string {
+  return `${t.suit}-${t.rank}`;
+}
+
+function countTiles(tiles: Tile[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const t of tiles) {
+    const key = tileKey(t);
+    counts[key] = (counts[key] || 0) + 1;
+  }
+  return counts;
+}
+
+function parseKey(key: string): Tile {
+  const [suit, rankStr] = key.split('-');
+  return { suit: suit as Tile['suit'], rank: Number(rankStr), id: '' };
+}
+
+interface ParsedMeld {
+  type: 'chi' | 'pon';
+  tiles: Tile[];
+}
+
+function isTerminalOrHonor(tile: Tile): boolean {
+  return (
+    tile.suit === 'wind' ||
+    tile.suit === 'dragon' ||
+    tile.rank === 1 ||
+    tile.rank === 9
+  );
+}
+
+function findMelds(counts: Record<string, number>): ParsedMeld[] | null {
+  const keys = Object.keys(counts).filter(k => counts[k] > 0).sort();
+  if (keys.length === 0) return [];
+
+  const first = keys[0];
+  const [suit, rankStr] = first.split('-');
+  const rank = Number(rankStr);
+
+  // try triplet
+  if (counts[first] >= 3) {
+    counts[first] -= 3;
+    const rest = findMelds(counts);
+    counts[first] += 3;
+    if (rest) {
+      return [{ type: 'pon', tiles: [parseKey(first), parseKey(first), parseKey(first)] }, ...rest];
+    }
+  }
+
+  // try sequence
+  if (
+    (suit === 'man' || suit === 'pin' || suit === 'sou') &&
+    counts[`${suit}-${rank + 1}`] > 0 &&
+    counts[`${suit}-${rank + 2}`] > 0
+  ) {
+    counts[first]--;
+    counts[`${suit}-${rank + 1}`]--;
+    counts[`${suit}-${rank + 2}`]--;
+    const rest = findMelds(counts);
+    counts[first]++;
+    counts[`${suit}-${rank + 1}`]++;
+    counts[`${suit}-${rank + 2}`]++;
+    if (rest) {
+      return [
+        {
+          type: 'chi',
+          tiles: [parseKey(first), parseKey(`${suit}-${rank + 1}`), parseKey(`${suit}-${rank + 2}`)],
+        },
+        ...rest,
+      ];
+    }
+  }
+
+  return null;
+}
+
+function decomposeHand(tiles: Tile[]): { pair: Tile[]; melds: ParsedMeld[] } | null {
+  const counts = countTiles(tiles);
+  const tileKeys = Object.keys(counts);
+  for (const key of tileKeys) {
+    if (counts[key] >= 2) {
+      counts[key] -= 2;
+      const melds = findMelds(counts);
+      counts[key] += 2;
+      if (melds) {
+        return { pair: [parseKey(key), parseKey(key)], melds };
+      }
+    }
+  }
+  return null;
+}
+
 export function calculateFu(hand: Tile[]): number {
-  // simplified fu calculation currently ignores hand contents
-  void hand;
-  return 30;
+  const parsed = decomposeHand(hand);
+  if (!parsed) return 0;
+
+  let fu = 20; // base fu for a winning hand
+
+  // pair fu (only dragons considered value tiles here)
+  if (parsed.pair[0].suit === 'dragon') {
+    fu += 2;
+  }
+
+  for (const meld of parsed.melds) {
+    if (meld.type === 'pon') {
+      fu += isTerminalOrHonor(meld.tiles[0]) ? 8 : 4;
+    }
+  }
+
+  // round up to nearest 10
+  fu = Math.ceil(fu / 10) * 10;
+  return fu;
 }
 
 export function calculateScore(hand: Tile[], yaku: Yaku[]): { han: number; fu: number; points: number } {

--- a/src/score/yaku.test.ts
+++ b/src/score/yaku.test.ts
@@ -55,7 +55,20 @@ describe('Scoring', () => {
     const yaku = detectYaku(hand);
     const { han, fu, points } = calculateScore(hand, yaku);
     expect(han).toBe(1);
+    expect(fu).toBe(20);
+    expect(points).toBe(160);
+  });
+
+  it('adds fu for honor triplets', () => {
+    const hand: Tile[] = [
+      t('dragon',1,'d1a'),t('dragon',1,'d1b'),t('dragon',1,'d1c'),
+      t('man',2,'m2a'),t('man',3,'m3a'),t('man',4,'m4a'),
+      t('pin',2,'p2a'),t('pin',3,'p3a'),t('pin',4,'p4a'),
+      t('sou',2,'s2a'),t('sou',3,'s3a'),t('sou',4,'s4a'),
+      t('man',5,'m5a'),t('man',5,'m5b'),
+    ];
+    const yaku = detectYaku(hand);
+    const { fu } = calculateScore(hand, yaku);
     expect(fu).toBe(30);
-    expect(points).toBe(240);
   });
 });


### PR DESCRIPTION
## Summary
- add hand decomposition helpers and fu logic
- calculate fu based on melds and pair
- update scoring tests

## Testing
- `npm run type-check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68565b1e9a0c832aaec427685e8fa90a