### PR TITLE
Make tile fonts bigger and adjustable

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,28 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { GameController } from './components/GameController';
 
 function App() {
+  const [tileFont, setTileFont] = useState(2);
+
   return (
-    <div className="min-h-screen bg-green-100 flex items-center justify-center py-8">
+    <div
+      className="min-h-screen bg-green-100 flex items-center justify-center py-8"
+      style={{ ['--tile-font-size' as any]: `${tileFont}rem` } as React.CSSProperties}
+    >
       <div className="w-full max-w-4xl mx-auto px-4 space-y-6">
         <h1 className="text-2xl font-bold text-center">麻雀 Web アプリ（1人用デモ）</h1>
+        <div className="flex items-center gap-2">
+          <label htmlFor="size">牌サイズ</label>
+          <input
+            id="size"
+            type="range"
+            min="1"
+            max="4"
+            step="0.1"
+            value={tileFont}
+            onChange={e => setTileFont(parseFloat(e.target.value))}
+          />
+        </div>
         <GameController />
       </div>
     </div>

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -152,7 +152,7 @@ export const TileView: React.FC<{ tile: Tile; isShonpai?: boolean }> = ({ tile, 
       : honorMap[tile.suit]?.[tile.rank] ?? '';
   return (
     <span
-      className="inline-block border px-1 py-0.5 text-base bg-white"
+      className="inline-block border px-1 py-0.5 bg-white tile-font-size"
       aria-label={kanji}
     >
       <span className="font-emoji">

--- a/src/index.css
+++ b/src/index.css
@@ -6,3 +6,12 @@
 .font-emoji {
   font-family: 'Noto Color Emoji', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif;
 }
+
+/* Default tile font size and class */
+:root {
+  --tile-font-size: 2rem;
+}
+
+.tile-font-size {
+  font-size: var(--tile-font-size);
+}


### PR DESCRIPTION
## Summary
- add CSS variable and class for tile font size
- enlarge tile fonts using `tile-font-size` class
- add slider to App for adjusting tile size

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68566050d320832abb896892ed0fa270