### PR TITLE
Add random agari hand generator

### DIFF
--- a/src/components/FuQuiz.tsx
+++ b/src/components/FuQuiz.tsx
@@ -4,6 +4,7 @@ import { calculateFu } from '../score/score';
 import { TileView } from './TileView';
 import { sortHand } from './Player';
 import { SAMPLE_HANDS } from '../quiz/sampleHands';
+import { generateRandomAgari } from '../quiz/randomAgari';
 
 // helper functions copied from score.ts for fu breakdown
 function tileKey(t: Tile): string {
@@ -141,12 +142,13 @@ interface FuQuizProps {
 
 export const FuQuiz: React.FC<FuQuizProps> = ({ initialIndex }) => {
   const [idx, setIdx] = useState(initialIndex ?? 0);
+  const [question, setQuestion] = useState(() =>
+    initialIndex !== undefined ? SAMPLE_HANDS[initialIndex] : generateRandomAgari(),
+  );
   const [guess, setGuess] = useState('');
   const [result, setResult] = useState<{ fu: number; steps: string[]; correct: boolean } | null>(
     null,
   );
-
-  const question = SAMPLE_HANDS[idx];
   const fullHand = sortHand([...question.hand, ...question.melds.flatMap(m => m.tiles)]);
 
   const onSubmit = (e: React.FormEvent) => {
@@ -158,7 +160,13 @@ export const FuQuiz: React.FC<FuQuizProps> = ({ initialIndex }) => {
   };
 
   const nextQuestion = () => {
-    setIdx((idx + 1) % SAMPLE_HANDS.length);
+    if (initialIndex !== undefined) {
+      const next = (idx + 1) % SAMPLE_HANDS.length;
+      setIdx(next);
+      setQuestion(SAMPLE_HANDS[next]);
+    } else {
+      setQuestion(generateRandomAgari());
+    }
     setGuess('');
     setResult(null);
   };

--- a/src/quiz/randomAgari.test.ts
+++ b/src/quiz/randomAgari.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { generateRandomAgari } from './randomAgari';
+import { isWinningHand } from '../score/yaku';
+
+describe('generateRandomAgari', () => {
+  it('creates a 14-tile winning hand', () => {
+    const { hand, melds } = generateRandomAgari();
+    expect(hand).toHaveLength(14);
+    expect(melds).toHaveLength(0);
+    expect(isWinningHand(hand)).toBe(true);
+  });
+});

--- a/src/quiz/randomAgari.ts
+++ b/src/quiz/randomAgari.ts
@@ -1,0 +1,69 @@
+import { Tile, Meld, Suit } from '../types/mahjong';
+import { generateTileWall } from '../components/TileWall';
+import { sortHand } from '../components/Player';
+
+export interface AgariHand {
+  hand: Tile[];
+  melds: Meld[];
+}
+
+function drawTiles(wall: Tile[], suit: Suit, rank: number, count: number): Tile[] {
+  const tiles: Tile[] = [];
+  for (let i = 0; i < wall.length && tiles.length < count; i++) {
+    if (wall[i].suit === suit && wall[i].rank === rank) {
+      tiles.push(...wall.splice(i, 1));
+      i--;
+    }
+  }
+  if (tiles.length < count) {
+    throw new Error('Not enough tiles to draw');
+  }
+  return tiles;
+}
+
+function randomFrom<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+export function generateRandomAgari(): AgariHand {
+  const wall = generateTileWall();
+  const hand: Tile[] = [];
+  const suits: Suit[] = ['man', 'pin', 'sou'];
+  const allSuits: Suit[] = ['man', 'pin', 'sou', 'wind', 'dragon'];
+
+  for (let i = 0; i < 4; i++) {
+    if (Math.random() < 0.5) {
+      const suit = randomFrom(suits);
+      const base = 1 + Math.floor(Math.random() * 7);
+      hand.push(...drawTiles(wall, suit, base, 1));
+      hand.push(...drawTiles(wall, suit, base + 1, 1));
+      hand.push(...drawTiles(wall, suit, base + 2, 1));
+    } else {
+      let added = false;
+      while (!added) {
+        const suit = randomFrom(allSuits);
+        const maxRank = suit === 'wind' ? 4 : suit === 'dragon' ? 3 : 9;
+        const rank = 1 + Math.floor(Math.random() * maxRank);
+        const count = wall.filter(t => t.suit === suit && t.rank === rank).length;
+        if (count >= 3) {
+          hand.push(...drawTiles(wall, suit, rank, 3));
+          added = true;
+        }
+      }
+    }
+  }
+
+  let paired = false;
+  while (!paired) {
+    const suit = randomFrom(allSuits);
+    const maxRank = suit === 'wind' ? 4 : suit === 'dragon' ? 3 : 9;
+    const rank = 1 + Math.floor(Math.random() * maxRank);
+    const count = wall.filter(t => t.suit === suit && t.rank === rank).length;
+    if (count >= 2) {
+      hand.push(...drawTiles(wall, suit, rank, 2));
+      paired = true;
+    }
+  }
+
+  return { hand: sortHand(hand), melds: [] };
+}


### PR DESCRIPTION
## Summary
- generate random winning hands with `generateRandomAgari`
- show new hands in FuQuiz unless `initialIndex` is provided
- test random hand generation

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685784e3c31c832a98785127971f5dfa