### PR TITLE
Implement riichi deposit and restrictions

### DIFF
--- a/src/components/Player.test.ts
+++ b/src/components/Player.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { incrementDiscardCount } from './DiscardUtil';
-import { createInitialPlayerState, drawTiles, discardTile, sortHand, claimMeld, declareRiichi, canDeclareRiichi } from './Player';
+import { createInitialPlayerState, drawTiles, discardTile, sortHand, claimMeld, declareRiichi, canDeclareRiichi, isTenpaiAfterDiscard } from './Player';
 import { generateTileWall } from './TileWall';
 import { Tile, PlayerState, MeldType } from '../types/mahjong';
 
@@ -180,5 +180,35 @@ describe('canDeclareRiichi', () => {
       drawnTile: null,
     };
     expect(canDeclareRiichi(player)).toBe(false);
+  });
+});
+
+describe('isTenpaiAfterDiscard', () => {
+  const t = (suit: Tile['suit'], rank: number, id: string): Tile => ({ suit, rank, id });
+
+  it('detects tenpai after discarding a tile', () => {
+    const hand: Tile[] = [
+      t('man', 1, 'a1'), t('man', 1, 'a2'),
+      t('man', 2, 'b1'), t('man', 2, 'b2'),
+      t('pin', 3, 'c1'), t('pin', 3, 'c2'),
+      t('pin', 4, 'd1'), t('pin', 4, 'd2'),
+      t('sou', 5, 'e1'), t('sou', 5, 'e2'),
+      t('sou', 6, 'f1'), t('sou', 6, 'f2'),
+      t('man', 7, 'g1'), t('man', 8, 'h1'),
+    ];
+    const player: PlayerState = { ...createInitialPlayerState('test', false), hand };
+    expect(isTenpaiAfterDiscard(player, 'h1')).toBe(true);
+  });
+
+  it('returns false if noten after discard', () => {
+    const hand: Tile[] = [
+      t('man', 1, 'a'), t('man', 2, 'b'), t('man', 3, 'c'),
+      t('man', 4, 'd'), t('man', 5, 'e'), t('man', 6, 'f'),
+      t('man', 7, 'g'), t('man', 8, 'h'), t('man', 9, 'i'),
+      t('pin', 1, 'j'), t('pin', 1, 'k'),
+      t('sou', 2, 'l'), t('sou', 2, 'm'), t('sou', 3, 'n'),
+    ];
+    const player: PlayerState = { ...createInitialPlayerState('bad', false), hand };
+    expect(isTenpaiAfterDiscard(player, 'a')).toBe(false);
   });
 });

--- a/src/components/Player.ts
+++ b/src/components/Player.ts
@@ -96,3 +96,10 @@ export function canDeclareRiichi(player: PlayerState): boolean {
   }
   return false;
 }
+
+export function isTenpaiAfterDiscard(player: PlayerState, tileId: string): boolean {
+  const remaining = player.hand.filter(t => t.id !== tileId);
+  const shanten = calcShanten(remaining, player.melds.length);
+  const base = Math.min(shanten.standard, shanten.chiitoi, shanten.kokushi);
+  return base === 0;
+}

--- a/src/components/ScoreBoard.tsx
+++ b/src/components/ScoreBoard.tsx
@@ -5,16 +5,18 @@ interface ScoreBoardProps {
   players: PlayerState[];
   kyoku: number;
   wallCount: number;
+  kyotaku: number;
   onHelp: () => void;
 }
 
-export const ScoreBoard: React.FC<ScoreBoardProps> = ({ players, kyoku, wallCount, onHelp }) => {
+export const ScoreBoard: React.FC<ScoreBoardProps> = ({ players, kyoku, wallCount, kyotaku, onHelp }) => {
   const kyokuStr = ['東1局', '東2局', '東3局', '東4局', '南1局', '南2局', '南3局', '南4局'][kyoku - 1] || '';
   return (
     <div className="flex justify-between items-center p-4 bg-gray-200 rounded-lg shadow">
       <div className="flex items-baseline gap-2">
         <span className="font-bold">{kyokuStr}</span>
         <span className="text-sm">残り{wallCount}</span>
+        <span className="text-sm">供託{kyotaku}</span>
       </div>
       <div className="flex gap-2 items-center">
         {players.map(p => (


### PR DESCRIPTION
## Summary
- prevent invalid discards when declaring riichi
- track riichi sticks and show them on the scoreboard
- award riichi sticks to the winner
- add helper to check tenpai after discard
- test new helper function

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857c1b44138832abad2082299d68717