### PR TITLE
Use only .eslintrc and document linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ npm test
 ```
 - 実行前に **必ず** `npm install` を実行して依存パッケージをインストールする
 
+### 5. Lint
+
+```sh
+npm run lint
+```
+- `.eslintrc.json` を利用した ESLint 設定で、TypeScript/React のコードをチェックできます。
+
 ---
 
 ## CI/CD（GitHub Actions & Pages）


### PR DESCRIPTION
## Summary
- document how to run ESLint
- clarify that `.eslintrc.json` is used for configuration

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856975be218832a854ba1b6e1006eec