### PR TITLE
Add riichi declaration support

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,1 @@
+module.exports = require('./.eslintrc.json');

--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Tile, PlayerState } from '../types/mahjong';
 import { generateTileWall, drawDoraIndicator } from './TileWall';
-import { createInitialPlayerState, drawTiles, discardTile, claimMeld } from './Player';
+import { createInitialPlayerState, drawTiles, discardTile, claimMeld, declareRiichi } from './Player';
 import { MeldType } from '../types/mahjong';
 import { isWinningHand, detectYaku } from '../score/yaku';
 import { calculateScore } from '../score/score';
@@ -106,6 +106,9 @@ export const GameController: React.FC = () => {
       const yaku = detectYaku(fullHand, p[currentIndex].melds, {
         isTsumo: true,
       });
+      if (p[currentIndex].isRiichi) {
+        yaku.push({ name: 'Riichi', han: 1 });
+      }
       const { han, fu, points } = calculateScore(p[currentIndex].hand, p[currentIndex].melds, yaku);
       const newPlayers = p.map((pl, idx) =>
         idx === currentIndex ? { ...pl, score: pl.score + points } : pl,
@@ -199,6 +202,13 @@ export const GameController: React.FC = () => {
     setTurn(caller);
   };
 
+  const handleRiichi = () => {
+    let p = [...playersRef.current];
+    p[0] = declareRiichi(p[0]);
+    setPlayers(p);
+    playersRef.current = p;
+  };
+
   // ターン進行
   const nextTurn = () => {
     let next = (turnRef.current + 1) % 4;
@@ -235,6 +245,7 @@ export const GameController: React.FC = () => {
         lastDiscard={lastDiscard}
         callOptions={callOptions ?? undefined}
         onCallAction={handleCallAction}
+        onDeclareRiichi={handleRiichi}
       />
       <div className="mt-2">{message}</div>
       {phase === 'end' && (

--- a/src/components/Player.test.ts
+++ b/src/components/Player.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { incrementDiscardCount } from './DiscardUtil';
-import { createInitialPlayerState, drawTiles, discardTile, sortHand, claimMeld } from './Player';
+import { createInitialPlayerState, drawTiles, discardTile, sortHand, claimMeld, declareRiichi } from './Player';
 import { generateTileWall } from './TileWall';
 import { Tile, PlayerState, MeldType } from '../types/mahjong';
 
@@ -112,6 +112,15 @@ describe('incrementDiscardCount', () => {
     result = incrementDiscardCount(record, tile);
     expect(result.isShonpai).toBe(true);
     expect(result.record['man-1']).toBe(1);
+  });
+});
+
+describe('declareRiichi', () => {
+  it('sets the riichi flag', () => {
+    const player = createInitialPlayerState('Carol', false);
+    const updated = declareRiichi(player);
+    expect(updated.isRiichi).toBe(true);
+    expect(player.isRiichi).toBe(false);
   });
 });
 

--- a/src/components/Player.ts
+++ b/src/components/Player.ts
@@ -68,3 +68,10 @@ export function claimMeld(
     melds: [...player.melds, { type, tiles }],
   };
 }
+
+export function declareRiichi(player: PlayerState): PlayerState {
+  return {
+    ...player,
+    isRiichi: true,
+  };
+}

--- a/src/components/UIBoard.test.tsx
+++ b/src/components/UIBoard.test.tsx
@@ -16,6 +16,7 @@ function renderBoard(shanten: { standard: number; chiitoi: number; kokushi: numb
     isMyTurn: true,
     shanten,
     lastDiscard: null,
+    onDeclareRiichi: () => {},
   };
   render(<UIBoard {...props} />);
 }

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -14,6 +14,8 @@ interface UIBoardProps {
   callOptions?: (MeldType | 'pass')[];
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
   onCallAction?: (action: MeldType | 'pass') => void;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
+  onDeclareRiichi?: () => void;
 }
 
 // 簡易UI：自分の手牌＋捨て牌、AIの捨て牌のみ表示
@@ -26,6 +28,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
   lastDiscard,
   callOptions,
   onCallAction,
+  onDeclareRiichi,
 }) => {
   if (players.length === 0) {
     return null;
@@ -136,6 +139,14 @@ export const UIBoard: React.FC<UIBoardProps> = ({
               </button>
             ))}
           </div>
+        )}
+        {!players[0].isRiichi && isMyTurn && (
+          <button
+            className="mt-2 px-2 py-1 bg-red-500 text-white rounded"
+            onClick={() => onDeclareRiichi?.()}
+          >
+            リーチ
+          </button>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add `declareRiichi` helper and test
- show riichi button in `UIBoard`
- handle riichi declaration in `GameController`
- score 1 han for riichi when winning
- add eslint config for linting

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685681ce56fc832aaaacc5a3ef95c161