### PR TITLE
Fix wall depletion logic and add wanpai handling

### DIFF
--- a/src/components/WallLogic.test.ts
+++ b/src/components/WallLogic.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { generateTileWall, drawDoraIndicator } from './TileWall';
+import { createInitialPlayerState, drawTiles } from './Player';
+
+describe('round initialization wall size', () => {
+  it('reserves 14 tiles for the dead wall resulting in 69 tiles remaining', () => {
+    let wall = generateTileWall();
+    let deadWall = wall.slice(0, 14);
+    wall = wall.slice(14);
+    const doraResult = drawDoraIndicator(deadWall, 1);
+    deadWall = doraResult.wall;
+    const players = [
+      createInitialPlayerState('A', true, 0),
+      createInitialPlayerState('B', true, 1),
+      createInitialPlayerState('C', true, 2),
+      createInitialPlayerState('D', true, 3),
+    ];
+    for (let i = 0; i < 4; i++) {
+      const res = drawTiles(players[i], wall, 13);
+      players[i] = res.player;
+      wall = res.wall;
+    }
+    const extra = drawTiles(players[0], wall, 1);
+    players[0] = extra.player;
+    wall = extra.wall;
+    // 136 total - 14 dead wall - 53 initial hands = 69 live wall tiles
+    expect(wall.length).toBe(69);
+  });
+});


### PR DESCRIPTION
## Summary
- add `DEAD_WALL_SIZE` constant and reserve wanpai
- draw dora indicators from dead wall and stop drawing when wall exhausted
- prevent AI from continuing turns after wall depletion
- add unit test covering initial wall size with wanpai

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_685786b60920832aa8a88cc4991a9bc0