### PR TITLE
Improve shonpai star display

### DIFF
--- a/src/components/TileView.test.tsx
+++ b/src/components/TileView.test.tsx
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { TileView } from './TileView';
+import { Tile } from '../types/mahjong';
+
+describe('TileView', () => {
+  it('shows a star overlay when shonpai', () => {
+    const tile: Tile = { suit: 'man', rank: 1, id: 'm1' };
+    const html = renderToStaticMarkup(<TileView tile={tile} isShonpai />);
+    expect(html).toContain('★');
+    expect(html).toContain('absolute');
+  });
+});

--- a/src/components/TileView.tsx
+++ b/src/components/TileView.tsx
@@ -58,9 +58,16 @@ export const TileView: React.FC<{ tile: Tile; isShonpai?: boolean }> = ({ tile, 
       ? `${tile.rank}${suitMap[tile.suit]}`
       : honorMap[tile.suit]?.[tile.rank] ?? '';
   return (
-    <span className="inline-block border px-1 py-0.5 bg-white tile-font-size" aria-label={kanji}>
+    <span
+      className="relative inline-block border px-1 py-0.5 bg-white tile-font-size"
+      aria-label={kanji}
+    >
       <span className="font-emoji">{emojiMap[tile.suit]?.[tile.rank] ?? kanji}</span>
-      {isShonpai && <span className="text-yellow-500 ml-0.5">★</span>}
+      {isShonpai && (
+        <span className="absolute -top-1 -right-1 text-xs text-yellow-500">
+          ★
+        </span>
+      )}
     </span>
   );
 };


### PR DESCRIPTION
## Summary
- style star overlay on tiles to avoid extra spacing
- test TileView star overlay

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68566dede2d0832a94d3ab46808b865f