### PR TITLE
Add seat/round wind scoring

### DIFF
--- a/src/components/FuQuiz.tsx
+++ b/src/components/FuQuiz.tsx
@@ -95,7 +95,12 @@ function decomposeHand(tiles: Tile[]): { pair: Tile[]; melds: ParsedMeld[] } | n
   return null;
 }
 
-function calculateFuDetail(hand: Tile[], melds: Meld[] = []): { fu: number; steps: string[] } {
+function calculateFuDetail(
+  hand: Tile[],
+  melds: Meld[] = [],
+  seatWind = 1,
+  roundWind = 1,
+): { fu: number; steps: string[] } {
   const allTiles = [...hand, ...melds.flatMap(m => m.tiles)];
   const parsed = decomposeHand(allTiles);
   if (!parsed) return { fu: 0, steps: ['invalid hand'] };
@@ -103,7 +108,11 @@ function calculateFuDetail(hand: Tile[], melds: Meld[] = []): { fu: number; step
   let fu = 20;
   const steps = ['基本符20'];
 
-  if (parsed.pair[0].suit === 'dragon') {
+  if (
+    parsed.pair[0].suit === 'dragon' ||
+    (parsed.pair[0].suit === 'wind' &&
+      (parsed.pair[0].rank === seatWind || parsed.pair[0].rank === roundWind))
+  ) {
     fu += 2;
     steps.push('役牌の雀頭 +2');
   }
@@ -145,6 +154,8 @@ export const FuQuiz: React.FC<FuQuizProps> = ({ initialIndex }) => {
   const [question, setQuestion] = useState(() =>
     initialIndex !== undefined ? SAMPLE_HANDS[initialIndex] : generateRandomAgari(),
   );
+  const seatWind = 1;
+  const roundWind = 1;
   const [guess, setGuess] = useState('');
   const [result, setResult] = useState<{ fu: number; steps: string[]; correct: boolean } | null>(
     null,
@@ -153,8 +164,8 @@ export const FuQuiz: React.FC<FuQuizProps> = ({ initialIndex }) => {
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    const fu = calculateFu(question.hand, question.melds);
-    const detail = calculateFuDetail(question.hand, question.melds);
+    const fu = calculateFu(question.hand, question.melds, { seatWind, roundWind });
+    const detail = calculateFuDetail(question.hand, question.melds, seatWind, roundWind);
     const correct = Number(guess) === fu;
     setResult({ fu, steps: detail.steps, correct });
   };

--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -197,15 +197,20 @@ export const GameController: React.FC = () => {
         ...p[currentIndex].hand,
         ...p[currentIndex].melds.flatMap(m => m.tiles),
       ];
+      const seatWind = p[currentIndex].seat + 1;
+      const roundWind = kyokuRef.current <= 4 ? 1 : 2;
       const yaku = detectYaku(fullHand, p[currentIndex].melds, {
         isTsumo: true,
         isRiichi: p[currentIndex].isRiichi,
+        seatWind,
+        roundWind,
       });
       const { han, fu, points } = calculateScore(
         p[currentIndex].hand,
         p[currentIndex].melds,
         yaku,
         dora,
+        { seatWind, roundWind },
       );
       const newPlayers = payoutTsumo(p, currentIndex, points);
       setPlayers(newPlayers);
@@ -240,14 +245,20 @@ export const GameController: React.FC = () => {
         ...winningPlayer.melds.flatMap(m => m.tiles),
         tile,
       ];
+      const seatWind = winningPlayer.seat + 1;
+      const roundWind = kyokuRef.current <= 4 ? 1 : 2;
       const yaku = detectYaku(fullHand, winningPlayer.melds, {
         isTsumo: false,
         isRiichi: winningPlayer.isRiichi,
+        seatWind,
+        roundWind,
       });
       const { han, fu, points } = calculateScore(
         [...winningPlayer.hand, tile],
         winningPlayer.melds,
         yaku,
+        [],
+        { seatWind, roundWind },
       );
       const updated = payoutRon(p, winIdx, idx, points);
       setPlayers(updated);

--- a/src/score/calculateFu.test.ts
+++ b/src/score/calculateFu.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { SAMPLE_HANDS } from '../quiz/sampleHands';
 import { calculateFu } from './score';
+import { Tile } from '../types/mahjong';
+
+const t = (suit: Tile['suit'], rank: number, id: string): Tile => ({
+  suit,
+  rank,
+  id,
+});
 
 describe('calculateFu', () => {
   it('computes fu for a hand with only sequences', () => {
@@ -22,5 +29,18 @@ describe('calculateFu', () => {
     const fu = calculateFu(hand, melds);
     // 基本符20 + カン(役牌)32 = 52、切り上げで60符になるはず
     expect(fu).toBe(60);
+  });
+
+  it('adds pair fu for seat wind', () => {
+    const hand = [
+      t('man',2,'m2a'),t('man',3,'m3a'),t('man',4,'m4a'),
+      t('pin',2,'p2a'),t('pin',3,'p3a'),t('pin',4,'p4a'),
+      t('sou',2,'s2a'),t('sou',3,'s3a'),t('sou',4,'s4a'),
+      t('man',6,'m6a'),t('man',7,'m7a'),t('man',8,'m8a'),
+      t('wind',1,'e1'),t('wind',1,'e2'),
+    ];
+    const fu = calculateFu(hand, [], { seatWind: 1, roundWind: 2 });
+    // 基本符20 + 自風の雀頭2 = 22、切り上げで30符になるはず
+    expect(fu).toBe(30);
   });
 });

--- a/src/score/score.ts
+++ b/src/score/score.ts
@@ -94,15 +94,24 @@ function decomposeHand(tiles: Tile[]): { pair: Tile[]; melds: ParsedMeld[] } | n
   return null;
 }
 
-export function calculateFu(hand: Tile[], melds: Meld[] = []): number {
+export function calculateFu(
+  hand: Tile[],
+  melds: Meld[] = [],
+  opts?: { seatWind?: number; roundWind?: number },
+): number {
   const allTiles = [...hand, ...melds.flatMap(m => m.tiles)];
   const parsed = decomposeHand(allTiles);
   if (!parsed) return 0;
 
   let fu = 20; // base fu for a winning hand
 
-  // pair fu (only dragons considered value tiles here)
-  if (parsed.pair[0].suit === 'dragon') {
+  // pair fu (dragons, seat wind, and round wind are value tiles)
+  if (
+    parsed.pair[0].suit === 'dragon' ||
+    (parsed.pair[0].suit === 'wind' &&
+      (parsed.pair[0].rank === opts?.seatWind ||
+        parsed.pair[0].rank === opts?.roundWind))
+  ) {
     fu += 2;
   }
 
@@ -154,11 +163,12 @@ export function calculateScore(
   melds: Meld[],
   yaku: Yaku[],
   doraIndicators: Tile[] = [],
+  opts?: { seatWind?: number; roundWind?: number },
 ): { han: number; fu: number; points: number } {
   const allTiles = [...hand, ...melds.flatMap(m => m.tiles)];
   const dora = countDora(allTiles, doraIndicators);
   const han = yaku.reduce((sum, y) => sum + y.han, 0) + dora;
-  const fu = calculateFu(hand, melds);
+  const fu = calculateFu(hand, melds, opts);
   const base = fu * Math.pow(2, han + 2);
   const points = base;
   return { han, fu, points };

--- a/src/score/yaku.test.ts
+++ b/src/score/yaku.test.ts
@@ -54,6 +54,19 @@ describe('Yaku detection', () => {
     expect(yaku.some(y => y.name === 'Yakuhai')).toBe(true);
   });
 
+  it('detects Yakuhai for seat wind', () => {
+    const hand: Tile[] = [
+      t('wind',1,'e1'),t('wind',1,'e2'),t('wind',1,'e3'),
+      t('man',2,'m2a'),t('man',3,'m3a'),t('man',4,'m4a'),
+      t('man',5,'m5a'),t('man',6,'m6a'),t('man',7,'m7a'),
+      t('pin',2,'p2a'),t('pin',3,'p3a'),t('pin',4,'p4a'),
+      t('sou',2,'s2a'),t('sou',2,'s2b'),
+    ];
+    expect(isWinningHand(hand)).toBe(true);
+    const yaku = detectYaku(hand, [], { isTsumo: true, seatWind: 1, roundWind: 2 });
+    expect(yaku.some(y => y.name === 'Yakuhai')).toBe(true);
+  });
+
   it('detects Pinfu', () => {
     const hand: Tile[] = [
       t('man',2,'m2a'),t('man',3,'m3a'),t('man',4,'m4a'),

--- a/src/score/yaku.ts
+++ b/src/score/yaku.ts
@@ -66,6 +66,23 @@ function countDragonTriplets(counts: Record<string, number>): number {
   return yakuhai;
 }
 
+function countValueTriplets(
+  counts: Record<string, number>,
+  seatWind?: number,
+  roundWind?: number,
+): number {
+  let total = countDragonTriplets(counts);
+  if (seatWind) {
+    const key = `wind-${seatWind}`;
+    total += Math.floor((counts[key] || 0) / 3);
+  }
+  if (roundWind && roundWind !== seatWind) {
+    const key = `wind-${roundWind}`;
+    total += Math.floor((counts[key] || 0) / 3);
+  }
+  return total;
+}
+
 function canFormSets(counts: Record<string, number>, memo = new Map<string, boolean>()): boolean {
   const serialized = JSON.stringify(counts);
   if (memo.has(serialized)) return memo.get(serialized)!;
@@ -289,7 +306,12 @@ export function isWinningHand(tiles: Tile[]): boolean {
 export function detectYaku(
   hand: Tile[],
   melds: Meld[] = [],
-  opts?: { isTsumo?: boolean; isRiichi?: boolean },
+  opts?: {
+    isTsumo?: boolean;
+    isRiichi?: boolean;
+    seatWind?: number;
+    roundWind?: number;
+  },
 ): Yaku[] {
   const allTiles = [...hand, ...melds.flatMap(m => m.tiles)];
   const result: Yaku[] = [];
@@ -341,7 +363,11 @@ export function detectYaku(
   } else if (isHonitsu(allTiles)) {
     result.push({ name: 'Honitsu', han: isClosed ? 3 : 2 });
   }
-  const yakuhai = countDragonTriplets(counts);
+  const yakuhai = countValueTriplets(
+    counts,
+    opts?.seatWind,
+    opts?.roundWind,
+  );
   for (let i = 0; i < yakuhai; i++) {
     result.push({ name: 'Yakuhai', han: 1 });
   }


### PR DESCRIPTION
## Summary
- account for seat and round wind tiles when calculating fu
- count seat/round wind triplets for Yakuhai
- support new options in GameController and FuQuiz
- test pair fu and Yakuhai using seat wind

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_6857879e49c0832ab8064e2c8bb0d3ea