### PR TITLE
Add mode selector for FuQuiz

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,16 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import App from './App';
+
+describe('App mode selector', () => {
+  it('switches between game and fu quiz', () => {
+    render(<App />);
+    // default is game mode
+    expect(screen.getByLabelText('観戦モード')).toBeTruthy();
+    const select = screen.getByLabelText('モード');
+    fireEvent.change(select, { target: { value: 'fu-quiz' } });
+    expect(screen.getByPlaceholderText('符を入力')).toBeTruthy();
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
 import { GameController } from './components/GameController';
+import { FuQuiz } from './components/FuQuiz';
 
 function App() {
   const [tileFont, setTileFont] = useState(2);
+  const [mode, setMode] = useState<'game' | 'fu-quiz'>('game');
 
   return (
     <div
@@ -23,7 +25,19 @@ function App() {
             onChange={e => setTileFont(parseFloat(e.target.value))}
           />
         </div>
-        <GameController />
+        <div className="flex items-center gap-2">
+          <label htmlFor="mode">モード</label>
+          <select
+            id="mode"
+            value={mode}
+            onChange={e => setMode(e.target.value as 'game' | 'fu-quiz')}
+            className="border px-2 py-1"
+          >
+            <option value="game">ゲーム</option>
+            <option value="fu-quiz">符クイズ</option>
+          </select>
+        </div>
+        {mode === 'game' ? <GameController /> : <FuQuiz />}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- toggle between game and fu-quiz in App
- test switching modes in App

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685777d4930c832a80329d83a928d128