### PR TITLE
Add calculateFu usage in FuQuiz

### DIFF
--- a/src/components/FuQuiz.tsx
+++ b/src/components/FuQuiz.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Tile, Meld } from '../types/mahjong';
+import { calculateFu } from '../score/score';
 import { TileView } from './TileView';
 import { sortHand } from './Player';
 
@@ -189,8 +190,9 @@ export const FuQuiz: React.FC<FuQuizProps> = ({ initialIndex }) => {
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    const fu = calculateFu(question.hand, question.melds);
     const detail = calculateFuDetail(question.hand, question.melds);
-    setResult(detail);
+    setResult({ fu, steps: detail.steps });
   };
 
   const nextQuestion = () => {


### PR DESCRIPTION
## Summary
- show fu quiz hands using `calculateFu`

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857792ac184832a95a00d8a577658cf