### PR TITLE
Change default game to 東1局戦

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ function App() {
   const [tileFont, setTileFont] = useState(2);
   const [mode, setMode] = useState<'game' | 'fu-quiz' | 'score-quiz'>('game');
   const [gameLength, setGameLength] = useState<'east1' | 'tonpu' | 'tonnan'>(
-    'tonnan',
+    'east1',
   );
 
   return (


### PR DESCRIPTION
## Summary
- switch default game length in `App.tsx` from 東南戦 to 東1局戦

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_6857c0692d98832a839ec432b4d285f3