### PR TITLE
Fix chiitoi display and add kokushi shanten

### DIFF
--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -22,7 +22,7 @@ export const GameController: React.FC = () => {
   const [message, setMessage] = useState<string>('');
   const [kyoku, setKyoku] = useState<number>(1); // 東1局など
   const [helpOpen, setHelpOpen] = useState(false);
-  const [shanten, setShanten] = useState<{ value: number; isChiitoi: boolean }>({ value: 8, isChiitoi: false });
+  const [shanten, setShanten] = useState<{ standard: number; chiitoi: number; kokushi: number }>({ standard: 8, chiitoi: 8, kokushi: 13 });
   const [discardCounts, setDiscardCounts] = useState<Record<string, number>>({});
   const [lastDiscard, setLastDiscard] = useState<{ tileId: string; isShonpai: boolean } | null>(null);
 

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -7,7 +7,7 @@ interface UIBoardProps {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
   onDiscard: (tileId: string) => void;
   isMyTurn: boolean;
-  shanten: { value: number; isChiitoi: boolean };
+  shanten: { standard: number; chiitoi: number; kokushi: number };
   lastDiscard: { tileId: string; isShonpai: boolean } | null;
 }
 
@@ -46,8 +46,16 @@ export const UIBoard: React.FC<UIBoardProps> = ({ players, dora, onDiscard, isMy
       <div className="col-span-4 flex flex-col items-center mt-4">
         <div className="text-lg mb-1">あなたの手牌</div>
         <div className="text-sm mb-2">
-          向聴数: {shanten.value}
-          {shanten.isChiitoi && shanten.value >= 0 && ' (七対子向聴)'}
+          {(() => {
+            const base = Math.min(shanten.standard, shanten.chiitoi, shanten.kokushi);
+            let label = '';
+            if (shanten.chiitoi === base && base < shanten.standard) {
+              label = `七対子${base}向聴`;
+            } else if (shanten.kokushi === base && base < shanten.standard) {
+              label = `国士無双${base}向聴`;
+            }
+            return <>向聴数: {base}{label && ` (${label})`}</>;
+          })()}
         </div>
         {(() => {
           const my = players[0];

--- a/src/utils/shanten.test.ts
+++ b/src/utils/shanten.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { calcStandardShanten, calcChiitoiShanten, calcShanten } from './shanten';
+import {
+  calcStandardShanten,
+  calcChiitoiShanten,
+  calcKokushiShanten,
+  calcShanten,
+} from './shanten';
 import { Tile } from '../types/mahjong';
 
 describe('shanten calculations', () => {
@@ -15,7 +20,8 @@ describe('shanten calculations', () => {
     ];
     expect(calcStandardShanten(hand)).toBe(-1);
     expect(calcChiitoiShanten(hand)).toBe(4);
-    expect(calcShanten(hand)).toEqual({ value: -1, isChiitoi: false });
+    expect(calcKokushiShanten(hand)).toBe(9);
+    expect(calcShanten(hand)).toEqual({ standard: -1, chiitoi: 4, kokushi: 9 });
   });
 
   it('calculates chiitoitsu tenpai correctly', () => {
@@ -30,7 +36,8 @@ describe('shanten calculations', () => {
     ];
     expect(calcChiitoiShanten(hand)).toBe(0);
     expect(calcStandardShanten(hand)).toBe(1);
-    expect(calcShanten(hand)).toEqual({ value: 0, isChiitoi: true });
+    expect(calcKokushiShanten(hand)).toBe(9);
+    expect(calcShanten(hand)).toEqual({ standard: 1, chiitoi: 0, kokushi: 9 });
   });
 
   it('handles a standard 1-shanten hand', () => {
@@ -43,6 +50,7 @@ describe('shanten calculations', () => {
     ];
     expect(calcStandardShanten(hand)).toBe(1);
     expect(calcChiitoiShanten(hand)).toBe(4);
-    expect(calcShanten(hand)).toEqual({ value: 1, isChiitoi: false });
+    expect(calcKokushiShanten(hand)).toBe(9);
+    expect(calcShanten(hand)).toEqual({ standard: 1, chiitoi: 4, kokushi: 9 });
   });
 });

--- a/src/utils/shanten.ts
+++ b/src/utils/shanten.ts
@@ -73,10 +73,32 @@ export function calcChiitoiShanten(hand: Tile[]): number {
   return 6 - pairCount + Math.max(0, 7 - unique);
 }
 
-export function calcShanten(hand: Tile[]): { value: number; isChiitoi: boolean } {
-  const normal = calcStandardShanten(hand);
-  const chiitoi = calcChiitoiShanten(hand);
-  return chiitoi < normal
-    ? { value: chiitoi, isChiitoi: true }
-    : { value: normal, isChiitoi: false };
+export function calcKokushiShanten(hand: Tile[]): number {
+  const yaochu = new Set([
+    'man-1', 'man-9', 'pin-1', 'pin-9', 'sou-1', 'sou-9',
+    'wind-1', 'wind-2', 'wind-3', 'wind-4',
+    'dragon-1', 'dragon-2', 'dragon-3',
+  ]);
+  const counts: Record<string, number> = {};
+  for (const t of hand) {
+    const key = `${t.suit}-${t.rank}`;
+    if (yaochu.has(key)) {
+      counts[key] = (counts[key] ?? 0) + 1;
+    }
+  }
+  const unique = Object.keys(counts).length;
+  const hasPair = Object.values(counts).some(c => c >= 2);
+  return 13 - unique - (hasPair ? 1 : 0);
+}
+
+export function calcShanten(hand: Tile[]): {
+  standard: number;
+  chiitoi: number;
+  kokushi: number;
+} {
+  return {
+    standard: calcStandardShanten(hand),
+    chiitoi: calcChiitoiShanten(hand),
+    kokushi: calcKokushiShanten(hand),
+  };
 }


### PR DESCRIPTION
## Summary
- show correct shanten value for chiitoi
- calculate kokushi shanten and expose via `calcShanten`
- update UI to mention chiitoi/kokushi when they are closer
- add tests for new shanten logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685660134530832a8ff08fad6da7eb9f