### PR TITLE
Improve AI call decisions

### DIFF
--- a/src/utils/ai.test.ts
+++ b/src/utils/ai.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { chooseAICallOption } from './ai';
+import { Tile, PlayerState } from '../types/mahjong';
+import { createInitialPlayerState } from '../components/Player';
+
+function makePlayer(hand: Tile[]): PlayerState {
+  return { ...createInitialPlayerState('ai', true), hand };
+}
+
+describe('chooseAICallOption', () => {
+  it('chooses kan when possible', () => {
+    const discard: Tile = { suit: 'man', rank: 3, id: 'd' };
+    const hand: Tile[] = [
+      { suit: 'man', rank: 3, id: 'a' },
+      { suit: 'man', rank: 3, id: 'b' },
+      { suit: 'man', rank: 3, id: 'c' },
+    ];
+    expect(chooseAICallOption(makePlayer(hand), discard)).toBe('kan');
+  });
+
+  it('chooses pon over chi', () => {
+    const discard: Tile = { suit: 'pin', rank: 5, id: 'd' };
+    const hand: Tile[] = [
+      { suit: 'pin', rank: 5, id: 'a' },
+      { suit: 'pin', rank: 5, id: 'b' },
+      { suit: 'pin', rank: 6, id: 'c' },
+    ];
+    expect(chooseAICallOption(makePlayer(hand), discard)).toBe('pon');
+  });
+
+  it('chooses chi when sequence exists', () => {
+    const discard: Tile = { suit: 'sou', rank: 4, id: 'd' };
+    const hand: Tile[] = [
+      { suit: 'sou', rank: 3, id: 'a' },
+      { suit: 'sou', rank: 5, id: 'b' },
+    ];
+    expect(chooseAICallOption(makePlayer(hand), discard)).toBe('chi');
+  });
+
+  it('passes when no meld available', () => {
+    const discard: Tile = { suit: 'wind', rank: 1, id: 'd' };
+    const hand: Tile[] = [
+      { suit: 'man', rank: 1, id: 'a' },
+      { suit: 'pin', rank: 2, id: 'b' },
+    ];
+    expect(chooseAICallOption(makePlayer(hand), discard)).toBe('pass');
+  });
+});

--- a/src/utils/ai.ts
+++ b/src/utils/ai.ts
@@ -1,0 +1,19 @@
+import { PlayerState, Tile, MeldType } from '../types/mahjong';
+import { getValidCallOptions } from './meld';
+
+/**
+ * Choose an AI call action based on available options.
+ * Prioritizes kan, then pon, then chi, otherwise pass.
+ */
+export function chooseAICallOption(
+  player: PlayerState,
+  tile: Tile,
+): MeldType | 'pass' {
+  const options = getValidCallOptions(player, tile).filter(
+    o => o !== 'pass',
+  ) as MeldType[];
+  if (options.includes('kan')) return 'kan';
+  if (options.includes('pon')) return 'pon';
+  if (options.includes('chi')) return 'chi';
+  return 'pass';
+}


### PR DESCRIPTION
## Summary
- add a simple AI decision helper for pon/chi/kan calls
- test AI call selection logic
- let AI players evaluate the last discard before drawing

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856873b24d4832aa65897b14d8d0750