### PR TITLE
Add dora tile scoring

### DIFF
--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -106,7 +106,12 @@ export const GameController: React.FC = () => {
       const yaku = detectYaku(fullHand, p[currentIndex].melds, {
         isTsumo: true,
       });
-      const { han, fu, points } = calculateScore(p[currentIndex].hand, p[currentIndex].melds, yaku);
+      const { han, fu, points } = calculateScore(
+        p[currentIndex].hand,
+        p[currentIndex].melds,
+        yaku,
+        dora,
+      );
       const newPlayers = p.map((pl, idx) =>
         idx === currentIndex ? { ...pl, score: pl.score + points } : pl,
       );

--- a/src/score/score.ts
+++ b/src/score/score.ts
@@ -117,8 +117,39 @@ export function calculateFu(hand: Tile[], melds: Meld[] = []): number {
   return fu;
 }
 
-export function calculateScore(hand: Tile[], melds: Meld[], yaku: Yaku[]): { han: number; fu: number; points: number } {
-  const han = yaku.reduce((sum, y) => sum + y.han, 0);
+function doraFromIndicator(indicator: Tile): Tile {
+  if (indicator.suit === 'man' || indicator.suit === 'pin' || indicator.suit === 'sou') {
+    const rank = indicator.rank === 9 ? 1 : indicator.rank + 1;
+    return { suit: indicator.suit, rank, id: '' };
+  }
+  if (indicator.suit === 'wind') {
+    const rank = indicator.rank === 4 ? 1 : indicator.rank + 1;
+    return { suit: 'wind', rank, id: '' };
+  }
+  // dragon
+  const rank = indicator.rank === 3 ? 1 : indicator.rank + 1;
+  return { suit: 'dragon', rank, id: '' };
+}
+
+function countDora(allTiles: Tile[], indicators: Tile[]): number {
+  const counts = countTiles(allTiles);
+  let total = 0;
+  for (const ind of indicators) {
+    const dora = doraFromIndicator(ind);
+    total += counts[tileKey(dora)] || 0;
+  }
+  return total;
+}
+
+export function calculateScore(
+  hand: Tile[],
+  melds: Meld[],
+  yaku: Yaku[],
+  doraIndicators: Tile[] = [],
+): { han: number; fu: number; points: number } {
+  const allTiles = [...hand, ...melds.flatMap(m => m.tiles)];
+  const dora = countDora(allTiles, doraIndicators);
+  const han = yaku.reduce((sum, y) => sum + y.han, 0) + dora;
   const fu = calculateFu(hand, melds);
   const base = fu * Math.pow(2, han + 2);
   const points = base;

--- a/src/score/yaku.test.ts
+++ b/src/score/yaku.test.ts
@@ -94,7 +94,7 @@ describe('Scoring', () => {
       t('pin',5,'p5a'),t('pin',5,'p5b'),
     ];
     const yaku = detectYaku(hand, [], { isTsumo: true });
-    const { han, fu, points } = calculateScore(hand, [], yaku);
+    const { han, fu, points } = calculateScore(hand, [], yaku, []);
     expect(han).toBe(2);
     expect(fu).toBe(20);
     expect(points).toBe(320);
@@ -109,7 +109,7 @@ describe('Scoring', () => {
       t('man',5,'m5a'),t('man',5,'m5b'),
     ];
     const yaku = detectYaku(hand, [], { isTsumo: true });
-    const { fu } = calculateScore(hand, [], yaku);
+    const { fu } = calculateScore(hand, [], yaku, []);
     expect(fu).toBe(30);
   });
 
@@ -129,7 +129,21 @@ describe('Scoring', () => {
     const fullHand = [...concealed, ...ponTiles];
     const yaku = detectYaku(fullHand, melds, { isTsumo: true });
     expect(yaku.some(y => y.name === 'Menzen Tsumo')).toBe(false);
-    const { fu } = calculateScore(concealed, melds, yaku);
+    const { fu } = calculateScore(concealed, melds, yaku, []);
     expect(fu).toBe(30);
+  });
+
+  it('adds dora to han calculation', () => {
+    const hand: Tile[] = [
+      t('man',2,'m2a'),t('man',3,'m3a'),t('man',4,'m4a'),
+      t('pin',2,'p2a'),t('pin',3,'p3a'),t('pin',4,'p4a'),
+      t('sou',2,'s2a'),t('sou',3,'s3a'),t('sou',4,'s4a'),
+      t('man',6,'m6a'),t('man',7,'m7a'),t('man',8,'m8a'),
+      t('pin',5,'p5a'),t('pin',5,'p5b'),
+    ];
+    const yaku = detectYaku(hand, [], { isTsumo: true });
+    const doraIndicator = t('pin',4,'di');
+    const { han } = calculateScore(hand, [], yaku, [doraIndicator]);
+    expect(han).toBe(4);
   });
 });


### PR DESCRIPTION
## Summary
- support dora indicators when calculating score
- pass current dora indicators from GameController
- test dora counting in scoring

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856819ecc14832a9dd4c2432e584110