### PR TITLE
Fix fu calculation and show winds

### DIFF
--- a/src/components/FuQuiz.test.tsx
+++ b/src/components/FuQuiz.test.tsx
@@ -26,4 +26,9 @@ describe('FuQuiz', () => {
     fireEvent.click(button);
     expect(screen.getByText('不正解。正解: 20符')).toBeTruthy();
   });
+
+  it('displays seat and round wind', () => {
+    render(<FuQuiz initialIndex={0} />);
+    expect(screen.getByText('場風: 東 / 自風: 東')).toBeTruthy();
+  });
 });

--- a/src/components/FuQuiz.tsx
+++ b/src/components/FuQuiz.tsx
@@ -108,13 +108,16 @@ function calculateFuDetail(
   let fu = 20;
   const steps = ['基本符20'];
 
-  if (
-    parsed.pair[0].suit === 'dragon' ||
-    (parsed.pair[0].suit === 'wind' &&
-      (parsed.pair[0].rank === seatWind || parsed.pair[0].rank === roundWind))
-  ) {
-    fu += 2;
-    steps.push('役牌の雀頭 +2');
+  let pairFu = 0;
+  if (parsed.pair[0].suit === 'dragon') {
+    pairFu = 2;
+  } else if (parsed.pair[0].suit === 'wind') {
+    if (parsed.pair[0].rank === seatWind) pairFu += 2;
+    if (parsed.pair[0].rank === roundWind) pairFu += 2;
+  }
+  if (pairFu > 0) {
+    fu += pairFu;
+    steps.push(`役牌の雀頭 +${pairFu}`);
   }
 
   for (const meld of parsed.melds) {
@@ -156,6 +159,7 @@ export const FuQuiz: React.FC<FuQuizProps> = ({ initialIndex }) => {
   );
   const seatWind = 1;
   const roundWind = 1;
+  const windNames: Record<number, string> = { 1: '東', 2: '南', 3: '西', 4: '北' };
   const [guess, setGuess] = useState('');
   const [result, setResult] = useState<{ fu: number; steps: string[]; correct: boolean } | null>(
     null,
@@ -184,6 +188,7 @@ export const FuQuiz: React.FC<FuQuizProps> = ({ initialIndex }) => {
 
   return (
     <div className="p-4 border rounded">
+      <div className="text-sm mb-1">場風: {windNames[roundWind]} / 自風: {windNames[seatWind]}</div>
       <div className="flex gap-1 mb-2 flex-wrap">
         {fullHand.map(t => (
           <TileView key={t.id} tile={t} />

--- a/src/score/calculateFu.test.ts
+++ b/src/score/calculateFu.test.ts
@@ -43,4 +43,17 @@ describe('calculateFu', () => {
     // 基本符20 + 自風の雀頭2 = 22、切り上げで30符になるはず
     expect(fu).toBe(30);
   });
+
+  it('adds 4 fu when seat and round wind are the same', () => {
+    const hand = [
+      t('man',2,'m2a'),t('man',3,'m3a'),t('man',4,'m4a'),
+      t('pin',2,'p2a'),t('pin',3,'p3a'),t('pin',4,'p4a'),
+      t('sou',2,'s2a'),t('sou',3,'s3a'),t('sou',4,'s4a'),
+      t('man',6,'m6a'),t('man',7,'m7a'),t('man',8,'m8a'),
+      t('wind',2,'s1'),t('wind',2,'s2'),
+    ];
+    const fu = calculateFu(hand, [], { seatWind: 2, roundWind: 2 });
+    // 基本符20 + ダブ南の雀頭4 = 24、切り上げで30符になるはず
+    expect(fu).toBe(30);
+  });
 });

--- a/src/score/score.ts
+++ b/src/score/score.ts
@@ -106,14 +106,14 @@ export function calculateFu(
   let fu = 20; // base fu for a winning hand
 
   // pair fu (dragons, seat wind, and round wind are value tiles)
-  if (
-    parsed.pair[0].suit === 'dragon' ||
-    (parsed.pair[0].suit === 'wind' &&
-      (parsed.pair[0].rank === opts?.seatWind ||
-        parsed.pair[0].rank === opts?.roundWind))
-  ) {
-    fu += 2;
+  let pairFu = 0;
+  if (parsed.pair[0].suit === 'dragon') {
+    pairFu = 2;
+  } else if (parsed.pair[0].suit === 'wind') {
+    if (parsed.pair[0].rank === opts?.seatWind) pairFu += 2;
+    if (parsed.pair[0].rank === opts?.roundWind) pairFu += 2;
   }
+  fu += pairFu;
 
   for (const meld of parsed.melds) {
     if (meld.type === 'pon') {


### PR DESCRIPTION
## Summary
- handle double value tile winds properly in fu calculation
- show seat/round wind on the quiz screen
- update fu breakdown logic to match
- add regression tests for double wind fu and quiz display

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_68579cba3950832abcb80b9f06a12ba7