### PR TITLE
Show riichi button only when available

### DIFF
--- a/src/components/Player.test.ts
+++ b/src/components/Player.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { incrementDiscardCount } from './DiscardUtil';
-import { createInitialPlayerState, drawTiles, discardTile, sortHand, claimMeld, declareRiichi } from './Player';
+import { createInitialPlayerState, drawTiles, discardTile, sortHand, claimMeld, declareRiichi, canDeclareRiichi } from './Player';
 import { generateTileWall } from './TileWall';
 import { Tile, PlayerState, MeldType } from '../types/mahjong';
 
@@ -142,5 +142,43 @@ describe('declareRiichi', () => {
     const player = createInitialPlayerState('RiichiMan', false);
     const updated = declareRiichi(player);
     expect(updated.isRiichi).toBe(true);
+  });
+});
+
+describe('canDeclareRiichi', () => {
+  const t = (suit: Tile['suit'], rank: number, id: string): Tile => ({ suit, rank, id });
+
+  it('returns true for a closed tenpai hand with drawn tile', () => {
+    const hand: Tile[] = [
+      t('man', 1, 'a1'), t('man', 1, 'a2'),
+      t('man', 2, 'b1'), t('man', 2, 'b2'),
+      t('pin', 3, 'c1'), t('pin', 3, 'c2'),
+      t('pin', 4, 'd1'), t('pin', 4, 'd2'),
+      t('sou', 5, 'e1'), t('sou', 5, 'e2'),
+      t('sou', 6, 'f1'), t('sou', 6, 'f2'),
+      t('man', 7, 'g1'), t('man', 8, 'h1'),
+    ];
+    const player: PlayerState = {
+      ...createInitialPlayerState('Tenpai', false),
+      hand,
+      drawnTile: hand[13],
+    };
+    expect(canDeclareRiichi(player)).toBe(true);
+  });
+
+  it('returns false when not in tenpai', () => {
+    const hand: Tile[] = [
+      t('man', 1, 'a'), t('man', 2, 'b'), t('man', 3, 'c'),
+      t('man', 4, 'd'), t('man', 5, 'e'), t('man', 6, 'f'),
+      t('man', 7, 'g'), t('man', 8, 'h'), t('man', 9, 'i'),
+      t('pin', 1, 'j'), t('pin', 1, 'k'),
+      t('sou', 2, 'l'), t('sou', 2, 'm'), t('sou', 3, 'n'),
+    ];
+    const player: PlayerState = {
+      ...createInitialPlayerState('NoTen', false),
+      hand,
+      drawnTile: null,
+    };
+    expect(canDeclareRiichi(player)).toBe(false);
   });
 });

--- a/src/components/Player.ts
+++ b/src/components/Player.ts
@@ -1,4 +1,5 @@
 import { PlayerState, Tile, MeldType } from '../types/mahjong';
+import { calcShanten } from '../utils/shanten';
 
 export function sortHand(hand: Tile[]): Tile[] {
   const order: Record<Tile['suit'], number> = {
@@ -79,4 +80,19 @@ export function claimMeld(
 export function declareRiichi(player: PlayerState): PlayerState {
   if (player.isRiichi) return player;
   return { ...player, isRiichi: true };
+}
+
+export function canDeclareRiichi(player: PlayerState): boolean {
+  if (player.isRiichi || player.melds.length > 0 || !player.drawnTile) {
+    return false;
+  }
+  for (const tile of player.hand) {
+    const remaining = player.hand.filter(t => t.id !== tile.id);
+    const shanten = calcShanten(remaining, player.melds.length);
+    const base = Math.min(shanten.standard, shanten.chiitoi, shanten.kokushi);
+    if (base === 0) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/src/components/UIBoard.test.tsx
+++ b/src/components/UIBoard.test.tsx
@@ -1,13 +1,15 @@
 // @vitest-environment jsdom
 import React from 'react'; // needed for JSX linting
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
 import { UIBoard } from './UIBoard';
-import { createInitialPlayerState } from './Player';
+import { createInitialPlayerState, canDeclareRiichi } from './Player';
 import { Tile } from '../types/mahjong';
+import type { PlayerState } from "../types/mahjong";
 
 const basePlayer = createInitialPlayerState('you', false);
 
+afterEach(() => cleanup());
 function renderBoard(shanten: { standard: number; chiitoi: number; kokushi: number }) {
   const props = {
     players: [basePlayer],
@@ -44,5 +46,64 @@ describe('UIBoard shanten display', () => {
   it('shows kokushi label for 2-shanten', () => {
     renderBoard({ standard: 3, chiitoi: 3, kokushi: 2 });
     expect(screen.getByText('向聴数: 2 (国士無双2向聴)')).toBeTruthy();
+  });
+});
+
+describe('UIBoard riichi button', () => {
+  const t = (suit: Tile['suit'], rank: number, id: string): Tile => ({ suit, rank, id });
+
+  function makePlayer(hand: Tile[]): PlayerState {
+    const p = { ...createInitialPlayerState('you', false), hand, drawnTile: hand[hand.length - 1] } as PlayerState;
+    return p;
+  }
+
+  it('shows the riichi button when riichi is possible', () => {
+    const hand: Tile[] = [
+      t('man',1,'a1'), t('man',1,'a2'),
+      t('man',2,'b1'), t('man',2,'b2'),
+      t('pin',3,'c1'), t('pin',3,'c2'),
+      t('pin',4,'d1'), t('pin',4,'d2'),
+      t('sou',5,'e1'), t('sou',5,'e2'),
+      t('sou',6,'f1'), t('sou',6,'f2'),
+      t('man',7,'g1'), t('man',8,'h1'),
+    ];
+    const player = makePlayer(hand);
+    expect(canDeclareRiichi(player)).toBe(true);
+    render(
+      <UIBoard
+        players={[player]}
+        dora={[]}
+        onDiscard={() => {}}
+        isMyTurn={true}
+        shanten={{ standard: 0, chiitoi: 0, kokushi: 13 }}
+        lastDiscard={null}
+        onRiichi={() => {}}
+      />,
+    );
+    expect(screen.getByText('リーチ')).toBeTruthy();
+  });
+
+  it('does not show the riichi button when riichi is not possible', () => {
+    const hand: Tile[] = [
+      t('man',1,'a'), t('man',2,'b'), t('man',3,'c'),
+      t('man',4,'d'), t('man',5,'e'), t('man',6,'f'),
+      t('man',7,'g'), t('man',8,'h'), t('man',9,'i'),
+      t('pin',1,'j'), t('pin',1,'k'),
+      t('sou',2,'l'), t('sou',2,'m'), t('sou',3,'n'),
+    ];
+    const player = { ...makePlayer(hand), drawnTile: null } as PlayerState;
+    expect(canDeclareRiichi(player)).toBe(false);
+    render(
+      <UIBoard
+        players={[player]}
+        dora={[]}
+        onDiscard={() => {}}
+        isMyTurn={true}
+        shanten={{ standard: 1, chiitoi: 4, kokushi: 9 }}
+        lastDiscard={null}
+        onRiichi={() => {}}
+      />,
+    );
+    expect(screen.queryByText('リーチ')).toBeNull();
   });
 });

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { PlayerState, Tile, MeldType } from '../types/mahjong';
 import { TileView } from './TileView';
+import { canDeclareRiichi } from './Player';
 import { MeldView } from './MeldView';
 
 interface UIBoardProps {
@@ -140,11 +141,10 @@ export const UIBoard: React.FC<UIBoardProps> = ({
             ))}
           </div>
         )}
-        {onRiichi && (
+        {onRiichi && isMyTurn && canDeclareRiichi(players[0]) && (
           <button
             className="mt-2 px-2 py-1 bg-red-200 rounded"
             onClick={() => onRiichi()}
-            disabled={!isMyTurn || players[0].isRiichi}
           >
             リーチ
           </button>


### PR DESCRIPTION
## Summary
- add `canDeclareRiichi` helper to determine if riichi can be declared
- hide the riichi button unless the player can declare riichi
- test the new helper and UI behaviour

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68576b98301c832a9aa846dc32f0a77b