### PR TITLE
Fix discard orientation

### DIFF
--- a/src/components/UIBoard.test.tsx
+++ b/src/components/UIBoard.test.tsx
@@ -7,6 +7,8 @@ import { createInitialPlayerState, canDeclareRiichi } from './Player';
 import { Tile } from '../types/mahjong';
 import type { PlayerState } from "../types/mahjong";
 
+const t = (suit: Tile['suit'], rank: number, id: string): Tile => ({ suit, rank, id });
+
 const basePlayer = createInitialPlayerState('you', false);
 
 afterEach(() => cleanup());
@@ -55,7 +57,6 @@ describe('UIBoard shanten display', () => {
 });
 
 describe('UIBoard riichi button', () => {
-  const t = (suit: Tile['suit'], rank: number, id: string): Tile => ({ suit, rank, id });
 
   function makePlayer(hand: Tile[]): PlayerState {
     const p = { ...createInitialPlayerState('you', false), hand, drawnTile: hand[hand.length - 1] } as PlayerState;
@@ -146,5 +147,36 @@ describe('UIBoard discard orientation', () => {
     expect(rightDiv.style.transform).toContain('rotate(90deg)');
     expect(topDiv.style.transform).toContain('rotate(180deg)');
     expect(leftDiv.style.transform).toContain('rotate(270deg)');
+  });
+
+  it('keeps discard order after rotation', () => {
+    const right = createInitialPlayerState('right', true, 1);
+    right.discard = [t('man', 1, 'a'), t('man', 2, 'b')];
+    const top = createInitialPlayerState('top', true, 2);
+    top.discard = [t('pin', 3, 'c'), t('pin', 4, 'd')];
+
+    render(
+      <UIBoard
+        players={[
+          createInitialPlayerState('me', false, 0),
+          right,
+          top,
+          createInitialPlayerState('left', true, 3),
+        ]}
+        dora={[]}
+        onDiscard={() => {}}
+        isMyTurn={true}
+        shanten={{ standard: 0, chiitoi: 0, kokushi: 0 }}
+        lastDiscard={null}
+      />,
+    );
+
+    const rightDiv = screen.getByTestId('discard-seat-1');
+    const topDiv = screen.getByTestId('discard-seat-2');
+
+    expect((rightDiv.firstChild as HTMLElement | null)?.getAttribute('aria-label')).toBe('2萬');
+    expect((rightDiv.lastChild as HTMLElement | null)?.getAttribute('aria-label')).toBe('1萬');
+    expect((topDiv.firstChild as HTMLElement | null)?.getAttribute('aria-label')).toBe('4筒');
+    expect((topDiv.lastChild as HTMLElement | null)?.getAttribute('aria-label')).toBe('3筒');
   });
 });

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -30,6 +30,11 @@ const seatRiverRotation = (seat: number) => {
   }
 };
 
+const shouldReverseRiver = (seat: number) => {
+  const rot = seatRiverRotation(seat) % 360;
+  return rot === 90 || rot === 180;
+};
+
 interface UIBoardProps {
   players: PlayerState[];
   dora: Tile[];
@@ -90,7 +95,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
           style={{ transform: `rotate(${seatRiverRotation(top.seat)}deg)` }}
           data-testid="discard-seat-2"
         >
-          {top.discard.map(tile => (
+          {(shouldReverseRiver(top.seat) ? [...top.discard].reverse() : top.discard).map(tile => (
             <TileView
               key={tile.id}
               tile={tile}
@@ -116,7 +121,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
           style={{ transform: `rotate(${seatRiverRotation(right.seat)}deg)` }}
           data-testid="discard-seat-1"
         >
-          {right.discard.map(tile => (
+          {(shouldReverseRiver(right.seat) ? [...right.discard].reverse() : right.discard).map(tile => (
             <TileView
               key={tile.id}
               tile={tile}


### PR DESCRIPTION
## Summary
- show discards in consistent order for other players
- add test verifying discard order after rotation

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857a958d37c832a8532d020b15c995d