### PR TITLE
Enable custom game length

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,9 @@ import { ScoreQuiz } from './components/ScoreQuiz';
 function App() {
   const [tileFont, setTileFont] = useState(2);
   const [mode, setMode] = useState<'game' | 'fu-quiz' | 'score-quiz'>('game');
+  const [gameLength, setGameLength] = useState<'east1' | 'tonpu' | 'tonnan'>(
+    'tonnan',
+  );
 
   return (
     <div
@@ -39,7 +42,32 @@ function App() {
             <option value="score-quiz">点数クイズ</option>
           </select>
         </div>
-        {mode === 'game' ? <GameController /> : mode === 'fu-quiz' ? <FuQuiz /> : <ScoreQuiz />}
+        {mode === 'game' && (
+          <div className="flex items-center gap-2">
+            <label htmlFor="length">試合形式</label>
+            <select
+              id="length"
+              value={gameLength}
+              onChange={e =>
+                setGameLength(
+                  e.target.value as 'east1' | 'tonpu' | 'tonnan',
+                )
+              }
+              className="border px-2 py-1"
+            >
+              <option value="east1">東1局のみ</option>
+              <option value="tonpu">東風戦</option>
+              <option value="tonnan">東南戦</option>
+            </select>
+          </div>
+        )}
+        {mode === 'game' ? (
+          <GameController key={gameLength} gameLength={gameLength} />
+        ) : mode === 'fu-quiz' ? (
+          <FuQuiz />
+        ) : (
+          <ScoreQuiz />
+        )}
       </div>
     </div>
   );

--- a/src/components/GameController.autoplay.test.tsx
+++ b/src/components/GameController.autoplay.test.tsx
@@ -6,7 +6,7 @@ import { GameController } from './GameController';
 
 describe('GameController auto play', () => {
   it('disables tile buttons when enabled', async () => {
-    const { container } = render(<GameController />);
+    const { container } = render(<GameController gameLength="tonnan" />);
     await screen.findAllByText('あなたの手牌');
     const checkbox = screen.getAllByLabelText('観戦モード')[0];
     fireEvent.click(checkbox);
@@ -15,7 +15,7 @@ describe('GameController auto play', () => {
   });
 
   it('AI discards when toggled during player turn', async () => {
-    render(<GameController />);
+    render(<GameController gameLength="tonnan" />);
     await screen.findAllByText('あなたの手牌');
     const checkbox = screen.getAllByLabelText('観戦モード')[0];
     fireEvent.click(checkbox);

--- a/src/components/GameController.length.test.ts
+++ b/src/components/GameController.length.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { maxKyokuForLength } from './GameController';
+
+describe('maxKyokuForLength', () => {
+  it('handles tonnan', () => {
+    expect(maxKyokuForLength('tonnan')).toBe(8);
+  });
+  it('handles tonpu', () => {
+    expect(maxKyokuForLength('tonpu')).toBe(4);
+  });
+  it('handles east1', () => {
+    expect(maxKyokuForLength('east1')).toBe(1);
+  });
+});

--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -18,9 +18,17 @@ import { RoundResultModal, RoundResult } from './RoundResultModal';
 
 const DEAD_WALL_SIZE = 14;
 
+export type GameLength = 'east1' | 'tonpu' | 'tonnan';
+export const maxKyokuForLength = (len: GameLength): number =>
+  len === 'tonnan' ? 8 : len === 'tonpu' ? 4 : 1;
+
 type GamePhase = 'init' | 'playing' | 'end';
 
-export const GameController: React.FC = () => {
+interface Props {
+  gameLength: GameLength;
+}
+
+export const GameController: React.FC<Props> = ({ gameLength }) => {
   // ゲーム状態
   const [wall, setWall] = useState<Tile[]>([]);
   const [players, setPlayers] = useState<PlayerState[]>([]);
@@ -148,9 +156,10 @@ export const GameController: React.FC = () => {
     }
   }, [phase]);
 
+  const maxKyoku = maxKyokuForLength(gameLength);
   const nextKyoku = () => {
     const next = kyokuRef.current + 1;
-    if (next > 8) {
+    if (next > maxKyoku) {
       setPhase('init');
     } else {
       setKyoku(next);


### PR DESCRIPTION
## Summary
- allow selecting 東南戦, 東風戦, or 東1局のみ
- compute maximum kyoku based on selected game length
- update autoplay tests for new prop
- test `maxKyokuForLength`

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857acbfd1e0832a883fb2aabb72b762