### PR TITLE
Fix auto skip when chi not allowed

### DIFF
--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -208,7 +208,8 @@ export const GameController: React.FC = () => {
         playersRef.current[0].seat,
         playersRef.current[idx].seat,
       );
-      if (options.length === 0) {
+      const hasAction = options.some(o => o !== 'pass');
+      if (!hasAction) {
         setCallOptions(null);
         setLastDiscard(null);
         nextTurn();


### PR DESCRIPTION
## Summary
- auto-skip when only `pass` remains after filtering chi options

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68576f54c6a8832aa5427d84a441b9a3