### PR TITLE
Add final game result screen

### DIFF
--- a/src/components/FinalResultModal.test.tsx
+++ b/src/components/FinalResultModal.test.tsx
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FinalResultModal } from './FinalResultModal';
+import { PlayerState } from '../types/mahjong';
+
+const players: PlayerState[] = [
+  { hand: [], discard: [], melds: [], score: 30000, isRiichi: false, name: 'A', isAI: false, drawnTile: null, seat: 0 },
+  { hand: [], discard: [], melds: [], score: 20000, isRiichi: false, name: 'B', isAI: true, drawnTile: null, seat: 1 },
+];
+
+describe('FinalResultModal', () => {
+  it('renders players sorted by score', () => {
+    render(<FinalResultModal players={players} onReplay={() => {}} />);
+    const rows = screen.getAllByRole('row');
+    expect(rows[1].textContent).toContain('A');
+  });
+});

--- a/src/components/FinalResultModal.tsx
+++ b/src/components/FinalResultModal.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { PlayerState } from '../types/mahjong';
+
+interface Props {
+  players: PlayerState[];
+  onReplay: () => void;
+}
+
+export const FinalResultModal: React.FC<Props> = ({ players, onReplay }) => {
+  if (players.length === 0) return null;
+  const sorted = [...players].sort((a, b) => b.score - a.score);
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg p-4 shadow-lg">
+        <h2 className="text-lg font-bold mb-2">最終結果</h2>
+        <table className="border-collapse text-sm mb-2">
+          <thead>
+            <tr>
+              <th className="border px-2 py-1">プレイヤー</th>
+              <th className="border px-2 py-1">点数</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map(p => (
+              <tr key={p.name}>
+                <td className="border px-2 py-1">{p.name}</td>
+                <td className="border px-2 py-1 text-right">{p.score}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <button className="mt-2 px-4 py-1 bg-blue-500 text-white rounded" onClick={onReplay}>リプレイ</button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -15,6 +15,7 @@ import { incrementDiscardCount, findRonWinner } from './DiscardUtil';
 import { chooseAICallOption } from '../utils/ai';
 import { payoutTsumo, payoutRon, payoutNoten } from '../utils/payout';
 import { RoundResultModal, RoundResult } from './RoundResultModal';
+import { FinalResultModal } from './FinalResultModal';
 
 const DEAD_WALL_SIZE = 14;
 
@@ -160,7 +161,7 @@ export const GameController: React.FC<Props> = ({ gameLength }) => {
   const nextKyoku = () => {
     const next = kyokuRef.current + 1;
     if (next > maxKyoku) {
-      setPhase('init');
+      setPhase('end');
     } else {
       setKyoku(next);
       startRound(false);
@@ -491,6 +492,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
       {roundResult && (
         <RoundResultModal
           results={roundResult.results}
+          nextLabel={kyokuRef.current >= maxKyoku ? '結果発表へ' : undefined}
           onNext={() => {
             setRoundResult(null);
             nextKyoku();
@@ -498,9 +500,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
         />
       )}
       {phase === 'end' && (
-        <button className="mt-4 px-4 py-2 bg-blue-500 text-white rounded" onClick={handleRestart}>
-          リプレイ
-        </button>
+        <FinalResultModal players={players} onReplay={handleRestart} />
       )}
       <HelpModal isOpen={helpOpen} onClose={() => setHelpOpen(false)} />
     </div>

--- a/src/components/RoundResultModal.test.tsx
+++ b/src/components/RoundResultModal.test.tsx
@@ -1,0 +1,16 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { RoundResultModal } from './RoundResultModal';
+
+const results = [
+  { name: 'A', score: 25000, change: 0, isTenpai: true },
+];
+
+describe('RoundResultModal', () => {
+  it('uses custom next label', () => {
+    render(<RoundResultModal results={results} onNext={() => {}} nextLabel="結果発表へ" />);
+    expect(screen.getByText('結果発表へ')).toBeTruthy();
+  });
+});

--- a/src/components/RoundResultModal.tsx
+++ b/src/components/RoundResultModal.tsx
@@ -14,9 +14,10 @@ export interface RoundResult {
 interface Props {
   results: RoundResultRow[];
   onNext: () => void;
+  nextLabel?: string;
 }
 
-export const RoundResultModal: React.FC<Props> = ({ results, onNext }) => {
+export const RoundResultModal: React.FC<Props> = ({ results, onNext, nextLabel = '次局へ' }) => {
   if (results.length === 0) return null;
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
@@ -42,7 +43,7 @@ export const RoundResultModal: React.FC<Props> = ({ results, onNext }) => {
             ))}
           </tbody>
         </table>
-        <button className="mt-2 px-4 py-1 bg-blue-500 text-white rounded" onClick={onNext}>次局へ</button>
+        <button className="mt-2 px-4 py-1 bg-blue-500 text-white rounded" onClick={onNext}>{nextLabel}</button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- show final result modal when game ends
- allow RoundResultModal to customize button label
- render final results after last round and adjust button text on final draw
- add tests for new modals

## Testing
- `npm ci`
- `npm run lint --if-present`
- `(npm run type-check --if-present || npx tsc --noEmit)`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857afd60400832abeade76ae89efd29