### PR TITLE
Add calculateFu tests

### DIFF
--- a/src/score/calculateFu.test.ts
+++ b/src/score/calculateFu.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { SAMPLE_HANDS } from '../quiz/sampleHands';
+import { calculateFu } from './score';
+
+describe('calculateFu', () => {
+  it('computes fu for a hand with only sequences', () => {
+    const { hand, melds } = SAMPLE_HANDS[0];
+    const fu = calculateFu(hand, melds);
+    // 基本符20のみなので20符になるはず
+    expect(fu).toBe(20);
+  });
+
+  it('computes fu for a hand with a dragon pon', () => {
+    const { hand, melds } = SAMPLE_HANDS[1];
+    const fu = calculateFu(hand, melds);
+    // 基本符20 + 明刻(役牌)8 = 28、切り上げで30符になるはず
+    expect(fu).toBe(30);
+  });
+
+  it('computes fu for a hand with a dragon kan', () => {
+    const { hand, melds } = SAMPLE_HANDS[2];
+    const fu = calculateFu(hand, melds);
+    // 基本符20 + カン(役牌)32 = 52、切り上げで60符になるはず
+    expect(fu).toBe(60);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests in `src/score/calculateFu.test.ts` validating fu counts for several sample hands

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68577e2f9798832aa15ee463f519db61