### PR TITLE
Implement kan draw and scoring updates

### DIFF
--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -194,6 +194,16 @@ export const GameController: React.FC = () => {
     p[caller] = claimMeld(p[caller], [...meldTiles, lastDiscard.tile], action);
     setPlayers(p);
     playersRef.current = p;
+
+    if (action === 'kan') {
+      const doraResult = drawDoraIndicator(wallRef.current, 1);
+      setDora(prev => [...prev, ...doraResult.dora]);
+      setWall(doraResult.wall);
+      wallRef.current = doraResult.wall;
+      turnRef.current = caller;
+      drawForCurrentPlayer();
+    }
+
     setCallOptions(null);
     setLastDiscard(null);
     setTurn(caller);

--- a/src/score/score.ts
+++ b/src/score/score.ts
@@ -112,6 +112,14 @@ export function calculateFu(hand: Tile[], melds: Meld[] = []): number {
     }
   }
 
+  for (const meld of melds) {
+    if (meld.type === 'kan') {
+      const base = isTerminalOrHonor(meld.tiles[0]) ? 8 : 4;
+      const kanFu = isTerminalOrHonor(meld.tiles[0]) ? 32 : 16;
+      fu += kanFu - base;
+    }
+  }
+
   // round up to nearest 10
   fu = Math.ceil(fu / 10) * 10;
   return fu;

--- a/src/score/yaku.test.ts
+++ b/src/score/yaku.test.ts
@@ -132,4 +132,24 @@ describe('Scoring', () => {
     const { fu } = calculateScore(concealed, melds, yaku);
     expect(fu).toBe(30);
   });
+
+  it('adds fu for a kan meld', () => {
+    // use 3 tiles for simplicity; scoring treats kan as pon plus bonus
+    const kanTiles = [
+      t('dragon',1,'k1a'),
+      t('dragon',1,'k1b'),
+      t('dragon',1,'k1c'),
+    ];
+    const concealed: Tile[] = [
+      t('man',2,'m2a'),t('man',3,'m3a'),t('man',4,'m4a'),
+      t('pin',2,'p2a'),t('pin',3,'p3a'),t('pin',4,'p4a'),
+      t('sou',2,'s2a'),t('sou',3,'s3a'),t('sou',4,'s4a'),
+      t('man',5,'m5a'),t('man',5,'m5b'),
+    ];
+    const melds: Meld[] = [{ type: 'kan', tiles: kanTiles }];
+    const fullHand = [...concealed, ...kanTiles];
+    const yaku = detectYaku(fullHand, melds, { isTsumo: true });
+    const { fu } = calculateScore(concealed, melds, yaku);
+    expect(fu).toBe(60);
+  });
 });


### PR DESCRIPTION
## Summary
- allow kan calls to draw from the wall and reveal a new dora
- award fu bonuses when kan melds are present
- test kan fu calculation

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856819a1b54832ab7fb4a275d2b96a3