### PR TITLE
Adjust seat 1 river rotation

### DIFF
--- a/src/components/RiverView.test.tsx
+++ b/src/components/RiverView.test.tsx
@@ -11,14 +11,17 @@ afterEach(() => cleanup());
 
 describe('RiverView', () => {
   it('applies rotation for the seat', () => {
-    render(<RiverView tiles={[]} seat={2} lastDiscard={null} dataTestId="rv" />);
-    const div = screen.getByTestId('rv');
+    render(<RiverView tiles={[]} seat={2} lastDiscard={null} dataTestId="rv-2" />);
+    let div = screen.getByTestId('rv-2');
     expect(div.style.transform).toContain('rotate(180deg)');
+    render(<RiverView tiles={[]} seat={1} lastDiscard={null} dataTestId="rv-1" />);
+    div = screen.getByTestId('rv-1');
+    expect(div.style.transform).toContain('rotate(270deg)');
   });
 
   it('reverses order when needed', () => {
     const tiles = [t('man', 1, 'a'), t('man', 2, 'b')];
-    render(<RiverView tiles={tiles} seat={1} lastDiscard={null} dataTestId="rv" />);
+    render(<RiverView tiles={tiles} seat={2} lastDiscard={null} dataTestId="rv" />);
     const div = screen.getByTestId('rv');
     const tileEls = div.querySelectorAll('[aria-label]');
     expect(tileEls[0].getAttribute('aria-label')).toBe('2萬');

--- a/src/components/RiverView.tsx
+++ b/src/components/RiverView.tsx
@@ -18,7 +18,7 @@ const seatRotation = (seat: number): number => {
 const seatRiverRotation = (seat: number): number => {
   switch (seat % 4) {
     case 1:
-      return 90;
+      return 270;
     case 2:
       return 180;
     case 3:

--- a/src/components/UIBoard.test.tsx
+++ b/src/components/UIBoard.test.tsx
@@ -144,7 +144,7 @@ describe('UIBoard discard orientation', () => {
     const rightDiv = screen.getByTestId('discard-seat-1');
     const topDiv = screen.getByTestId('discard-seat-2');
     const leftDiv = screen.getByTestId('discard-seat-3');
-    expect(rightDiv.style.transform).toContain('rotate(90deg)');
+    expect(rightDiv.style.transform).toContain('rotate(270deg)');
     expect(topDiv.style.transform).toContain('rotate(180deg)');
     expect(leftDiv.style.transform).toContain('rotate(270deg)');
   });
@@ -177,8 +177,8 @@ describe('UIBoard discard orientation', () => {
     const rightTiles = rightDiv.querySelectorAll('[aria-label]');
     const topTiles = topDiv.querySelectorAll('[aria-label]');
 
-    expect(rightTiles[0].getAttribute('aria-label')).toBe('2萬');
-    expect(rightTiles[rightTiles.length - 1].getAttribute('aria-label')).toBe('1萬');
+    expect(rightTiles[0].getAttribute('aria-label')).toBe('1萬');
+    expect(rightTiles[rightTiles.length - 1].getAttribute('aria-label')).toBe('2萬');
     expect(topTiles[0].getAttribute('aria-label')).toBe('4筒');
     expect(topTiles[topTiles.length - 1].getAttribute('aria-label')).toBe('3筒');
   });


### PR DESCRIPTION
## Summary
- rotate seat 1 rivers to 270 degrees
- keep reverse logic, update unit tests accordingly

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857bdc88b30832a898743bf30c6985e