### PR TITLE
Implement basic meld claiming

### DIFF
--- a/src/components/Player.test.ts
+++ b/src/components/Player.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { incrementDiscardCount } from './DiscardUtil';
-import { createInitialPlayerState, drawTiles, discardTile, sortHand } from './Player';
+import { createInitialPlayerState, drawTiles, discardTile, sortHand, claimMeld } from './Player';
 import { generateTileWall } from './TileWall';
-import { Tile, PlayerState } from '../types/mahjong';
+import { Tile, PlayerState, MeldType } from '../types/mahjong';
 
 // Unit tests for Player helper functions
 
@@ -73,6 +73,23 @@ describe('discardTile', () => {
     const player: PlayerState = { ...createInitialPlayerState('Bob', false), hand };
     const updated = discardTile(player, 's1');
     expect(updated.hand).toEqual(sortHand(hand.filter(t => t.id !== 's1')));
+  });
+});
+
+describe('claimMeld', () => {
+  it('removes tiles and adds a meld', () => {
+    const hand: Tile[] = [
+      { suit: 'man', rank: 1, id: 'm1' },
+      { suit: 'man', rank: 2, id: 'm2' },
+      { suit: 'man', rank: 3, id: 'm3' },
+      { suit: 'pin', rank: 5, id: 'p1' },
+    ];
+    const player: PlayerState = { ...createInitialPlayerState('Bob', false), hand };
+    const tiles = hand.slice(0, 3);
+    const updated = claimMeld(player, tiles, 'chi' as MeldType);
+    expect(updated.hand).toHaveLength(1);
+    expect(updated.hand[0].id).toBe('p1');
+    expect(updated.melds).toEqual([{ type: 'chi', tiles }]);
   });
 });
 

--- a/src/components/Player.ts
+++ b/src/components/Player.ts
@@ -1,4 +1,4 @@
-import { PlayerState, Tile } from '../types/mahjong';
+import { PlayerState, Tile, MeldType } from '../types/mahjong';
 
 export function sortHand(hand: Tile[]): Tile[] {
   const order: Record<Tile['suit'], number> = {
@@ -52,5 +52,19 @@ export function discardTile(player: PlayerState, tileId: string): PlayerState {
     hand: sortHand(newHand),
     discard: [...player.discard, tile],
     drawnTile: null,
+  };
+}
+
+export function claimMeld(
+  player: PlayerState,
+  tiles: Tile[],
+  type: MeldType,
+): PlayerState {
+  // remove called tiles from hand
+  const hand = player.hand.filter(h => !tiles.some(t => t.id === h.id));
+  return {
+    ...player,
+    hand: sortHand(hand),
+    melds: [...player.melds, { type, tiles }],
   };
 }

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PlayerState, Tile, Suit } from '../types/mahjong';
+import { PlayerState, Tile, Suit, MeldType } from '../types/mahjong';
 
 interface UIBoardProps {
   players: PlayerState[];
@@ -8,11 +8,23 @@ interface UIBoardProps {
   onDiscard: (tileId: string) => void;
   isMyTurn: boolean;
   shanten: { standard: number; chiitoi: number; kokushi: number };
-  lastDiscard: { tileId: string; isShonpai: boolean } | null;
+  lastDiscard: { tile: Tile; player: number; isShonpai: boolean } | null;
+  callOptions?: (MeldType | 'pass')[];
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
+  onCallAction?: (action: MeldType | 'pass') => void;
 }
 
 // 簡易UI：自分の手牌＋捨て牌、AIの捨て牌のみ表示
-export const UIBoard: React.FC<UIBoardProps> = ({ players, dora, onDiscard, isMyTurn, shanten, lastDiscard }) => {
+export const UIBoard: React.FC<UIBoardProps> = ({
+  players,
+  dora,
+  onDiscard,
+  isMyTurn,
+  shanten,
+  lastDiscard,
+  callOptions,
+  onCallAction,
+}) => {
   if (players.length === 0) {
     return null;
   }
@@ -27,7 +39,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({ players, dora, onDiscard, isMy
               <TileView
                 key={tile.id}
                 tile={tile}
-                isShonpai={lastDiscard?.tileId === tile.id && lastDiscard.isShonpai}
+                isShonpai={lastDiscard?.tile.id === tile.id && lastDiscard.isShonpai}
               />
             ))}
           </div>
@@ -92,10 +104,23 @@ export const UIBoard: React.FC<UIBoardProps> = ({ players, dora, onDiscard, isMy
             <TileView
               key={tile.id}
               tile={tile}
-              isShonpai={lastDiscard?.tileId === tile.id && lastDiscard.isShonpai}
+              isShonpai={lastDiscard?.tile.id === tile.id && lastDiscard.isShonpai}
             />
           ))}
         </div>
+        {callOptions && callOptions.length > 0 && (
+          <div className="flex gap-2 mt-2">
+            {callOptions.map(act => (
+              <button
+                key={act}
+                className="px-2 py-1 bg-yellow-200 rounded"
+                onClick={() => onCallAction?.(act)}
+              >
+                {act === 'pon' ? 'ポン' : act === 'chi' ? 'チー' : act === 'kan' ? 'カン' : 'スルー'}
+              </button>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add `claimMeld` helper for removing tiles and creating a meld
- allow user to claim the latest discard in `GameController`
- track discard data with claiming options
- render call buttons in `UIBoard`
- test new helper function

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856673fbacc832a817daa5dcb914699