### PR TITLE
Implement detailed Mahjong scoring

### DIFF
--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -143,17 +143,25 @@ export const GameController: React.FC = () => {
         isTsumo: true,
         isRiichi: p[currentIndex].isRiichi,
       });
-      const { han, fu, points } = calculateScore(
+      const dealerIndex = 1;
+      const isDealer = currentIndex === dealerIndex;
+      const { han, fu, tsumo } = calculateScore(
         p[currentIndex].hand,
         p[currentIndex].melds,
         yaku,
         dora,
+        isDealer,
       );
-      const newPlayers = payoutTsumo(p, currentIndex, points);
+      const newPlayers = payoutTsumo(p, currentIndex, tsumo, dealerIndex);
       setPlayers(newPlayers);
       playersRef.current = newPlayers;
+      const totalPoints = isDealer
+        ? tsumo.dealer * (p.length - 1)
+        : tsumo.dealer + tsumo.nonDealer * (p.length - 2);
       setMessage(
-        `${p[currentIndex].name} の和了！ ${yaku.map(y => y.name).join(', ')} ${han}翻 ${fu}符 ${points}点`,
+        `${p[currentIndex].name} の和了！ ${yaku
+          .map(y => y.name)
+          .join(', ')} ${han}翻 ${fu}符 ${totalPoints}点`,
       );
       setTimeout(nextKyoku, 500);
       return;
@@ -185,18 +193,22 @@ export const GameController: React.FC = () => {
         isTsumo: false,
         isRiichi: winningPlayer.isRiichi,
       });
-      const { han, fu, points } = calculateScore(
+      const dealerIndex = 1;
+      const isDealer = winIdx === dealerIndex;
+      const { han, fu, ron } = calculateScore(
         [...winningPlayer.hand, tile],
         winningPlayer.melds,
         yaku,
+        [],
+        isDealer,
       );
-      const updated = payoutRon(p, winIdx, idx, points);
+      const updated = payoutRon(p, winIdx, idx, ron);
       setPlayers(updated);
       playersRef.current = updated;
       setMessage(
         `${winningPlayer.name} のロン！ ${yaku
           .map(y => y.name)
-          .join(', ')} ${han}翻 ${fu}符 ${points}点`,
+          .join(', ')} ${han}翻 ${fu}符 ${ron}点`,
       );
       setTimeout(nextKyoku, 500);
       return;

--- a/src/score/score.ts
+++ b/src/score/score.ts
@@ -154,12 +154,40 @@ export function calculateScore(
   melds: Meld[],
   yaku: Yaku[],
   doraIndicators: Tile[] = [],
-): { han: number; fu: number; points: number } {
+  isDealer = false,
+): {
+  han: number;
+  fu: number;
+  ron: number;
+  tsumo: { dealer: number; nonDealer: number };
+} {
   const allTiles = [...hand, ...melds.flatMap(m => m.tiles)];
   const dora = countDora(allTiles, doraIndicators);
   const han = yaku.reduce((sum, y) => sum + y.han, 0) + dora;
   const fu = calculateFu(hand, melds);
-  const base = fu * Math.pow(2, han + 2);
-  const points = base;
-  return { han, fu, points };
+
+  let base = fu * Math.pow(2, han + 2);
+
+  if (han >= 13) {
+    base = 8000;
+  } else if (han >= 11) {
+    base = 6000;
+  } else if (han >= 8) {
+    base = 4000;
+  } else if (han >= 6) {
+    base = 3000;
+  } else if (han >= 5) {
+    base = 2000;
+  } else if (base >= 2000) {
+    base = 2000;
+  }
+
+  const round100 = (n: number) => Math.ceil(n / 100) * 100;
+
+  const ron = round100(base * (isDealer ? 6 : 4));
+
+  const dealerPay = round100(base * 2);
+  const nonDealerPay = isDealer ? dealerPay : round100(base);
+
+  return { han, fu, ron, tsumo: { dealer: dealerPay, nonDealer: nonDealerPay } };
 }

--- a/src/score/yaku.test.ts
+++ b/src/score/yaku.test.ts
@@ -118,10 +118,12 @@ describe('Scoring', () => {
       t('pin',5,'p5a'),t('pin',5,'p5b'),
     ];
     const yaku = detectYaku(hand, [], { isTsumo: true });
-    const { han, fu, points } = calculateScore(hand, [], yaku, []);
+    const { han, fu, ron, tsumo } = calculateScore(hand, [], yaku, [], false);
     expect(han).toBe(3);
     expect(fu).toBe(20);
-    expect(points).toBe(640);
+    expect(ron).toBe(2600);
+    expect(tsumo.dealer).toBe(1300);
+    expect(tsumo.nonDealer).toBe(700);
   });
 
   it('adds fu for honor triplets', () => {
@@ -208,5 +210,39 @@ describe('Scoring', () => {
     const { han } = calculateScore(hand, [], yaku, []);
     // メンタンピン三色だから5ハンでは…?
     expect(han).toBe(4);
+  });
+
+  it('applies mangan limit and dealer/child differences', () => {
+    const hand: Tile[] = [
+      t('man',2,'m2a'),t('man',3,'m3a'),t('man',4,'m4a'),
+      t('pin',2,'p2a'),t('pin',3,'p3a'),t('pin',4,'p4a'),
+      t('sou',2,'s2a'),t('sou',3,'s3a'),t('sou',4,'s4a'),
+      t('man',6,'m6a'),t('man',7,'m7a'),t('man',8,'m8a'),
+      t('pin',5,'p5a'),t('pin',5,'p5b'),
+    ];
+    const yaku = detectYaku(hand, [], { isTsumo: true });
+    const doraIndicator = t('man',5,'di1');
+    const result = calculateScore(hand, [], yaku, [doraIndicator, doraIndicator], false);
+    expect(result.han).toBe(5);
+    expect(result.ron).toBe(8000);
+    expect(result.tsumo.dealer).toBe(4000);
+    expect(result.tsumo.nonDealer).toBe(2000);
+  });
+
+  it('calculates yakuman points for non-dealer', () => {
+    const hand: Tile[] = [
+      t('man',1,'m1a'),t('man',9,'m9a'),
+      t('pin',1,'p1a'),t('pin',9,'p9a'),
+      t('sou',1,'s1a'),t('sou',9,'s9a'),
+      t('wind',1,'e'),t('wind',2,'s'),t('wind',3,'w'),t('wind',4,'n'),
+      t('dragon',1,'d1a'),t('dragon',2,'d2a'),t('dragon',3,'d3a'),
+      t('man',1,'m1b'),
+    ];
+    const yaku = detectYaku(hand, [], { isTsumo: true });
+    const result = calculateScore(hand, [], yaku, [], false);
+    expect(result.han).toBeGreaterThanOrEqual(13);
+    expect(result.ron).toBe(32000);
+    expect(result.tsumo.dealer).toBe(16000);
+    expect(result.tsumo.nonDealer).toBe(8000);
   });
 });

--- a/src/utils/payout.test.ts
+++ b/src/utils/payout.test.ts
@@ -12,12 +12,23 @@ function setupPlayers() {
 }
 
 describe('payoutTsumo', () => {
-  it('adjusts scores for a tsumo win', () => {
+  it('adjusts scores for a non-dealer tsumo win', () => {
     const players = setupPlayers();
-    const updated = payoutTsumo(players, 0, 1000);
-    expect(updated[0].score).toBe(players[0].score + 3000);
-    for (let i = 1; i < 4; i++) {
-      expect(updated[i].score).toBe(players[i].score - 1000);
+    const payments = { dealer: 2000, nonDealer: 1000 };
+    const updated = payoutTsumo(players, 0, payments, 1);
+    expect(updated[0].score).toBe(players[0].score + 4000);
+    expect(updated[1].score).toBe(players[1].score - 2000);
+    expect(updated[2].score).toBe(players[2].score - 1000);
+    expect(updated[3].score).toBe(players[3].score - 1000);
+  });
+
+  it('adjusts scores when the dealer tsumo wins', () => {
+    const players = setupPlayers();
+    const payments = { dealer: 2000, nonDealer: 2000 };
+    const updated = payoutTsumo(players, 1, payments, 1);
+    expect(updated[1].score).toBe(players[1].score + 6000);
+    for (let i of [0,2,3]) {
+      expect(updated[i].score).toBe(players[i].score - 2000);
     }
   });
 });

--- a/src/utils/payout.ts
+++ b/src/utils/payout.ts
@@ -3,13 +3,24 @@ import { PlayerState } from '../types/mahjong';
 export function payoutTsumo(
   players: PlayerState[],
   winner: number,
-  points: number,
+  payments: { dealer: number; nonDealer: number },
+  dealerIndex: number,
 ): PlayerState[] {
   return players.map((p, idx) => {
     if (idx === winner) {
-      return { ...p, score: p.score + points * (players.length - 1) };
+      const gain =
+        winner === dealerIndex
+          ? payments.dealer * (players.length - 1)
+          : payments.dealer + payments.nonDealer * (players.length - 2);
+      return { ...p, score: p.score + gain };
     }
-    return { ...p, score: p.score - points };
+    const pay =
+      winner === dealerIndex
+        ? payments.dealer
+        : idx === dealerIndex
+          ? payments.dealer
+          : payments.nonDealer;
+    return { ...p, score: p.score - pay };
   });
 }
 


### PR DESCRIPTION
## Summary
- implement point limits and dealer-aware scoring in `calculateScore`
- adjust GameController to use new scoring result
- handle dealer vs non-dealer payments in `payoutTsumo`
- extend tests for scoring and payouts

## Testing
- `npm run type-check`
- `npm run lint`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856b159933c832ab06f11000e21307b