### PR TITLE
Auto skip pass when no call options

### DIFF
--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -208,7 +208,13 @@ export const GameController: React.FC = () => {
         playersRef.current[0].seat,
         playersRef.current[idx].seat,
       );
-      setCallOptions(options);
+      if (options.length === 0) {
+        setCallOptions(null);
+        setLastDiscard(null);
+        nextTurn();
+      } else {
+        setCallOptions(options);
+      }
     } else {
       nextTurn();
     }

--- a/src/utils/meld.test.ts
+++ b/src/utils/meld.test.ts
@@ -44,6 +44,19 @@ describe('getValidCallOptions', () => {
     };
     expect(getValidCallOptions(player, discard)).toEqual(['chi', 'pass']);
   });
+
+  it('returns empty array when no meld is possible', () => {
+    const discard: Tile = { suit: 'wind', rank: 1, id: 'd4' };
+    const hand: Tile[] = [
+      { suit: 'man', rank: 3, id: 'x' },
+      { suit: 'pin', rank: 5, id: 'y' },
+    ];
+    const player: PlayerState = {
+      ...createInitialPlayerState('you', false),
+      hand,
+    };
+    expect(getValidCallOptions(player, discard)).toEqual([]);
+  });
 });
 
 describe('selectMeldTiles', () => {

--- a/src/utils/meld.ts
+++ b/src/utils/meld.ts
@@ -37,6 +37,6 @@ export function getValidCallOptions(
   (['pon', 'chi', 'kan'] as MeldType[]).forEach(t => {
     if (selectMeldTiles(player, tile, t)) actions.push(t);
   });
-  actions.push('pass');
+  if (actions.length > 0) actions.push('pass');
   return actions;
 }


### PR DESCRIPTION
## Summary
- omit `pass` from `getValidCallOptions` when no meld exists
- automatically advance turn if user has no call options
- test empty case in `getValidCallOptions`

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856b1e55c18832aa29625ee2e27bccb