### PR TITLE
Add scoring table to help modal

### DIFF
--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { YAKU_LIST } from '../yaku';
+import { ScoreTable } from './ScoreTable';
 
 interface HelpModalProps {
   isOpen: boolean;
@@ -7,12 +8,15 @@ interface HelpModalProps {
 }
 
 export const HelpModal: React.FC<HelpModalProps> = ({ isOpen, onClose }) => {
+  const [view, setView] = useState<'yaku' | 'score'>('yaku');
+  const [isDealer, setIsDealer] = useState(false);
+  const [winType, setWinType] = useState<'ron' | 'tsumo'>('ron');
   if (!isOpen) return null;
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
       <div className="bg-white rounded-lg p-4 max-w-md w-full shadow-lg">
         <div className="flex justify-between items-center mb-2">
-          <h2 className="text-lg font-bold">役一覧</h2>
+          <h2 className="text-lg font-bold">{view === 'yaku' ? '役一覧' : '点数表'}</h2>
           <button
             onClick={onClose}
             className="text-gray-500 hover:text-black font-bold"
@@ -21,28 +25,84 @@ export const HelpModal: React.FC<HelpModalProps> = ({ isOpen, onClose }) => {
             ×
           </button>
         </div>
-        <div className="max-h-96 overflow-y-auto">
-          <table className="w-full border-collapse text-sm">
-            <thead>
-              <tr>
-                <th className="border px-2 py-1">役</th>
-                <th className="border px-2 py-1">門前</th>
-                <th className="border px-2 py-1">副露</th>
-                <th className="border px-2 py-1">説明</th>
-              </tr>
-            </thead>
-            <tbody>
-              {YAKU_LIST.map(y => (
-                <tr key={y.name}>
-                  <td className="border px-2 py-1 font-semibold">{y.name}</td>
-                  <td className="border px-2 py-1 text-center">{y.hanClosed}</td>
-                  <td className="border px-2 py-1 text-center">{y.hanOpen}</td>
-                  <td className="border px-2 py-1">{y.description}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div className="flex gap-2 mb-2">
+          <button
+            className={`px-2 py-1 rounded ${view === 'yaku' ? 'bg-blue-200' : 'bg-gray-200'}`}
+            onClick={() => setView('yaku')}
+          >
+            役一覧
+          </button>
+          <button
+            className={`px-2 py-1 rounded ${view === 'score' ? 'bg-blue-200' : 'bg-gray-200'}`}
+            onClick={() => setView('score')}
+          >
+            点数表
+          </button>
         </div>
+        {view === 'yaku' ? (
+          <div className="max-h-96 overflow-y-auto">
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr>
+                  <th className="border px-2 py-1">役</th>
+                  <th className="border px-2 py-1">門前</th>
+                  <th className="border px-2 py-1">副露</th>
+                  <th className="border px-2 py-1">説明</th>
+                </tr>
+              </thead>
+              <tbody>
+                {YAKU_LIST.map(y => (
+                  <tr key={y.name}>
+                    <td className="border px-2 py-1 font-semibold">{y.name}</td>
+                    <td className="border px-2 py-1 text-center">{y.hanClosed}</td>
+                    <td className="border px-2 py-1 text-center">{y.hanOpen}</td>
+                    <td className="border px-2 py-1">{y.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <div className="flex gap-2">
+              <label>
+                <input
+                  type="radio"
+                  checked={!isDealer}
+                  onChange={() => setIsDealer(false)}
+                />
+                子
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  checked={isDealer}
+                  onChange={() => setIsDealer(true)}
+                />
+                親
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  checked={winType === 'ron'}
+                  onChange={() => setWinType('ron')}
+                />
+                ロン
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  checked={winType === 'tsumo'}
+                  onChange={() => setWinType('tsumo')}
+                />
+                ツモ
+              </label>
+            </div>
+            <div className="max-h-96 overflow-y-auto">
+              <ScoreTable isDealer={isDealer} winType={winType} />
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/ScoreTable.test.tsx
+++ b/src/components/ScoreTable.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, within, cleanup } from '@testing-library/react';
+import { ScoreTable } from './ScoreTable';
+
+describe('ScoreTable', () => {
+  afterEach(() => cleanup());
+  it('shows 30fu 2han child ron as 2000', () => {
+    render(<ScoreTable isDealer={false} winType="ron" />);
+    const rows = screen.getAllByRole('row');
+    const row30 = rows[3];
+    const cells = within(row30).getAllByRole('cell');
+    // Debug row content to ensure correct index
+    // console.log(row30.textContent, cells.map(c => c.textContent));
+    expect(cells[2].textContent).toBe('2000');
+  });
+
+  it('shows 30fu 2han child tsumo split payments', () => {
+    render(<ScoreTable isDealer={false} winType="tsumo" />);
+    const rows = screen.getAllByRole('row');
+    const row30 = rows[3];
+    const cells = within(row30).getAllByRole('cell');
+    // console.log(row30.textContent, cells.map(c => c.textContent));
+    expect(cells[2].textContent).toBe('500-1000');
+  });
+});

--- a/src/components/ScoreTable.tsx
+++ b/src/components/ScoreTable.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+
+interface ScoreTableProps {
+  isDealer: boolean;
+  winType: 'ron' | 'tsumo';
+}
+
+function calcBase(han: number, fu: number): number {
+  if (han >= 13) return 8000; // kazoe yakuman
+  if (han >= 11) return 6000; // sanbaiman
+  if (han >= 8) return 4000; // baiman
+  if (han >= 6) return 3000; // haneman
+  const base = fu * Math.pow(2, han + 2);
+  if (han === 5 || base >= 2000) return 2000; // mangan
+  return base;
+}
+
+function formatScore(han: number, fu: number, isDealer: boolean, winType: 'ron' | 'tsumo'): string {
+  const base = calcBase(han, fu);
+  if (winType === 'ron') {
+    const mult = isDealer ? 6 : 4;
+    const total = Math.ceil((base * mult) / 100) * 100;
+    return total.toString();
+  }
+  if (isDealer) {
+    const each = Math.ceil((base * 2) / 100) * 100;
+    return `${each}オール`;
+  }
+  const nonDealer = Math.ceil(base / 100) * 100;
+  const dealerPay = Math.ceil((base * 2) / 100) * 100;
+  return `${nonDealer}-${dealerPay}`;
+}
+
+export const ScoreTable: React.FC<ScoreTableProps> = ({ isDealer, winType }) => {
+  const fuList = [20, 25, 30, 40, 50, 60, 70];
+  const hanList = [1, 2, 3, 4];
+  return (
+    <table className="w-full border-collapse text-sm">
+      <thead>
+        <tr>
+          <th className="border px-2 py-1">符\翻</th>
+          {hanList.map(h => (
+            <th key={`h${h}`} className="border px-2 py-1 text-center">
+              {h}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {fuList.map(fu => (
+          <tr key={`f${fu}`}>
+            <td className="border px-2 py-1 text-center">{fu}</td>
+            {hanList.map(h => (
+              <td key={`f${fu}h${h}`} className="border px-2 py-1 text-center">
+                {formatScore(h, fu, isDealer, winType)}
+              </td>
+            ))}
+          </tr>
+        ))}
+        <tr>
+          <td className="border px-2 py-1 text-center">満貫以上</td>
+          {hanList.map(h => (
+            <td key={`m${h}`} className="border px-2 py-1 text-center">
+              {formatScore(Math.max(h, 5), 30, isDealer, winType)}
+            </td>
+          ))}
+        </tr>
+      </tbody>
+    </table>
+  );
+};
+


### PR DESCRIPTION
## Summary
- add `<ScoreTable>` component and tests
- enhance `<HelpModal>` with yaku/score toggle and child/parent & ron/tsumo options
- show score calculation table in help modal

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_6857b0c6c58c832abc6e713054ffa90a