### PR TITLE
Refine call option detection

### DIFF
--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -3,6 +3,7 @@ import { Tile, PlayerState } from '../types/mahjong';
 import { generateTileWall, drawDoraIndicator } from './TileWall';
 import { createInitialPlayerState, drawTiles, discardTile, claimMeld } from './Player';
 import { MeldType } from '../types/mahjong';
+import { selectMeldTiles, getValidCallOptions } from '../utils/meld';
 import { isWinningHand, detectYaku } from '../score/yaku';
 import { calculateScore } from '../score/score';
 import { UIBoard } from './UIBoard';
@@ -134,40 +135,13 @@ export const GameController: React.FC = () => {
     setPlayers(p);
     playersRef.current = p;
     if (idx !== 0) {
-      setCallOptions(['pon', 'chi', 'kan', 'pass']);
+      const options = getValidCallOptions(p[0], tile);
+      setCallOptions(options);
     } else {
       nextTurn();
     }
   };
 
-  const selectMeldTiles = (
-    player: PlayerState,
-    tile: Tile,
-    type: MeldType,
-  ): Tile[] | null => {
-    if (type === 'pon' || type === 'kan') {
-      const need = type === 'pon' ? 2 : 3;
-      const matches = player.hand.filter(
-        t => t.suit === tile.suit && t.rank === tile.rank,
-      );
-      if (matches.length >= need) return matches.slice(0, need);
-      return null;
-    }
-    // chi
-    if (tile.suit === 'man' || tile.suit === 'pin' || tile.suit === 'sou') {
-      const opts = [
-        [tile.rank - 2, tile.rank - 1],
-        [tile.rank - 1, tile.rank + 1],
-        [tile.rank + 1, tile.rank + 2],
-      ];
-      for (const [a, b] of opts) {
-        const t1 = player.hand.find(t => t.suit === tile.suit && t.rank === a);
-        const t2 = player.hand.find(t => t.suit === tile.suit && t.rank === b);
-        if (t1 && t2) return [t1, t2];
-      }
-    }
-    return null;
-  };
 
   const handleCallAction = (action: MeldType | 'pass') => {
     if (!lastDiscard) return;

--- a/src/utils/meld.test.ts
+++ b/src/utils/meld.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { getValidCallOptions, selectMeldTiles } from './meld';
+import { PlayerState, Tile } from '../types/mahjong';
+import { createInitialPlayerState } from '../components/Player';
+
+describe('getValidCallOptions', () => {
+  it('returns pon when two matching tiles exist', () => {
+    const discard: Tile = { suit: 'man', rank: 5, id: 'd1' };
+    const hand: Tile[] = [
+      { suit: 'man', rank: 5, id: 'a' },
+      { suit: 'man', rank: 5, id: 'b' },
+      { suit: 'sou', rank: 1, id: 'x' },
+    ];
+    const player: PlayerState = {
+      ...createInitialPlayerState('you', false),
+      hand,
+    };
+    expect(getValidCallOptions(player, discard)).toEqual(['pon', 'pass']);
+  });
+
+  it('includes kan when three matching tiles exist', () => {
+    const discard: Tile = { suit: 'pin', rank: 2, id: 'd2' };
+    const hand: Tile[] = [
+      { suit: 'pin', rank: 2, id: 'a' },
+      { suit: 'pin', rank: 2, id: 'b' },
+      { suit: 'pin', rank: 2, id: 'c' },
+    ];
+    const player: PlayerState = {
+      ...createInitialPlayerState('you', false),
+      hand,
+    };
+    expect(getValidCallOptions(player, discard)).toEqual(['pon', 'kan', 'pass']);
+  });
+
+  it('detects chi sequences', () => {
+    const discard: Tile = { suit: 'sou', rank: 3, id: 'd3' };
+    const hand: Tile[] = [
+      { suit: 'sou', rank: 2, id: 'a' },
+      { suit: 'sou', rank: 4, id: 'b' },
+    ];
+    const player: PlayerState = {
+      ...createInitialPlayerState('you', false),
+      hand,
+    };
+    expect(getValidCallOptions(player, discard)).toEqual(['chi', 'pass']);
+  });
+});
+
+describe('selectMeldTiles', () => {
+  it('returns tiles for pon', () => {
+    const tile: Tile = { suit: 'man', rank: 7, id: 'd' };
+    const hand: Tile[] = [
+      { suit: 'man', rank: 7, id: 'a' },
+      { suit: 'man', rank: 7, id: 'b' },
+    ];
+    const player: PlayerState = {
+      ...createInitialPlayerState('you', false),
+      hand,
+    };
+    const result = selectMeldTiles(player, tile, 'pon');
+    expect(result?.length).toBe(2);
+  });
+});

--- a/src/utils/meld.ts
+++ b/src/utils/meld.ts
@@ -1,0 +1,42 @@
+import { PlayerState, Tile, MeldType } from '../types/mahjong';
+
+export function selectMeldTiles(
+  player: PlayerState,
+  tile: Tile,
+  type: MeldType,
+): Tile[] | null {
+  if (type === 'pon' || type === 'kan') {
+    const need = type === 'pon' ? 2 : 3;
+    const matches = player.hand.filter(
+      t => t.suit === tile.suit && t.rank === tile.rank,
+    );
+    if (matches.length >= need) return matches.slice(0, need);
+    return null;
+  }
+  // chi
+  if (tile.suit === 'man' || tile.suit === 'pin' || tile.suit === 'sou') {
+    const opts = [
+      [tile.rank - 2, tile.rank - 1],
+      [tile.rank - 1, tile.rank + 1],
+      [tile.rank + 1, tile.rank + 2],
+    ];
+    for (const [a, b] of opts) {
+      const t1 = player.hand.find(t => t.suit === tile.suit && t.rank === a);
+      const t2 = player.hand.find(t => t.suit === tile.suit && t.rank === b);
+      if (t1 && t2) return [t1, t2];
+    }
+  }
+  return null;
+}
+
+export function getValidCallOptions(
+  player: PlayerState,
+  tile: Tile,
+): (MeldType | 'pass')[] {
+  const actions: (MeldType | 'pass')[] = [];
+  (['pon', 'chi', 'kan'] as MeldType[]).forEach(t => {
+    if (selectMeldTiles(player, tile, t)) actions.push(t);
+  });
+  actions.push('pass');
+  return actions;
+}


### PR DESCRIPTION
## Summary
- compute actionable meld options only after AI discard
- expose meld utilities for reuse
- test call option helper

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856818ec4b4832a99a5a2a1bc949737