### PR TITLE
Add yaku detection test coverage

### DIFF
--- a/src/score/yaku.test.ts
+++ b/src/score/yaku.test.ts
@@ -29,6 +29,20 @@ describe('Yaku detection', () => {
     expect(yaku.some(y => y.name === 'Tanyao')).toBe(true);
   });
 
+  it('does not detect Tanyao when terminals or honors are present', () => {
+    const hand: Tile[] = [
+      t('man',1,'m1a'),t('man',1,'m1b'),t('man',1,'m1c'),
+      t('man',2,'m2a'),t('man',3,'m3a'),t('man',4,'m4a'),
+      t('pin',6,'p6a'),t('pin',7,'p7a'),t('pin',8,'p8a'),
+      t('sou',2,'s2a'),t('sou',3,'s3a'),t('sou',4,'s4a'),
+      t('man',5,'m5a'),t('man',5,'m5b'),
+    ];
+    expect(isWinningHand(hand)).toBe(true);
+    expect(isTanyao(hand)).toBe(false);
+    const yaku = detectYaku(hand);
+    expect(yaku.some(y => y.name === 'Tanyao')).toBe(false);
+  });
+
   it('detects Yakuhai', () => {
     const hand: Tile[] = [
       t('dragon',1,'d1a'),t('dragon',1,'d1b'),t('dragon',1,'d1c'),
@@ -40,6 +54,32 @@ describe('Yaku detection', () => {
     expect(isWinningHand(hand)).toBe(true);
     const yaku = detectYaku(hand);
     expect(yaku.some(y => y.name === 'Yakuhai')).toBe(true);
+  });
+
+  it('does not detect Yakuhai without a dragon triplet', () => {
+    const hand: Tile[] = [
+      t('man',2,'a1'),t('man',3,'a2'),t('man',4,'a3'),
+      t('pin',2,'b1'),t('pin',3,'b2'),t('pin',4,'b3'),
+      t('sou',2,'c1'),t('sou',3,'c2'),t('sou',4,'c3'),
+      t('man',6,'d1'),t('man',7,'d2'),t('man',8,'d3'),
+      t('pin',5,'e1'),t('pin',5,'e2'),
+    ];
+    expect(isWinningHand(hand)).toBe(true);
+    const yaku = detectYaku(hand);
+    expect(yaku.some(y => y.name === 'Yakuhai')).toBe(false);
+  });
+
+  it('detects multiple Yakuhai triplets separately', () => {
+    const hand: Tile[] = [
+      t('dragon',1,'d1a'),t('dragon',1,'d1b'),t('dragon',1,'d1c'),
+      t('dragon',2,'d2a'),t('dragon',2,'d2b'),t('dragon',2,'d2c'),
+      t('man',2,'m2a'),t('man',3,'m3a'),t('man',4,'m4a'),
+      t('pin',2,'p2a'),t('pin',3,'p3a'),t('pin',4,'p4a'),
+      t('sou',5,'s5a'),t('sou',5,'s5b'),
+    ];
+    expect(isWinningHand(hand)).toBe(true);
+    const yaku = detectYaku(hand);
+    expect(yaku.filter(y => y.name === 'Yakuhai')).toHaveLength(2);
   });
 });
 

--- a/src/score/yaku.test.ts
+++ b/src/score/yaku.test.ts
@@ -81,6 +81,7 @@ describe('Yaku detection', () => {
     const yaku = detectYaku(hand);
     expect(yaku.filter(y => y.name === 'Yakuhai')).toHaveLength(2);
 
+
     it('detects Chiitoitsu', () => {
     const hand: Tile[] = [
       t('man',1,'m1a'),t('man',1,'m1b'),


### PR DESCRIPTION
## Summary
- cover Tanyao and Yakuhai detection with negative cases
- ensure multiple dragon triplets count as separate Yakuhai

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68565b1bc2ec832aaead68acaa2e38cd