### PR TITLE
Support open meld scoring

### DIFF
--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -98,12 +98,15 @@ export const GameController: React.FC = () => {
     playersRef.current = p;
     setWall(result.wall);
     wallRef.current = result.wall;
-    if (isWinningHand(p[currentIndex].hand)) {
-      const yaku = detectYaku(p[currentIndex].hand, {
+    if (isWinningHand([...p[currentIndex].hand, ...p[currentIndex].melds.flatMap(m => m.tiles)])) {
+      const fullHand = [
+        ...p[currentIndex].hand,
+        ...p[currentIndex].melds.flatMap(m => m.tiles),
+      ];
+      const yaku = detectYaku(fullHand, p[currentIndex].melds, {
         isTsumo: true,
-        melds: p[currentIndex].melds,
       });
-      const { han, fu, points } = calculateScore(p[currentIndex].hand, yaku);
+      const { han, fu, points } = calculateScore(p[currentIndex].hand, p[currentIndex].melds, yaku);
       const newPlayers = p.map((pl, idx) =>
         idx === currentIndex ? { ...pl, score: pl.score + points } : pl,
       );

--- a/src/score/score.ts
+++ b/src/score/score.ts
@@ -1,4 +1,4 @@
-import { Tile } from '../types/mahjong';
+import { Tile, Meld } from '../types/mahjong';
 import { Yaku } from './yaku';
 
 function tileKey(t: Tile): string {
@@ -94,8 +94,9 @@ function decomposeHand(tiles: Tile[]): { pair: Tile[]; melds: ParsedMeld[] } | n
   return null;
 }
 
-export function calculateFu(hand: Tile[]): number {
-  const parsed = decomposeHand(hand);
+export function calculateFu(hand: Tile[], melds: Meld[] = []): number {
+  const allTiles = [...hand, ...melds.flatMap(m => m.tiles)];
+  const parsed = decomposeHand(allTiles);
   if (!parsed) return 0;
 
   let fu = 20; // base fu for a winning hand
@@ -116,9 +117,9 @@ export function calculateFu(hand: Tile[]): number {
   return fu;
 }
 
-export function calculateScore(hand: Tile[], yaku: Yaku[]): { han: number; fu: number; points: number } {
+export function calculateScore(hand: Tile[], melds: Meld[], yaku: Yaku[]): { han: number; fu: number; points: number } {
   const han = yaku.reduce((sum, y) => sum + y.han, 0);
-  const fu = calculateFu(hand);
+  const fu = calculateFu(hand, melds);
   const base = fu * Math.pow(2, han + 2);
   const points = base;
   return { han, fu, points };

--- a/src/score/yaku.test.ts
+++ b/src/score/yaku.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { Tile } from '../types/mahjong';
+import { Tile, Meld } from '../types/mahjong';
 import { detectYaku, isTanyao, isWinningHand } from './yaku';
 import { calculateScore } from './score';
 
@@ -25,7 +25,7 @@ describe('Yaku detection', () => {
       t('pin',5,'p5a'),t('pin',5,'p5b'),
     ];
     expect(isWinningHand(hand)).toBe(true);
-    const yaku = detectYaku(hand, { isTsumo: true });
+    const yaku = detectYaku(hand, [], { isTsumo: true });
     expect(yaku.some(y => y.name === 'Tanyao')).toBe(true);
   });
 
@@ -37,7 +37,7 @@ describe('Yaku detection', () => {
       t('man',6,'m6a'),t('man',7,'m7a'),t('man',8,'m8a'),
       t('pin',5,'p5a'),t('pin',5,'p5b'),
     ];
-    const yaku = detectYaku(hand, { isTsumo: true, melds: [] });
+    const yaku = detectYaku(hand, [], { isTsumo: true });
     expect(yaku.some(y => y.name === 'Menzen Tsumo')).toBe(true);
   });
 
@@ -50,7 +50,7 @@ describe('Yaku detection', () => {
       t('sou',2,'s2a'),t('sou',2,'s2b'),
     ];
     expect(isWinningHand(hand)).toBe(true);
-    const yaku = detectYaku(hand, { isTsumo: true });
+    const yaku = detectYaku(hand, [], { isTsumo: true });
     expect(yaku.some(y => y.name === 'Yakuhai')).toBe(true);
   });
 
@@ -65,7 +65,7 @@ describe('Yaku detection', () => {
       t('dragon',1,'d1a'),t('dragon',1,'d1b'),
     ];
     expect(isWinningHand(hand)).toBe(true);
-    const yaku = detectYaku(hand, { isTsumo: true });
+    const yaku = detectYaku(hand, [], { isTsumo: true });
     expect(yaku.some(y => y.name === 'Chiitoitsu')).toBe(true);
   });
 
@@ -79,7 +79,7 @@ describe('Yaku detection', () => {
       t('man',1,'m1b'),
     ];
     expect(isWinningHand(hand)).toBe(true);
-    const yaku = detectYaku(hand, { isTsumo: true });
+    const yaku = detectYaku(hand, [], { isTsumo: true });
     expect(yaku.some(y => y.name === 'Kokushi Musou')).toBe(true);
   });
 });
@@ -93,8 +93,8 @@ describe('Scoring', () => {
       t('man',6,'m6a'),t('man',7,'m7a'),t('man',8,'m8a'),
       t('pin',5,'p5a'),t('pin',5,'p5b'),
     ];
-    const yaku = detectYaku(hand, { isTsumo: true });
-    const { han, fu, points } = calculateScore(hand, yaku);
+    const yaku = detectYaku(hand, [], { isTsumo: true });
+    const { han, fu, points } = calculateScore(hand, [], yaku);
     expect(han).toBe(2);
     expect(fu).toBe(20);
     expect(points).toBe(320);
@@ -108,8 +108,28 @@ describe('Scoring', () => {
       t('sou',2,'s2a'),t('sou',3,'s3a'),t('sou',4,'s4a'),
       t('man',5,'m5a'),t('man',5,'m5b'),
     ];
-    const yaku = detectYaku(hand, { isTsumo: true });
-    const { fu } = calculateScore(hand, yaku);
+    const yaku = detectYaku(hand, [], { isTsumo: true });
+    const { fu } = calculateScore(hand, [], yaku);
+    expect(fu).toBe(30);
+  });
+
+  it('scores correctly with an open meld', () => {
+    const ponTiles = [
+      t('dragon',1,'d1a'),
+      t('dragon',1,'d1b'),
+      t('dragon',1,'d1c'),
+    ];
+    const concealed: Tile[] = [
+      t('man',2,'m2a'),t('man',3,'m3a'),t('man',4,'m4a'),
+      t('pin',2,'p2a'),t('pin',3,'p3a'),t('pin',4,'p4a'),
+      t('sou',2,'s2a'),t('sou',3,'s3a'),t('sou',4,'s4a'),
+      t('man',5,'m5a'),t('man',5,'m5b'),
+    ];
+    const melds: Meld[] = [{ type: 'pon', tiles: ponTiles }];
+    const fullHand = [...concealed, ...ponTiles];
+    const yaku = detectYaku(fullHand, melds, { isTsumo: true });
+    expect(yaku.some(y => y.name === 'Menzen Tsumo')).toBe(false);
+    const { fu } = calculateScore(concealed, melds, yaku);
     expect(fu).toBe(30);
   });
 });

--- a/src/score/yaku.ts
+++ b/src/score/yaku.ts
@@ -122,21 +122,25 @@ export function isWinningHand(tiles: Tile[]): boolean {
 }
 
 export function detectYaku(
-  tiles: Tile[],
-  opts?: { melds?: Meld[]; isTsumo?: boolean }
+  hand: Tile[],
+  melds: Meld[] = [],
+  opts?: { isTsumo?: boolean },
 ): Yaku[] {
+  const allTiles = [...hand, ...melds.flatMap(m => m.tiles)];
   const result: Yaku[] = [];
-  const counts = countTiles(tiles);
-  if (isChiitoitsu(tiles)) {
+  const counts = countTiles(allTiles);
+  const isClosed = melds.length === 0;
+
+  if (isChiitoitsu(allTiles)) {
     result.push({ name: 'Chiitoitsu', han: 2 });
   }
-  if (isKokushi(tiles)) {
+  if (isKokushi(allTiles)) {
     result.push({ name: 'Kokushi Musou', han: 13 });
   }
-  if (isTanyao(tiles)) {
+  if (isTanyao(allTiles)) {
     result.push({ name: 'Tanyao', han: 1 });
   }
-  if (opts?.isTsumo && (!opts?.melds || opts.melds.length === 0)) {
+  if (opts?.isTsumo && isClosed) {
     result.push({ name: 'Menzen Tsumo', han: 1 });
   }
   const yakuhai = countDragonTriplets(counts);


### PR DESCRIPTION
## Summary
- consider meld tiles when detecting yaku
- include meld tiles for fu/point calculations
- handle open hands in GameController
- add unit tests for open meld scoring

## Testing
- `npm run lint`
- `npm run build`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68566a22f018832ab9dafca23f07bc8a