### PR TITLE
Add Menzen Tsumo yaku

### DIFF
--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -90,7 +90,10 @@ export const GameController: React.FC = () => {
     playersRef.current = p;
     setWall(result.wall);
     if (isWinningHand(p[currentIndex].hand)) {
-      const yaku = detectYaku(p[currentIndex].hand);
+      const yaku = detectYaku(p[currentIndex].hand, {
+        isTsumo: true,
+        melds: p[currentIndex].melds,
+      });
       const { han, fu, points } = calculateScore(p[currentIndex].hand, yaku);
       const newPlayers = p.map((pl, idx) =>
         idx === currentIndex ? { ...pl, score: pl.score + points } : pl,

--- a/src/score/yaku.test.ts
+++ b/src/score/yaku.test.ts
@@ -25,8 +25,20 @@ describe('Yaku detection', () => {
       t('pin',5,'p5a'),t('pin',5,'p5b'),
     ];
     expect(isWinningHand(hand)).toBe(true);
-    const yaku = detectYaku(hand);
+    const yaku = detectYaku(hand, { isTsumo: true });
     expect(yaku.some(y => y.name === 'Tanyao')).toBe(true);
+  });
+
+  it('detects Menzen Tsumo', () => {
+    const hand: Tile[] = [
+      t('man',2,'m2a'),t('man',3,'m3a'),t('man',4,'m4a'),
+      t('pin',2,'p2a'),t('pin',3,'p3a'),t('pin',4,'p4a'),
+      t('sou',2,'s2a'),t('sou',3,'s3a'),t('sou',4,'s4a'),
+      t('man',6,'m6a'),t('man',7,'m7a'),t('man',8,'m8a'),
+      t('pin',5,'p5a'),t('pin',5,'p5b'),
+    ];
+    const yaku = detectYaku(hand, { isTsumo: true, melds: [] });
+    expect(yaku.some(y => y.name === 'Menzen Tsumo')).toBe(true);
   });
 
   it('detects Yakuhai', () => {
@@ -38,7 +50,7 @@ describe('Yaku detection', () => {
       t('sou',2,'s2a'),t('sou',2,'s2b'),
     ];
     expect(isWinningHand(hand)).toBe(true);
-    const yaku = detectYaku(hand);
+    const yaku = detectYaku(hand, { isTsumo: true });
     expect(yaku.some(y => y.name === 'Yakuhai')).toBe(true);
   });
 
@@ -53,7 +65,7 @@ describe('Yaku detection', () => {
       t('dragon',1,'d1a'),t('dragon',1,'d1b'),
     ];
     expect(isWinningHand(hand)).toBe(true);
-    const yaku = detectYaku(hand);
+    const yaku = detectYaku(hand, { isTsumo: true });
     expect(yaku.some(y => y.name === 'Chiitoitsu')).toBe(true);
   });
 
@@ -67,7 +79,7 @@ describe('Yaku detection', () => {
       t('man',1,'m1b'),
     ];
     expect(isWinningHand(hand)).toBe(true);
-    const yaku = detectYaku(hand);
+    const yaku = detectYaku(hand, { isTsumo: true });
     expect(yaku.some(y => y.name === 'Kokushi Musou')).toBe(true);
   });
 });
@@ -81,11 +93,11 @@ describe('Scoring', () => {
       t('man',6,'m6a'),t('man',7,'m7a'),t('man',8,'m8a'),
       t('pin',5,'p5a'),t('pin',5,'p5b'),
     ];
-    const yaku = detectYaku(hand);
+    const yaku = detectYaku(hand, { isTsumo: true });
     const { han, fu, points } = calculateScore(hand, yaku);
-    expect(han).toBe(1);
+    expect(han).toBe(2);
     expect(fu).toBe(20);
-    expect(points).toBe(160);
+    expect(points).toBe(320);
   });
 
   it('adds fu for honor triplets', () => {
@@ -96,7 +108,7 @@ describe('Scoring', () => {
       t('sou',2,'s2a'),t('sou',3,'s3a'),t('sou',4,'s4a'),
       t('man',5,'m5a'),t('man',5,'m5b'),
     ];
-    const yaku = detectYaku(hand);
+    const yaku = detectYaku(hand, { isTsumo: true });
     const { fu } = calculateScore(hand, yaku);
     expect(fu).toBe(30);
   });

--- a/src/score/yaku.ts
+++ b/src/score/yaku.ts
@@ -1,4 +1,4 @@
-import { Tile } from '../types/mahjong';
+import { Tile, Meld } from '../types/mahjong';
 
 export interface Yaku {
   name: string;
@@ -121,7 +121,10 @@ export function isWinningHand(tiles: Tile[]): boolean {
   return false;
 }
 
-export function detectYaku(tiles: Tile[]): Yaku[] {
+export function detectYaku(
+  tiles: Tile[],
+  opts?: { melds?: Meld[]; isTsumo?: boolean }
+): Yaku[] {
   const result: Yaku[] = [];
   const counts = countTiles(tiles);
   if (isChiitoitsu(tiles)) {
@@ -132,6 +135,9 @@ export function detectYaku(tiles: Tile[]): Yaku[] {
   }
   if (isTanyao(tiles)) {
     result.push({ name: 'Tanyao', han: 1 });
+  }
+  if (opts?.isTsumo && (!opts?.melds || opts.melds.length === 0)) {
+    result.push({ name: 'Menzen Tsumo', han: 1 });
   }
   const yakuhai = countDragonTriplets(counts);
   for (let i = 0; i < yakuhai; i++) {

--- a/src/yaku.ts
+++ b/src/yaku.ts
@@ -19,6 +19,12 @@ export const YAKU_LIST: Yaku[] = [
     hanOpen: 1,
   },
   {
+    name: 'Menzen Tsumo',
+    description: '門前で自摸和了する',
+    hanClosed: 1,
+    hanOpen: 0,
+  },
+  {
     name: 'Pinfu',
     description: '順子のみで雀頭は役牌以外、両面待ちの形',
     hanClosed: 1,


### PR DESCRIPTION
## Summary
- support "Menzen Tsumo" scoring
- show the yaku in help modal
- detect closed self-draw wins in GameController
- update yaku tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685662ab6854832a83ef49ae8d03f7eb