### PR TITLE
Add feedback to FuQuiz with tests

### DIFF
--- a/src/components/FuQuiz.test.tsx
+++ b/src/components/FuQuiz.test.tsx
@@ -1,16 +1,29 @@
 // @vitest-environment jsdom
 import React from 'react';
-import { describe, it, expect } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { FuQuiz } from './FuQuiz';
 
+// 固定のサンプルハンドで符計算クイズをテストする
+// SAMPLE_HANDS[0] は calculateFu(...) が 20 になる
+
+afterEach(() => cleanup());
 describe('FuQuiz', () => {
-  it('shows the correct fu after submitting', () => {
+  it('shows "正解！" when the guess is correct', () => {
     render(<FuQuiz initialIndex={0} />);
     const input = screen.getByPlaceholderText('符を入力');
     fireEvent.change(input, { target: { value: '20' } });
     const button = screen.getByText('答える');
     fireEvent.click(button);
-    expect(screen.getByText('正解: 20符')).toBeTruthy();
+    expect(screen.getByText('正解！')).toBeTruthy();
+  });
+
+  it('shows the correct answer when the guess is wrong', () => {
+    render(<FuQuiz initialIndex={0} />);
+    const input = screen.getByPlaceholderText('符を入力');
+    fireEvent.change(input, { target: { value: '30' } });
+    const button = screen.getByText('答える');
+    fireEvent.click(button);
+    expect(screen.getByText('不正解。正解: 20符')).toBeTruthy();
   });
 });

--- a/src/components/FuQuiz.tsx
+++ b/src/components/FuQuiz.tsx
@@ -142,7 +142,9 @@ interface FuQuizProps {
 export const FuQuiz: React.FC<FuQuizProps> = ({ initialIndex }) => {
   const [idx, setIdx] = useState(initialIndex ?? 0);
   const [guess, setGuess] = useState('');
-  const [result, setResult] = useState<{ fu: number; steps: string[] } | null>(null);
+  const [result, setResult] = useState<{ fu: number; steps: string[]; correct: boolean } | null>(
+    null,
+  );
 
   const question = SAMPLE_HANDS[idx];
   const fullHand = sortHand([...question.hand, ...question.melds.flatMap(m => m.tiles)]);
@@ -151,7 +153,8 @@ export const FuQuiz: React.FC<FuQuizProps> = ({ initialIndex }) => {
     e.preventDefault();
     const fu = calculateFu(question.hand, question.melds);
     const detail = calculateFuDetail(question.hand, question.melds);
-    setResult({ fu, steps: detail.steps });
+    const correct = Number(guess) === fu;
+    setResult({ fu, steps: detail.steps, correct });
   };
 
   const nextQuestion = () => {
@@ -178,7 +181,7 @@ export const FuQuiz: React.FC<FuQuizProps> = ({ initialIndex }) => {
       </form>
       {result && (
         <div className="mt-2">
-          <div>正解: {result.fu}符</div>
+          <div>{result.correct ? '正解！' : `不正解。正解: ${result.fu}符`}</div>
           <ul className="list-disc list-inside text-sm">
             {result.steps.map((s, i) => (
               <li key={i}>{s}</li>


### PR DESCRIPTION
## Summary
- enhance `FuQuiz` component to provide correct/incorrect feedback
- rewrite `FuQuiz.test.tsx` to test both correct and incorrect answers

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_68577e3a4168832a8894d6061c883ae2