### PR TITLE
Fix river order for top/left seats

### DIFF
--- a/src/components/RiverView.test.tsx
+++ b/src/components/RiverView.test.tsx
@@ -17,15 +17,27 @@ describe('RiverView', () => {
     render(<RiverView tiles={[]} seat={1} lastDiscard={null} dataTestId="rv-1" />);
     div = screen.getByTestId('rv-1');
     expect(div.style.transform).toContain('rotate(270deg)');
+    render(<RiverView tiles={[]} seat={3} lastDiscard={null} dataTestId="rv-3" />);
+    div = screen.getByTestId('rv-3');
+    expect(div.style.transform).toContain('rotate(90deg)');
   });
 
   it('reverses order when needed', () => {
     const tiles = [t('man', 1, 'a'), t('man', 2, 'b')];
-    render(<RiverView tiles={tiles} seat={2} lastDiscard={null} dataTestId="rv" />);
+    render(<RiverView tiles={tiles} seat={3} lastDiscard={null} dataTestId="rv" />);
     const div = screen.getByTestId('rv');
     const tileEls = div.querySelectorAll('[aria-label]');
     expect(tileEls[0].getAttribute('aria-label')).toBe('2萬');
     expect(tileEls[tileEls.length - 1].getAttribute('aria-label')).toBe('1萬');
+  });
+
+  it('keeps order when reverse not needed', () => {
+    const tiles = [t('man', 1, 'a'), t('man', 2, 'b')];
+    render(<RiverView tiles={tiles} seat={2} lastDiscard={null} dataTestId="rv-nr" />);
+    const div = screen.getByTestId('rv-nr');
+    const tileEls = div.querySelectorAll('[aria-label]');
+    expect(tileEls[0].getAttribute('aria-label')).toBe('1萬');
+    expect(tileEls[tileEls.length - 1].getAttribute('aria-label')).toBe('2萬');
   });
 
   it('reserves space for empty river', () => {

--- a/src/components/RiverView.tsx
+++ b/src/components/RiverView.tsx
@@ -22,7 +22,7 @@ const seatRiverRotation = (seat: number): number => {
     case 2:
       return 180;
     case 3:
-      return 270;
+      return 90;
     default:
       return 0;
   }
@@ -30,7 +30,7 @@ const seatRiverRotation = (seat: number): number => {
 
 const shouldReverseRiver = (seat: number): boolean => {
   const rot = seatRiverRotation(seat) % 360;
-  return rot === 90 || rot === 180;
+  return rot === 90;
 };
 
 /** minimum cells to reserve for a player's discard area */

--- a/src/components/UIBoard.test.tsx
+++ b/src/components/UIBoard.test.tsx
@@ -146,7 +146,7 @@ describe('UIBoard discard orientation', () => {
     const leftDiv = screen.getByTestId('discard-seat-3');
     expect(rightDiv.style.transform).toContain('rotate(270deg)');
     expect(topDiv.style.transform).toContain('rotate(180deg)');
-    expect(leftDiv.style.transform).toContain('rotate(270deg)');
+    expect(leftDiv.style.transform).toContain('rotate(90deg)');
   });
 
   it('keeps discard order after rotation', () => {
@@ -154,6 +154,8 @@ describe('UIBoard discard orientation', () => {
     right.discard = [t('man', 1, 'a'), t('man', 2, 'b')];
     const top = createInitialPlayerState('top', true, 2);
     top.discard = [t('pin', 3, 'c'), t('pin', 4, 'd')];
+    const left = createInitialPlayerState('left', true, 3);
+    left.discard = [t('sou', 5, 'e'), t('sou', 6, 'f')];
 
     render(
       <UIBoard
@@ -161,7 +163,7 @@ describe('UIBoard discard orientation', () => {
           createInitialPlayerState('me', false, 0),
           right,
           top,
-          createInitialPlayerState('left', true, 3),
+          left,
         ]}
         dora={[]}
         onDiscard={() => {}}
@@ -173,13 +175,17 @@ describe('UIBoard discard orientation', () => {
 
     const rightDiv = screen.getByTestId('discard-seat-1');
     const topDiv = screen.getByTestId('discard-seat-2');
+    const leftDiv = screen.getByTestId('discard-seat-3');
 
     const rightTiles = rightDiv.querySelectorAll('[aria-label]');
     const topTiles = topDiv.querySelectorAll('[aria-label]');
+    const leftTiles = leftDiv.querySelectorAll('[aria-label]');
 
     expect(rightTiles[0].getAttribute('aria-label')).toBe('1萬');
     expect(rightTiles[rightTiles.length - 1].getAttribute('aria-label')).toBe('2萬');
-    expect(topTiles[0].getAttribute('aria-label')).toBe('4筒');
-    expect(topTiles[topTiles.length - 1].getAttribute('aria-label')).toBe('3筒');
+    expect(topTiles[0].getAttribute('aria-label')).toBe('3筒');
+    expect(topTiles[topTiles.length - 1].getAttribute('aria-label')).toBe('4筒');
+    expect(leftTiles[0].getAttribute('aria-label')).toBe('6索');
+    expect(leftTiles[leftTiles.length - 1].getAttribute('aria-label')).toBe('5索');
   });
 });


### PR DESCRIPTION
## Summary
- correct discard ordering for top and left players
- test rotation and order for all seats

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857c01d4530832a94bf2011d3fe16ec