### PR TITLE
Add called tile tracking to melds

### DIFF
--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -228,7 +228,13 @@ const handleCallAction = (action: MeldType | 'pass') => {
       ...p[discarder],
       discard: p[discarder].discard.filter(t => t.id !== lastDiscard.tile.id),
     };
-    p[caller] = claimMeld(p[caller], [...meldTiles, lastDiscard.tile], action);
+    p[caller] = claimMeld(
+      p[caller],
+      [...meldTiles, lastDiscard.tile],
+      action,
+      discarder,
+      lastDiscard.tile.id,
+    );
     setPlayers(p);
     playersRef.current = p;
 
@@ -256,7 +262,13 @@ const handleCallAction = (action: MeldType | 'pass') => {
       ...p[discarder],
       discard: p[discarder].discard.filter(t => t.id !== lastDiscard.tile.id),
     };
-    p[caller] = claimMeld(p[caller], [...meldTiles, lastDiscard.tile], action);
+    p[caller] = claimMeld(
+      p[caller],
+      [...meldTiles, lastDiscard.tile],
+      action,
+      discarder,
+      lastDiscard.tile.id,
+    );
     setPlayers(p);
     playersRef.current = p;
     setMessage(`${p[caller].name} が ${action}しました。`);

--- a/src/components/MeldView.test.tsx
+++ b/src/components/MeldView.test.tsx
@@ -13,10 +13,29 @@ describe('MeldView', () => {
         { suit: 'man', rank: 2, id: 'm2' },
         { suit: 'man', rank: 3, id: 'm3' },
       ],
+      fromPlayer: 1,
+      calledTileId: 'm2',
     };
 
     const html = renderToStaticMarkup(<MeldView meld={meld} />);
     const count = (html.match(/tile-font-size/g) || []).length;
     expect(count).toBe(3);
+  });
+
+  it('adds rotate class to called tile', () => {
+    const meld: Meld = {
+      type: 'pon',
+      tiles: [
+        { suit: 'pin', rank: 5, id: 'p1' },
+        { suit: 'pin', rank: 5, id: 'p2' },
+        { suit: 'pin', rank: 5, id: 'p3' },
+      ],
+      fromPlayer: 2,
+      calledTileId: 'p2',
+    };
+    const html = renderToStaticMarkup(<MeldView meld={meld} />);
+    // ensure rotate class applied to the called tile span
+    const rotateCount = (html.match(/rotate-90/g) || []).length;
+    expect(rotateCount).toBe(1);
   });
 });

--- a/src/components/MeldView.tsx
+++ b/src/components/MeldView.tsx
@@ -6,7 +6,11 @@ export const MeldView: React.FC<{ meld: Meld }> = ({ meld }) => {
   return (
     <div className="flex gap-1 border rounded px-1 bg-gray-50">
       {meld.tiles.map(tile => (
-        <TileView key={tile.id} tile={tile} />
+        <TileView
+          key={tile.id}
+          tile={tile}
+          className={tile.id === meld.calledTileId ? 'rotate-90' : undefined}
+        />
       ))}
     </div>
   );

--- a/src/components/Player.test.ts
+++ b/src/components/Player.test.ts
@@ -86,10 +86,10 @@ describe('claimMeld', () => {
     ];
     const player: PlayerState = { ...createInitialPlayerState('Bob', false), hand };
     const tiles = hand.slice(0, 3);
-    const updated = claimMeld(player, tiles, 'chi' as MeldType);
+    const updated = claimMeld(player, tiles, 'chi' as MeldType, 1, 'm2');
     expect(updated.hand).toHaveLength(1);
     expect(updated.hand[0].id).toBe('p1');
-    expect(updated.melds).toEqual([{ type: 'chi', tiles }]);
+    expect(updated.melds).toEqual([{ type: 'chi', tiles, fromPlayer: 1, calledTileId: 'm2' }]);
   });
 });
 

--- a/src/components/Player.ts
+++ b/src/components/Player.ts
@@ -59,12 +59,14 @@ export function claimMeld(
   player: PlayerState,
   tiles: Tile[],
   type: MeldType,
+  fromPlayer: number,
+  calledTileId: string,
 ): PlayerState {
   // remove called tiles from hand
   const hand = player.hand.filter(h => !tiles.some(t => t.id === h.id));
   return {
     ...player,
     hand: sortHand(hand),
-    melds: [...player.melds, { type, tiles }],
+    melds: [...player.melds, { type, tiles, fromPlayer, calledTileId }],
   };
 }

--- a/src/components/TileView.tsx
+++ b/src/components/TileView.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { Tile, Suit } from '../types/mahjong';
 
-export const TileView: React.FC<{ tile: Tile; isShonpai?: boolean }> = ({ tile, isShonpai }) => {
+export const TileView: React.FC<{
+  tile: Tile;
+  isShonpai?: boolean;
+  className?: string;
+}> = ({ tile, isShonpai, className }) => {
   const suitMap: Record<string, string> = { man: '萬', pin: '筒', sou: '索', wind: '', dragon: '' };
   const honorMap: Record<string, Record<number, string>> = {
     wind: { 1: '東', 2: '南', 3: '西', 4: '北' },
@@ -59,7 +63,7 @@ export const TileView: React.FC<{ tile: Tile; isShonpai?: boolean }> = ({ tile, 
       : honorMap[tile.suit]?.[tile.rank] ?? '';
   return (
     <span
-      className="relative inline-block border px-1 py-0.5 bg-white tile-font-size"
+      className={`relative inline-block border px-1 py-0.5 bg-white tile-font-size ${className ?? ''}`}
       aria-label={kanji}
     >
       <span className="font-emoji">{emojiMap[tile.suit]?.[tile.rank] ?? kanji}</span>

--- a/src/index.css
+++ b/src/index.css
@@ -15,3 +15,8 @@
 .tile-font-size {
   font-size: var(--tile-font-size);
 }
+
+/* Utility class for rotating a tile 90 degrees */
+.rotate-90 {
+  transform: rotate(90deg);
+}

--- a/src/score/yaku.test.ts
+++ b/src/score/yaku.test.ts
@@ -149,7 +149,9 @@ describe('Scoring', () => {
       t('sou',2,'s2a'),t('sou',3,'s3a'),t('sou',4,'s4a'),
       t('man',5,'m5a'),t('man',5,'m5b'),
     ];
-    const melds: Meld[] = [{ type: 'pon', tiles: ponTiles }];
+    const melds: Meld[] = [
+      { type: 'pon', tiles: ponTiles, fromPlayer: 1, calledTileId: 'd1a' },
+    ];
     const fullHand = [...concealed, ...ponTiles];
     const yaku = detectYaku(fullHand, melds, { isTsumo: true });
     expect(yaku.some(y => y.name === 'Menzen Tsumo')).toBe(false);
@@ -184,7 +186,9 @@ describe('Scoring', () => {
       t('sou',2,'s2a'),t('sou',3,'s3a'),t('sou',4,'s4a'),
       t('man',5,'m5a'),t('man',5,'m5b'),
     ];
-    const melds: Meld[] = [{ type: 'kan', tiles: kanTiles }];
+    const melds: Meld[] = [
+      { type: 'kan', tiles: kanTiles, fromPlayer: 2, calledTileId: 'k1a' },
+    ];
     const fullHand = [...concealed, ...kanTiles];
     const yaku = detectYaku(fullHand, melds, { isTsumo: true });
     const { fu } = calculateScore(concealed, melds, yaku);

--- a/src/types/mahjong.ts
+++ b/src/types/mahjong.ts
@@ -12,6 +12,10 @@ export type MeldType = 'pon' | 'chi' | 'kan';
 export interface Meld {
   type: MeldType;
   tiles: Tile[];
+  /** index of the player from whom the tile was taken */
+  fromPlayer: number;
+  /** id of the tile claimed from another player's discard */
+  calledTileId: string;
 }
 
 // プレイヤー状態


### PR DESCRIPTION
## Summary
- extend `Meld` with `fromPlayer` and `calledTileId`
- store discarder info in `claimMeld` and update callers
- rotate called tile in meld display
- expose optional className prop on `TileView`
- add rotate-90 utility style
- test MeldView rotation and adjust existing tests

## Testing
- `npm run lint`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68568a247aac832aafa283b8a7a1543e