### PR TITLE
Fix tile orientation and river position

### DIFF
--- a/src/components/MeldView.test.tsx
+++ b/src/components/MeldView.test.tsx
@@ -34,8 +34,8 @@ describe('MeldView', () => {
       calledTileId: 'p2',
     };
     const html = renderToStaticMarkup(<MeldView meld={meld} seat={1} />);
-    const rotateCount = (html.match(/rotate\(180deg\)/g) || []).length;
-    // seat rotation 90 + called tile rotation 90 -> 180deg
+    const rotateCount = (html.match(/rotate\(360deg\)/g) || []).length;
+    // seat rotation 270 + called tile rotation 90 -> 360deg
     expect(rotateCount).toBe(1);
   });
 

--- a/src/components/MeldView.tsx
+++ b/src/components/MeldView.tsx
@@ -2,7 +2,18 @@ import React from 'react';
 import { Meld } from '../types/mahjong';
 import { TileView } from './TileView';
 
-const seatRotation = (seat: number) => (seat % 4) * 90;
+const seatRotation = (seat: number) => {
+  switch (seat % 4) {
+    case 1:
+      return 270;
+    case 3:
+      return 90;
+    case 2:
+      return 180;
+    default:
+      return 0;
+  }
+};
 
 export const MeldView: React.FC<{ meld: Meld; seat?: number }> = ({ meld, seat = 0 }) => {
   return (

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -4,7 +4,18 @@ import { TileView } from './TileView';
 import { canDeclareRiichi } from './Player';
 import { MeldView } from './MeldView';
 
-const seatRotation = (seat: number) => (seat % 4) * 90;
+const seatRotation = (seat: number) => {
+  switch (seat % 4) {
+    case 1:
+      return 270; // shimocha (right)
+    case 3:
+      return 90; // kamicha (left)
+    case 2:
+      return 180; // toimen
+    default:
+      return 0; // self
+  }
+};
 
 interface UIBoardProps {
   players: PlayerState[];
@@ -132,6 +143,16 @@ export const UIBoard: React.FC<UIBoardProps> = ({
             ))}
           </div>
         )}
+        <div className="flex gap-1 mb-2">
+          {me.discard.map(tile => (
+            <TileView
+              key={tile.id}
+              tile={tile}
+              rotate={seatRotation(me.seat)}
+              isShonpai={lastDiscard?.tile.id === tile.id && lastDiscard.isShonpai}
+            />
+          ))}
+        </div>
         <div className="text-lg mb-1">あなたの手牌</div>
         <div className="text-sm mb-2">
           {(() => {
@@ -175,16 +196,6 @@ export const UIBoard: React.FC<UIBoardProps> = ({
             </div>
           );
         })()}
-        <div className="flex gap-1 mt-2">
-          {me.discard.map(tile => (
-            <TileView
-              key={tile.id}
-              tile={tile}
-              rotate={seatRotation(me.seat)}
-              isShonpai={lastDiscard?.tile.id === tile.id && lastDiscard.isShonpai}
-            />
-          ))}
-        </div>
         {callOptions && callOptions.length > 0 && (
           <div className="flex gap-2 mt-2">
             {callOptions.map(act => (


### PR DESCRIPTION
## Summary
- fix player tile orientation logic for right/left seats
- show player's discard pile above the hand
- update MeldView rotation logic
- adjust tests for new tile rotations

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857a2490620832a91b375cb66321302