### PR TITLE
Fix called discard placement

### DIFF
--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -337,7 +337,9 @@ const handleCallAction = (action: MeldType | 'pass') => {
     }
     p[discarder] = {
       ...p[discarder],
-      discard: p[discarder].discard.filter(t => t.id !== lastDiscard.tile.id),
+      discard: p[discarder].discard.map(t =>
+        t.id === lastDiscard.tile.id ? { ...t, called: true } : t,
+      ),
     };
     p[caller] = claimMeld(
       p[caller],
@@ -386,7 +388,9 @@ const handleCallAction = (action: MeldType | 'pass') => {
     if (!meldTiles) return;
     p[discarder] = {
       ...p[discarder],
-      discard: p[discarder].discard.filter(t => t.id !== lastDiscard.tile.id),
+      discard: p[discarder].discard.map(t =>
+        t.id === lastDiscard.tile.id ? { ...t, called: true } : t,
+      ),
     };
     p[caller] = claimMeld(
       p[caller],

--- a/src/components/RiverView.test.tsx
+++ b/src/components/RiverView.test.tsx
@@ -45,4 +45,14 @@ describe('RiverView', () => {
     const div = screen.getByTestId('rv');
     expect(div.children.length).toBe(RESERVED_RIVER_SLOTS);
   });
+
+  it('offsets called tiles based on seat', () => {
+    const tiles = [t('man', 1, 'a'), { ...t('man', 2, 'b'), called: true }];
+    render(<RiverView tiles={tiles} seat={1} lastDiscard={null} dataTestId="rv-call" />);
+    const div = screen.getByTestId('rv-call');
+    const tileEls = div.querySelectorAll('[aria-label]');
+    const style = tileEls[1].getAttribute('style') ?? '';
+    expect(style).toContain('rotate(90deg)');
+    expect(style).toContain('translateY(-6px)');
+  });
 });

--- a/src/components/RiverView.tsx
+++ b/src/components/RiverView.tsx
@@ -33,6 +33,19 @@ const shouldReverseRiver = (seat: number): boolean => {
   return rot === 90;
 };
 
+const calledOffset = (seat: number): string => {
+  switch (seat % 4) {
+    case 1:
+      return 'translateY(-6px)';
+    case 2:
+      return 'translateX(-6px)';
+    case 3:
+      return 'translateY(6px)';
+    default:
+      return 'translateX(6px)';
+  }
+};
+
 /** minimum cells to reserve for a player's discard area */
 export const RESERVED_RIVER_SLOTS = 20;
 
@@ -61,7 +74,8 @@ export const RiverView: React.FC<RiverViewProps> = ({
         <TileView
           key={tile.id}
           tile={tile}
-          rotate={seatRotation(seat) - seatRiverRotation(seat)}
+          rotate={seatRotation(seat) - seatRiverRotation(seat) + (tile.called ? 90 : 0)}
+          extraTransform={tile.called ? calledOffset(seat) : ''}
           isShonpai={lastDiscard?.tile.id === tile.id && lastDiscard.isShonpai}
         />
       ))}

--- a/src/components/TileView.test.tsx
+++ b/src/components/TileView.test.tsx
@@ -17,4 +17,12 @@ describe('TileView', () => {
     const html = renderToStaticMarkup(<TileView tile={tile} rotate={90} />);
     expect(html).toContain('rotate(90deg)');
   });
+
+  it('includes extra transform', () => {
+    const tile: Tile = { suit: 'man', rank: 3, id: 'm3' };
+    const html = renderToStaticMarkup(
+      <TileView tile={tile} extraTransform="translateX(5px)" />,
+    );
+    expect(html).toContain('translateX(5px)');
+  });
 });

--- a/src/components/TileView.tsx
+++ b/src/components/TileView.tsx
@@ -6,7 +6,8 @@ export const TileView: React.FC<{
   isShonpai?: boolean;
   className?: string;
   rotate?: number;
-}> = ({ tile, isShonpai, className, rotate = 0 }) => {
+  extraTransform?: string;
+}> = ({ tile, isShonpai, className, rotate = 0, extraTransform = '' }) => {
   const suitMap: Record<string, string> = { man: '萬', pin: '筒', sou: '索', wind: '', dragon: '' };
   const honorMap: Record<string, Record<number, string>> = {
     wind: { 1: '東', 2: '南', 3: '西', 4: '北' },
@@ -66,7 +67,7 @@ export const TileView: React.FC<{
     <span
       className={`relative inline-block border px-1 py-0.5 bg-white tile-font-size ${className ?? ''}`}
       aria-label={kanji}
-      style={{ transform: `rotate(${rotate}deg)` }}
+      style={{ transform: `rotate(${rotate}deg) ${extraTransform}` }}
     >
       <span className="font-emoji">{emojiMap[tile.suit]?.[tile.rank] ?? kanji}</span>
       {isShonpai && (

--- a/src/types/mahjong.ts
+++ b/src/types/mahjong.ts
@@ -5,6 +5,8 @@ export interface Tile {
   suit: Suit;
   rank: number; // 1–9／風:1東2南3西4北／三元:1白2発3中
   id: string;   // ユニーク識別子
+  /** true if this discard was claimed for a meld */
+  called?: boolean;
 }
 
 export type MeldType = 'pon' | 'chi' | 'kan';


### PR DESCRIPTION
## Summary
- track whether a discard tile was called
- keep called tiles in the river and rotate/offset them by seat
- expose `extraTransform` prop on `TileView`
- test called-tile layout

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857c38a7710832a9e3184657bc55162