### PR TITLE
Add FuQuiz mode selection

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,18 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import App from './App';
+
+describe('App mode switching', () => {
+  it('renders FuQuiz when mode is changed', async () => {
+    render(<App />);
+    // Wait for GameController (scoreboard) to appear
+    expect(await screen.findByText('東1局')).toBeTruthy();
+    const select = screen.getByLabelText('モード');
+    fireEvent.change(select, { target: { value: 'fu-quiz' } });
+    expect(
+      screen.getByRole('heading', { name: '符計算クイズ' })
+    ).toBeTruthy();
+  });
+});

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -12,7 +12,7 @@ describe('App mode switching', () => {
     const select = screen.getByLabelText('モード');
     fireEvent.change(select, { target: { value: 'fu-quiz' } });
     expect(
-      screen.getByRole('heading', { name: '符計算クイズ' })
+      await screen.findByRole('heading', { name: '符計算クイズ' })
     ).toBeTruthy();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
 import { GameController } from './components/GameController';
+import { FuQuiz } from './components/FuQuiz';
 
 function App() {
   const [tileFont, setTileFont] = useState(2);
+  const [mode, setMode] = useState<'game' | 'fu-quiz'>('game');
 
   return (
     <div
@@ -11,7 +13,7 @@ function App() {
     >
       <div className="w-full max-w-4xl mx-auto px-4 space-y-6">
         <h1 className="text-2xl font-bold text-center">麻雀 Web アプリ（1人用デモ）</h1>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-wrap">
           <label htmlFor="size">牌サイズ</label>
           <input
             id="size"
@@ -22,8 +24,18 @@ function App() {
             value={tileFont}
             onChange={e => setTileFont(parseFloat(e.target.value))}
           />
+          <label htmlFor="mode" className="ml-4">モード</label>
+          <select
+            id="mode"
+            value={mode}
+            onChange={e => setMode(e.target.value as 'game' | 'fu-quiz')}
+            className="border rounded px-2 py-1"
+          >
+            <option value="game">ゲーム</option>
+            <option value="fu-quiz">符計算クイズ</option>
+          </select>
         </div>
-        <GameController />
+        {mode === 'fu-quiz' ? <FuQuiz /> : <GameController />}
       </div>
     </div>
   );

--- a/src/components/FuQuiz.tsx
+++ b/src/components/FuQuiz.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export const FuQuiz: React.FC = () => {
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-bold mb-2">符計算クイズ</h2>
+      <p>Coming soon!</p>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add a simple `<FuQuiz>` component
- add mode selector to `App` and conditionally render `FuQuiz` or `GameController`
- test mode switching logic

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68576eb1e35c832a9420809c826b5cbc