### PR TITLE
Reserve river space for each player

### DIFF
--- a/src/components/RiverView.test.tsx
+++ b/src/components/RiverView.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import React from 'react';
 import { render, screen, cleanup } from '@testing-library/react';
-import { RiverView } from './RiverView';
+import { RiverView, RESERVED_RIVER_SLOTS } from './RiverView';
 import { Tile } from '../types/mahjong';
 
 const t = (suit: Tile['suit'], rank: number, id: string): Tile => ({ suit, rank, id });
@@ -20,7 +20,14 @@ describe('RiverView', () => {
     const tiles = [t('man', 1, 'a'), t('man', 2, 'b')];
     render(<RiverView tiles={tiles} seat={1} lastDiscard={null} dataTestId="rv" />);
     const div = screen.getByTestId('rv');
-    expect((div.firstChild as HTMLElement | null)?.getAttribute('aria-label')).toBe('2萬');
-    expect((div.lastChild as HTMLElement | null)?.getAttribute('aria-label')).toBe('1萬');
+    const tileEls = div.querySelectorAll('[aria-label]');
+    expect(tileEls[0].getAttribute('aria-label')).toBe('2萬');
+    expect(tileEls[tileEls.length - 1].getAttribute('aria-label')).toBe('1萬');
+  });
+
+  it('reserves space for empty river', () => {
+    render(<RiverView tiles={[]} seat={0} lastDiscard={null} dataTestId="rv" />);
+    const div = screen.getByTestId('rv');
+    expect(div.children.length).toBe(RESERVED_RIVER_SLOTS);
   });
 });

--- a/src/components/RiverView.tsx
+++ b/src/components/RiverView.tsx
@@ -33,6 +33,9 @@ const shouldReverseRiver = (seat: number): boolean => {
   return rot === 90 || rot === 180;
 };
 
+/** minimum cells to reserve for a player's discard area */
+export const RESERVED_RIVER_SLOTS = 20;
+
 interface RiverViewProps {
   tiles: Tile[];
   seat: number;
@@ -47,6 +50,7 @@ export const RiverView: React.FC<RiverViewProps> = ({
   dataTestId,
 }) => {
   const ordered = shouldReverseRiver(seat) ? [...tiles].reverse() : tiles;
+  const placeholdersCount = Math.max(0, RESERVED_RIVER_SLOTS - ordered.length);
   return (
     <div
       className="grid grid-cols-6 gap-1"
@@ -59,6 +63,13 @@ export const RiverView: React.FC<RiverViewProps> = ({
           tile={tile}
           rotate={seatRotation(seat) - seatRiverRotation(seat)}
           isShonpai={lastDiscard?.tile.id === tile.id && lastDiscard.isShonpai}
+        />
+      ))}
+      {Array.from({ length: placeholdersCount }).map((_, idx) => (
+        <span
+          key={`placeholder-${idx}`}
+          className="inline-block border px-1 py-0.5 bg-white tile-font-size opacity-0"
+          style={{ transform: `rotate(${seatRotation(seat) - seatRiverRotation(seat)}deg)` }}
         />
       ))}
     </div>

--- a/src/components/UIBoard.test.tsx
+++ b/src/components/UIBoard.test.tsx
@@ -174,9 +174,12 @@ describe('UIBoard discard orientation', () => {
     const rightDiv = screen.getByTestId('discard-seat-1');
     const topDiv = screen.getByTestId('discard-seat-2');
 
-    expect((rightDiv.firstChild as HTMLElement | null)?.getAttribute('aria-label')).toBe('2萬');
-    expect((rightDiv.lastChild as HTMLElement | null)?.getAttribute('aria-label')).toBe('1萬');
-    expect((topDiv.firstChild as HTMLElement | null)?.getAttribute('aria-label')).toBe('4筒');
-    expect((topDiv.lastChild as HTMLElement | null)?.getAttribute('aria-label')).toBe('3筒');
+    const rightTiles = rightDiv.querySelectorAll('[aria-label]');
+    const topTiles = topDiv.querySelectorAll('[aria-label]');
+
+    expect(rightTiles[0].getAttribute('aria-label')).toBe('2萬');
+    expect(rightTiles[rightTiles.length - 1].getAttribute('aria-label')).toBe('1萬');
+    expect(topTiles[0].getAttribute('aria-label')).toBe('4筒');
+    expect(topTiles[topTiles.length - 1].getAttribute('aria-label')).toBe('3筒');
   });
 });


### PR DESCRIPTION
## Summary
- allocate minimum river space with placeholders so layout doesn't shift
- export constant for reserved slots
- update RiverView tests and add new assertion
- adjust UIBoard tests for placeholders

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_6857b028ba98832a810d380a3ff21a75