### PR TITLE
Fix open-meld shanten calculation

### DIFF
--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -52,7 +52,7 @@ export const GameController: React.FC = () => {
   useEffect(() => {
     playersRef.current = players;
     if (players.length > 0) {
-      setShanten(calcShanten(players[0].hand));
+      setShanten(calcShanten(players[0].hand, players[0].melds.length));
     }
   }, [players]);
 

--- a/src/utils/shanten.test.ts
+++ b/src/utils/shanten.test.ts
@@ -78,4 +78,15 @@ describe('shanten calculations', () => {
     ];
     expect(calcKokushiShanten(hand)).toBe(2);
   });
+
+  it('accounts for open melds in standard shanten', () => {
+    const hand: Tile[] = [
+      t('man', 1, 'a'), t('man', 2, 'b'), t('man', 3, 'c'),
+      t('man', 4, 'd'), t('man', 5, 'e'), t('man', 6, 'f'),
+      t('man', 7, 'g'), t('man', 8, 'h'), t('man', 9, 'i'),
+      t('pin', 2, 'j'), t('pin', 2, 'k'),
+    ];
+    expect(calcStandardShanten(hand, 1)).toBe(-1);
+    expect(calcShanten(hand, 1).standard).toBe(-1);
+  });
 });

--- a/src/utils/shanten.ts
+++ b/src/utils/shanten.ts
@@ -5,7 +5,7 @@ function tileIndex(tile: Tile): number {
   return base[tile.suit] + tile.rank - 1;
 }
 
-export function calcStandardShanten(hand: Tile[]): number {
+export function calcStandardShanten(hand: Tile[], openMelds = 0): number {
   const counts = new Array(34).fill(0);
   for (const t of hand) counts[tileIndex(t)]++;
   let melds = 0;
@@ -57,6 +57,7 @@ export function calcStandardShanten(hand: Tile[]): number {
     }
   }
   if (pairs > 1) pairs = 1;
+  melds += openMelds;
   if (taatsu > 4 - melds) taatsu = 4 - melds;
   return 8 - melds * 2 - taatsu - pairs;
 }
@@ -91,13 +92,13 @@ export function calcKokushiShanten(hand: Tile[]): number {
   return 13 - unique - (hasPair ? 1 : 0);
 }
 
-export function calcShanten(hand: Tile[]): {
+export function calcShanten(hand: Tile[], openMelds = 0): {
   standard: number;
   chiitoi: number;
   kokushi: number;
 } {
   return {
-    standard: calcStandardShanten(hand),
+    standard: calcStandardShanten(hand, openMelds),
     chiitoi: calcChiitoiShanten(hand),
     kokushi: calcKokushiShanten(hand),
   };


### PR DESCRIPTION
## Summary
- count existing melds when computing shanten
- update shanten usage in GameController
- add regression test for melded hand

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856b2ab9e28832ab54c72b2214dfbc4