### PR TITLE
Improve scoring test docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,5 @@ npm test --if-present
 ```
 
 Use Node.js 20.x for parity with GitHub Actions. All Pull Requests should pass these commands locally prior to submission.
+
+When writing point calculation tests, include a comment explaining the computation and why the expected score should result (e.g., "今の実装だと◯◯の計算になって、だからこの点数になるはずだ").

--- a/src/score/yaku.test.ts
+++ b/src/score/yaku.test.ts
@@ -215,6 +215,8 @@ describe('Scoring', () => {
     ];
     const yaku = detectYaku(hand, [], { isTsumo: true });
     const { han, fu, points } = calculateScore(hand, [], yaku, []);
+    // 今の実装では基本点 = fu * 2^(han + 2)
+    // この手は20符5翻なので 20 * 2^(5 + 2) = 2560 となるはず
     expect(han).toBe(5);
     expect(fu).toBe(20);
     expect(points).toBe(2560);
@@ -252,6 +254,7 @@ describe('Scoring', () => {
     const yaku = detectYaku(fullHand, melds, { isTsumo: true });
     expect(yaku.some(y => y.name === 'Menzen Tsumo')).toBe(false);
     const { fu } = calculateScore(concealed, melds, yaku, []);
+    // 基本符20 + 明刻(役牌)8 = 28、切り上げで30符になるはず
     expect(fu).toBe(30);
   });
 
@@ -288,6 +291,7 @@ describe('Scoring', () => {
     const fullHand = [...concealed, ...kanTiles];
     const yaku = detectYaku(fullHand, melds, { isTsumo: true });
     const { fu } = calculateScore(concealed, melds, yaku);
+    // 基本符20 + カン(役牌)32 = 52、切り上げで60符になるはず
     expect(fu).toBe(60);
   });
 


### PR DESCRIPTION
## Summary
- update contributing agent instructions to mention score test annotations
- add Japanese comments explaining expected scoring math in tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68577156fb78832a8d85c55a5fccb762