### PR TITLE
Fix wall exhaustion draw

### DIFF
--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -409,7 +409,6 @@ const handleCallAction = (action: MeldType | 'pass') => {
     let next = (turnRef.current + 1) % 4;
     setTurn(next);
     setTimeout(() => {
-      if (wallRef.current.length === 0) return;
       if (playersRef.current[next].isAI) {
         // Check if the AI wants to call on the previous discard
         if (lastDiscard && lastDiscard.player !== next) {
@@ -444,7 +443,12 @@ const handleCallAction = (action: MeldType | 'pass') => {
   // UI
   return (
     <div className="p-2 flex flex-col gap-4">
-      <ScoreBoard players={players} kyoku={kyoku} onHelp={() => setHelpOpen(true)} />
+      <ScoreBoard
+        players={players}
+        kyoku={kyoku}
+        wallCount={wall.length}
+        onHelp={() => setHelpOpen(true)}
+      />
       <label className="flex items-center gap-2">
         <input type="checkbox" checked={playerIsAI} onChange={togglePlayerAI} />
         観戦モード

--- a/src/components/ScoreBoard.tsx
+++ b/src/components/ScoreBoard.tsx
@@ -4,14 +4,18 @@ import { PlayerState } from '../types/mahjong';
 interface ScoreBoardProps {
   players: PlayerState[];
   kyoku: number;
+  wallCount: number;
   onHelp: () => void;
 }
 
-export const ScoreBoard: React.FC<ScoreBoardProps> = ({ players, kyoku, onHelp }) => {
+export const ScoreBoard: React.FC<ScoreBoardProps> = ({ players, kyoku, wallCount, onHelp }) => {
   const kyokuStr = ['東1局', '東2局', '東3局', '東4局', '南1局', '南2局', '南3局', '南4局'][kyoku - 1] || '';
   return (
     <div className="flex justify-between items-center p-4 bg-gray-200 rounded-lg shadow">
-      <span className="font-bold">{kyokuStr}</span>
+      <div className="flex items-baseline gap-2">
+        <span className="font-bold">{kyokuStr}</span>
+        <span className="text-sm">残り{wallCount}</span>
+      </div>
       <div className="flex gap-2 items-center">
         {players.map(p => (
           <span key={p.name} className="bg-white rounded px-2 py-1 shadow">

--- a/src/components/WallLogic.test.ts
+++ b/src/components/WallLogic.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { generateTileWall, drawDoraIndicator } from './TileWall';
 import { createInitialPlayerState, drawTiles } from './Player';
+import { payoutNoten } from '../utils/payout';
 
 describe('round initialization wall size', () => {
   it('reserves 14 tiles for the dead wall resulting in 69 tiles remaining', () => {
@@ -25,5 +26,37 @@ describe('round initialization wall size', () => {
     wall = extra.wall;
     // 136 total - 14 dead wall - 53 initial hands = 69 live wall tiles
     expect(wall.length).toBe(69);
+  });
+});
+
+describe('exhausted wall ends the round in a draw', () => {
+  it('applies noten payout when no tiles remain', () => {
+    let wall = generateTileWall();
+    let deadWall = wall.slice(0, 14);
+    wall = wall.slice(14);
+    const doraResult = drawDoraIndicator(deadWall, 1);
+    deadWall = doraResult.wall;
+    const players = [
+      createInitialPlayerState('A', true, 0),
+      createInitialPlayerState('B', true, 1),
+      createInitialPlayerState('C', true, 2),
+      createInitialPlayerState('D', true, 3),
+    ];
+    for (let i = 0; i < 4; i++) {
+      const res = drawTiles(players[i], wall, 13);
+      players[i] = res.player;
+      wall = res.wall;
+    }
+    const extra = drawTiles(players[0], wall, 1);
+    players[0] = extra.player;
+    wall = extra.wall;
+
+    // all remaining tiles are drawn
+    wall = [];
+
+    const tenpai = [true, false, false, true];
+    // 2 players tenpai -> each noten player pays 1000 and each tenpai player gains 1000
+    const { players: updated } = payoutNoten(players, tenpai);
+    expect(updated.map(p => p.score)).toEqual([26000, 24000, 24000, 26000]);
   });
 });


### PR DESCRIPTION
## Summary
- ensure draw is processed when the live wall is empty
- show remaining wall tiles on the scoreboard
- add test for noten payout when the wall has no tiles

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68579bb876f0832a898677720d7cbac9