### PR TITLE
Add Pinfu and Iipeiko yaku

### DIFF
--- a/src/score/yaku.test.ts
+++ b/src/score/yaku.test.ts
@@ -54,6 +54,30 @@ describe('Yaku detection', () => {
     expect(yaku.some(y => y.name === 'Yakuhai')).toBe(true);
   });
 
+  it('detects Pinfu', () => {
+    const hand: Tile[] = [
+      t('man',2,'m2a'),t('man',3,'m3a'),t('man',4,'m4a'),
+      t('pin',2,'p2a'),t('pin',3,'p3a'),t('pin',4,'p4a'),
+      t('sou',2,'s2a'),t('sou',3,'s3a'),t('sou',4,'s4a'),
+      t('man',6,'m6a'),t('man',7,'m7a'),t('man',8,'m8a'),
+      t('pin',5,'p5a'),t('pin',5,'p5b'),
+    ];
+    const yaku = detectYaku(hand, [], { isTsumo: true });
+    expect(yaku.some(y => y.name === 'Pinfu')).toBe(true);
+  });
+
+  it('detects Iipeiko', () => {
+    const hand: Tile[] = [
+      t('man',2,'m2a'),t('man',3,'m3a'),t('man',4,'m4a'),
+      t('man',2,'m2b'),t('man',3,'m3b'),t('man',4,'m4b'),
+      t('pin',2,'p2a'),t('pin',3,'p3a'),t('pin',4,'p4a'),
+      t('sou',6,'s6a'),t('sou',7,'s7a'),t('sou',8,'s8a'),
+      t('pin',5,'p5a'),t('pin',5,'p5b'),
+    ];
+    const yaku = detectYaku(hand, [], { isTsumo: true });
+    expect(yaku.some(y => y.name === 'Iipeiko')).toBe(true);
+  });
+
   it('detects Chiitoitsu', () => {
     const hand: Tile[] = [
       t('man',1,'m1a'),t('man',1,'m1b'),
@@ -95,9 +119,9 @@ describe('Scoring', () => {
     ];
     const yaku = detectYaku(hand, [], { isTsumo: true });
     const { han, fu, points } = calculateScore(hand, [], yaku, []);
-    expect(han).toBe(2);
+    expect(han).toBe(3);
     expect(fu).toBe(20);
-    expect(points).toBe(320);
+    expect(points).toBe(640);
   });
 
   it('adds fu for honor triplets', () => {
@@ -144,7 +168,7 @@ describe('Scoring', () => {
     const yaku = detectYaku(hand, [], { isTsumo: true });
     const doraIndicator = t('pin',4,'di');
     const { han } = calculateScore(hand, [], yaku, [doraIndicator]);
-    expect(han).toBe(4);
+    expect(han).toBe(5);
   });
 
   it('adds fu for a kan meld', () => {


### PR DESCRIPTION
## Summary
- add utilities to decompose a hand
- implement Pinfu and Iipeiko checks
- cover new yaku in unit tests and update scoring expectations

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856858f93b4832a8256422f55599108