### PR TITLE
Fix left seat river order

### DIFF
--- a/src/components/RiverView.test.tsx
+++ b/src/components/RiverView.test.tsx
@@ -22,16 +22,16 @@ describe('RiverView', () => {
     expect(div.style.transform).toContain('rotate(90deg)');
   });
 
-  it('reverses order when needed', () => {
+  it('keeps order for left seat', () => {
     const tiles = [t('man', 1, 'a'), t('man', 2, 'b')];
     render(<RiverView tiles={tiles} seat={3} lastDiscard={null} dataTestId="rv" />);
     const div = screen.getByTestId('rv');
     const tileEls = div.querySelectorAll('[aria-label]');
-    expect(tileEls[0].getAttribute('aria-label')).toBe('2萬');
-    expect(tileEls[tileEls.length - 1].getAttribute('aria-label')).toBe('1萬');
+    expect(tileEls[0].getAttribute('aria-label')).toBe('1萬');
+    expect(tileEls[tileEls.length - 1].getAttribute('aria-label')).toBe('2萬');
   });
 
-  it('keeps order when reverse not needed', () => {
+  it('keeps order for opposite seat', () => {
     const tiles = [t('man', 1, 'a'), t('man', 2, 'b')];
     render(<RiverView tiles={tiles} seat={2} lastDiscard={null} dataTestId="rv-nr" />);
     const div = screen.getByTestId('rv-nr');

--- a/src/components/RiverView.tsx
+++ b/src/components/RiverView.tsx
@@ -28,10 +28,6 @@ const seatRiverRotation = (seat: number): number => {
   }
 };
 
-const shouldReverseRiver = (seat: number): boolean => {
-  const rot = seatRiverRotation(seat) % 360;
-  return rot === 90;
-};
 
 /** minimum cells to reserve for a player's discard area */
 export const RESERVED_RIVER_SLOTS = 20;
@@ -49,7 +45,7 @@ export const RiverView: React.FC<RiverViewProps> = ({
   lastDiscard,
   dataTestId,
 }) => {
-  const ordered = shouldReverseRiver(seat) ? [...tiles].reverse() : tiles;
+  const ordered = tiles;
   const placeholdersCount = Math.max(0, RESERVED_RIVER_SLOTS - ordered.length);
   return (
     <div

--- a/src/components/UIBoard.test.tsx
+++ b/src/components/UIBoard.test.tsx
@@ -185,7 +185,7 @@ describe('UIBoard discard orientation', () => {
     expect(rightTiles[rightTiles.length - 1].getAttribute('aria-label')).toBe('2萬');
     expect(topTiles[0].getAttribute('aria-label')).toBe('3筒');
     expect(topTiles[topTiles.length - 1].getAttribute('aria-label')).toBe('4筒');
-    expect(leftTiles[0].getAttribute('aria-label')).toBe('6索');
-    expect(leftTiles[leftTiles.length - 1].getAttribute('aria-label')).toBe('5索');
+    expect(leftTiles[0].getAttribute('aria-label')).toBe('5索');
+    expect(leftTiles[leftTiles.length - 1].getAttribute('aria-label')).toBe('6索');
   });
 });


### PR DESCRIPTION
## Summary
- unify river ordering across all seats
- adjust related tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857c30862b8832aae8b6caea6504f0b