### PR TITLE
Improve river orientation

### DIFF
--- a/src/components/MeldView.test.tsx
+++ b/src/components/MeldView.test.tsx
@@ -22,7 +22,7 @@ describe('MeldView', () => {
     expect(count).toBe(3);
   });
 
-  it('adds rotate class to called tile', () => {
+  it('rotates the called tile 90 degrees', () => {
     const meld: Meld = {
       type: 'pon',
       tiles: [
@@ -33,9 +33,26 @@ describe('MeldView', () => {
       fromPlayer: 2,
       calledTileId: 'p2',
     };
-    const html = renderToStaticMarkup(<MeldView meld={meld} />);
-    // ensure rotate class applied to the called tile span
-    const rotateCount = (html.match(/rotate-90/g) || []).length;
+    const html = renderToStaticMarkup(<MeldView meld={meld} seat={1} />);
+    const rotateCount = (html.match(/rotate\(180deg\)/g) || []).length;
+    // seat rotation 90 + called tile rotation 90 -> 180deg
     expect(rotateCount).toBe(1);
+  });
+
+  it('applies seat rotation', () => {
+    const meld: Meld = {
+      type: 'chi',
+      tiles: [
+        { suit: 'man', rank: 4, id: 'm4' },
+        { suit: 'man', rank: 5, id: 'm5' },
+        { suit: 'man', rank: 6, id: 'm6' },
+      ],
+      fromPlayer: 3,
+      calledTileId: 'm5',
+    };
+    const html = renderToStaticMarkup(<MeldView meld={meld} seat={2} />);
+    // seat rotation of 180deg applied to two tiles, called tile rotates further
+    const count = (html.match(/rotate\(180deg\)/g) || []).length;
+    expect(count).toBe(2);
   });
 });

--- a/src/components/MeldView.tsx
+++ b/src/components/MeldView.tsx
@@ -2,14 +2,16 @@ import React from 'react';
 import { Meld } from '../types/mahjong';
 import { TileView } from './TileView';
 
-export const MeldView: React.FC<{ meld: Meld }> = ({ meld }) => {
+const seatRotation = (seat: number) => (seat % 4) * 90;
+
+export const MeldView: React.FC<{ meld: Meld; seat?: number }> = ({ meld, seat = 0 }) => {
   return (
     <div className="flex gap-1 border rounded px-1 bg-gray-50">
       {meld.tiles.map(tile => (
         <TileView
           key={tile.id}
           tile={tile}
-          className={tile.id === meld.calledTileId ? 'rotate-90' : undefined}
+          rotate={seatRotation(seat) + (tile.id === meld.calledTileId ? 90 : 0)}
         />
       ))}
     </div>

--- a/src/components/TileView.test.tsx
+++ b/src/components/TileView.test.tsx
@@ -11,4 +11,10 @@ describe('TileView', () => {
     expect(html).toContain('★');
     expect(html).toContain('absolute');
   });
+
+  it('applies rotation style', () => {
+    const tile: Tile = { suit: 'man', rank: 2, id: 'm2' };
+    const html = renderToStaticMarkup(<TileView tile={tile} rotate={90} />);
+    expect(html).toContain('rotate(90deg)');
+  });
 });

--- a/src/components/TileView.tsx
+++ b/src/components/TileView.tsx
@@ -5,7 +5,8 @@ export const TileView: React.FC<{
   tile: Tile;
   isShonpai?: boolean;
   className?: string;
-}> = ({ tile, isShonpai, className }) => {
+  rotate?: number;
+}> = ({ tile, isShonpai, className, rotate = 0 }) => {
   const suitMap: Record<string, string> = { man: '萬', pin: '筒', sou: '索', wind: '', dragon: '' };
   const honorMap: Record<string, Record<number, string>> = {
     wind: { 1: '東', 2: '南', 3: '西', 4: '北' },
@@ -65,6 +66,7 @@ export const TileView: React.FC<{
     <span
       className={`relative inline-block border px-1 py-0.5 bg-white tile-font-size ${className ?? ''}`}
       aria-label={kanji}
+      style={{ transform: `rotate(${rotate}deg)` }}
     >
       <span className="font-emoji">{emojiMap[tile.suit]?.[tile.rank] ?? kanji}</span>
       {isShonpai && (

--- a/src/components/UIBoard.test.tsx
+++ b/src/components/UIBoard.test.tsx
@@ -12,7 +12,12 @@ const basePlayer = createInitialPlayerState('you', false);
 afterEach(() => cleanup());
 function renderBoard(shanten: { standard: number; chiitoi: number; kokushi: number }) {
   const props = {
-    players: [basePlayer],
+    players: [
+      basePlayer,
+      createInitialPlayerState('ai1', true, 1),
+      createInitialPlayerState('ai2', true, 2),
+      createInitialPlayerState('ai3', true, 3),
+    ],
     dora: [] as Tile[],
     onDiscard: () => {},
     isMyTurn: true,
@@ -71,7 +76,12 @@ describe('UIBoard riichi button', () => {
     expect(canDeclareRiichi(player)).toBe(true);
     render(
       <UIBoard
-        players={[player]}
+        players={[
+          player,
+          createInitialPlayerState('ai1', true, 1),
+          createInitialPlayerState('ai2', true, 2),
+          createInitialPlayerState('ai3', true, 3),
+        ]}
         dora={[]}
         onDiscard={() => {}}
         isMyTurn={true}
@@ -95,7 +105,12 @@ describe('UIBoard riichi button', () => {
     expect(canDeclareRiichi(player)).toBe(false);
     render(
       <UIBoard
-        players={[player]}
+        players={[
+          player,
+          createInitialPlayerState('ai1', true, 1),
+          createInitialPlayerState('ai2', true, 2),
+          createInitialPlayerState('ai3', true, 3),
+        ]}
         dora={[]}
         onDiscard={() => {}}
         isMyTurn={true}

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -4,6 +4,8 @@ import { TileView } from './TileView';
 import { canDeclareRiichi } from './Player';
 import { MeldView } from './MeldView';
 
+const seatRotation = (seat: number) => (seat % 4) * 90;
+
 interface UIBoardProps {
   players: PlayerState[];
   dora: Tile[];
@@ -39,32 +41,80 @@ export const UIBoard: React.FC<UIBoardProps> = ({
   if (players.length === 0) {
     return null;
   }
+  const me = players[0];
+  const right = players[1];
+  const top = players[2];
+  const left = players[3];
   return (
-    <div className="w-full grid grid-cols-4 gap-2">
-      {/* 上部：AIの捨て牌 */}
-      {players.slice(1).map(ai => (
-        <div key={ai.name} className="flex flex-col items-center">
-          <div className="text-sm mb-1">{ai.name}</div>
-          {ai.melds.length > 0 && (
-            <div className="flex gap-1 mb-1">
-              {ai.melds.map((m, idx) => (
-                <MeldView key={idx} meld={m} />
-              ))}
-            </div>
-          )}
-          <div className="grid grid-cols-6 gap-1">
-            {ai.discard.map(tile => (
-              <TileView
-                key={tile.id}
-                tile={tile}
-                isShonpai={lastDiscard?.tile.id === tile.id && lastDiscard.isShonpai}
-              />
+    <div className="w-full grid grid-rows-3 grid-cols-3 gap-2 place-items-center">
+      {/* 対面 */}
+      <div className="row-start-1 col-start-2 flex flex-col items-center">
+        <div className="text-sm mb-1">{top.name}</div>
+        {top.melds.length > 0 && (
+          <div className="flex gap-1 mb-1">
+            {top.melds.map((m, idx) => (
+              <MeldView key={idx} meld={m} seat={top.seat} />
             ))}
           </div>
+        )}
+        <div className="grid grid-cols-6 gap-1">
+          {top.discard.map(tile => (
+            <TileView
+              key={tile.id}
+              tile={tile}
+              rotate={seatRotation(top.seat)}
+              isShonpai={lastDiscard?.tile.id === tile.id && lastDiscard.isShonpai}
+            />
+          ))}
         </div>
-      ))}
+      </div>
+
+      {/* 右側：下家 */}
+      <div className="row-start-2 col-start-3 flex flex-col items-center">
+        <div className="text-sm mb-1">{right.name}</div>
+        {right.melds.length > 0 && (
+          <div className="flex gap-1 mb-1">
+            {right.melds.map((m, idx) => (
+              <MeldView key={idx} meld={m} seat={right.seat} />
+            ))}
+          </div>
+        )}
+        <div className="grid grid-cols-6 gap-1">
+          {right.discard.map(tile => (
+            <TileView
+              key={tile.id}
+              tile={tile}
+              rotate={seatRotation(right.seat)}
+              isShonpai={lastDiscard?.tile.id === tile.id && lastDiscard.isShonpai}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* 左側：上家 */}
+      <div className="row-start-2 col-start-1 flex flex-col items-center">
+        <div className="text-sm mb-1">{left.name}</div>
+        {left.melds.length > 0 && (
+          <div className="flex gap-1 mb-1">
+            {left.melds.map((m, idx) => (
+              <MeldView key={idx} meld={m} seat={left.seat} />
+            ))}
+          </div>
+        )}
+        <div className="grid grid-cols-6 gap-1">
+          {left.discard.map(tile => (
+            <TileView
+              key={tile.id}
+              tile={tile}
+              rotate={seatRotation(left.seat)}
+              isShonpai={lastDiscard?.tile.id === tile.id && lastDiscard.isShonpai}
+            />
+          ))}
+        </div>
+      </div>
+
       {/* ドラ表示 */}
-      <div className="col-span-4 flex flex-col items-center mt-2">
+      <div className="row-start-2 col-start-2 flex flex-col items-center">
         <div className="text-sm mb-1">ドラ表示</div>
         <div className="flex gap-1">
           {dora.map(tile => (
@@ -72,12 +122,13 @@ export const UIBoard: React.FC<UIBoardProps> = ({
           ))}
         </div>
       </div>
+
       {/* 自分の手牌 */}
-      <div className="col-span-4 flex flex-col items-center mt-4">
-        {players[0].melds.length > 0 && (
+      <div className="row-start-3 col-start-2 flex flex-col items-center mt-4">
+        {me.melds.length > 0 && (
           <div className="flex gap-2 mb-2">
-            {players[0].melds.map((m, idx) => (
-              <MeldView key={idx} meld={m} />
+            {me.melds.map((m, idx) => (
+              <MeldView key={idx} meld={m} seat={me.seat} />
             ))}
           </div>
         )}
@@ -95,7 +146,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
           })()}
         </div>
         {(() => {
-          const my = players[0];
+          const my = me;
           const handTiles = my.drawnTile
             ? my.hand.filter(t => t.id !== my.drawnTile?.id)
             : my.hand;
@@ -125,10 +176,11 @@ export const UIBoard: React.FC<UIBoardProps> = ({
           );
         })()}
         <div className="flex gap-1 mt-2">
-          {players[0].discard.map(tile => (
+          {me.discard.map(tile => (
             <TileView
               key={tile.id}
               tile={tile}
+              rotate={seatRotation(me.seat)}
               isShonpai={lastDiscard?.tile.id === tile.id && lastDiscard.isShonpai}
             />
           ))}
@@ -159,7 +211,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
             ))}
           </div>
         )}
-        {onRiichi && isMyTurn && canDeclareRiichi(players[0]) && (
+        {onRiichi && isMyTurn && canDeclareRiichi(me) && (
           <button
             className="mt-2 px-2 py-1 bg-red-200 rounded"
             onClick={() => onRiichi()}

--- a/src/index.css
+++ b/src/index.css
@@ -20,3 +20,9 @@
 .rotate-90 {
   transform: rotate(90deg);
 }
+.rotate-180 {
+  transform: rotate(180deg);
+}
+.rotate-270 {
+  transform: rotate(270deg);
+}


### PR DESCRIPTION
## Summary
- orient tiles and melds according to seat
- lay out the four rivers around the table
- extend tile rotation utilities
- adjust tests for new orientation

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present || npx tsc --noEmit`
- `npm run build`
- `npm test --if-present`

------
https://chatgpt.com/codex/tasks/task_e_68579f871250832ab02f666d2299040f