### PR TITLE
Extend score table to 130 fu

### DIFF
--- a/src/components/ScoreTable.test.tsx
+++ b/src/components/ScoreTable.test.tsx
@@ -24,4 +24,13 @@ describe('ScoreTable', () => {
     // console.log(row30.textContent, cells.map(c => c.textContent));
     expect(cells[2].textContent).toBe('500-1000');
   });
+
+  it('includes 120fu row showing child ron score', () => {
+    render(<ScoreTable isDealer={false} winType="ron" />);
+    const rows = screen.getAllByRole('row');
+    const row120 = rows[12];
+    const cells = within(row120).getAllByRole('cell');
+    // 120fu 1han -> base 120 * 2^3 = 960, ron child => 960*4=3840 -> 3900 after rounding
+    expect(cells[1].textContent).toBe('3900');
+  });
 });

--- a/src/components/ScoreTable.tsx
+++ b/src/components/ScoreTable.tsx
@@ -32,7 +32,23 @@ function formatScore(han: number, fu: number, isDealer: boolean, winType: 'ron' 
 }
 
 export const ScoreTable: React.FC<ScoreTableProps> = ({ isDealer, winType }) => {
-  const fuList = [20, 25, 30, 40, 50, 60, 70];
+  // Display fu values up to the rarely-seen limit of 130
+  // so that even edge cases are shown in the table.
+  const fuList = [
+    20,
+    25,
+    30,
+    40,
+    50,
+    60,
+    70,
+    80,
+    90,
+    100,
+    110,
+    120,
+    130,
+  ];
   const hanList = [1, 2, 3, 4];
   return (
     <table className="w-full border-collapse text-sm">


### PR DESCRIPTION
## Summary
- show fu values up to 130 in `<ScoreTable>`
- test that 120 fu is displayed correctly

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`

------
https://chatgpt.com/codex/tasks/task_e_6857bf1bacd0832a9a7ded45ef4db901