### PR TITLE
Implement seat tracking and chi restrictions

### DIFF
--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -4,6 +4,7 @@ import { generateTileWall, drawDoraIndicator } from './TileWall';
 import { createInitialPlayerState, drawTiles, discardTile, claimMeld } from './Player';
 import { MeldType } from '../types/mahjong';
 import { selectMeldTiles, getValidCallOptions } from '../utils/meld';
+import { filterChiOptions } from '../utils/table';
 import { isWinningHand, detectYaku } from '../score/yaku';
 import { calculateScore } from '../score/score';
 import { UIBoard } from './UIBoard';
@@ -56,10 +57,10 @@ export const GameController: React.FC = () => {
       const doraTiles = doraResult.dora;
       wall = doraResult.wall;
       let p: PlayerState[] = [
-        createInitialPlayerState('あなた', false),
-        createInitialPlayerState('AI東家', true),
-        createInitialPlayerState('AI南家', true),
-        createInitialPlayerState('AI西家', true),
+        createInitialPlayerState('あなた', false, 0),
+        createInitialPlayerState('AI東家', true, 1),
+        createInitialPlayerState('AI南家', true, 2),
+        createInitialPlayerState('AI西家', true, 3),
       ];
       // 配牌
       for (let i = 0; i < 4; i++) {
@@ -167,7 +168,12 @@ export const GameController: React.FC = () => {
       return;
     }
     if (idx !== 0) {
-      const options = getValidCallOptions(p[0], tile);
+      let options = getValidCallOptions(p[0], tile);
+      options = filterChiOptions(
+        options,
+        playersRef.current[0].seat,
+        playersRef.current[idx].seat,
+      );
       setCallOptions(options);
     } else {
       nextTurn();

--- a/src/components/Player.ts
+++ b/src/components/Player.ts
@@ -15,7 +15,11 @@ export function sortHand(hand: Tile[]): Tile[] {
   });
 }
 
-export function createInitialPlayerState(name: string, isAI: boolean): PlayerState {
+export function createInitialPlayerState(
+  name: string,
+  isAI: boolean,
+  seat = 0,
+): PlayerState {
   return {
     hand: [],
     discard: [],
@@ -25,6 +29,7 @@ export function createInitialPlayerState(name: string, isAI: boolean): PlayerSta
     name,
     isAI,
     drawnTile: null,
+    seat,
   };
 }
 

--- a/src/types/mahjong.ts
+++ b/src/types/mahjong.ts
@@ -24,4 +24,5 @@ export interface PlayerState {
   name: string;
   isAI: boolean;
   drawnTile: Tile | null;
+  seat: number;
 }

--- a/src/utils/table.test.ts
+++ b/src/utils/table.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { isLeftOf, filterChiOptions } from './table';
+
+describe('isLeftOf', () => {
+  it('returns true when first seat is immediately left of second', () => {
+    expect(isLeftOf(1, 0)).toBe(true);
+    expect(isLeftOf(2, 1)).toBe(true);
+    expect(isLeftOf(3, 2)).toBe(true);
+    expect(isLeftOf(0, 3)).toBe(true);
+  });
+
+  it('returns false otherwise', () => {
+    expect(isLeftOf(0, 0)).toBe(false);
+    expect(isLeftOf(2, 0)).toBe(false);
+  });
+});
+
+describe('filterChiOptions', () => {
+  it('removes chi when caller is not left of discarder', () => {
+    const opts = ['pon', 'chi', 'kan', 'pass'];
+    expect(filterChiOptions(opts, 2, 0)).toEqual(['pon', 'kan', 'pass']);
+  });
+
+  it('keeps chi when caller is left of discarder', () => {
+    const opts = ['pon', 'chi', 'kan', 'pass'];
+    expect(filterChiOptions(opts, 1, 0)).toEqual(opts);
+  });
+});

--- a/src/utils/table.ts
+++ b/src/utils/table.ts
@@ -1,0 +1,14 @@
+export function isLeftOf(a: number, b: number): boolean {
+  return a === ((b + 1) % 4);
+}
+
+export function filterChiOptions(
+  options: (string)[],
+  callerSeat: number,
+  discarderSeat: number,
+): string[] {
+  if (!isLeftOf(callerSeat, discarderSeat)) {
+    return options.filter(o => o !== 'chi');
+  }
+  return options;
+}


### PR DESCRIPTION
## Summary
- add `seat` field to `PlayerState` and update player creation
- track seating in `GameController` and limit chi by position
- provide helper functions for seat checks with tests

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856858c603c832aa2c993da4b1f9a6c