### PR TITLE
Display tenpai

### DIFF
--- a/src/components/UIBoard.test.tsx
+++ b/src/components/UIBoard.test.tsx
@@ -47,7 +47,12 @@ describe('UIBoard shanten display', () => {
 
   it('shows kokushi label when lower', () => {
     renderBoard({ standard: 4, chiitoi: 4, kokushi: 0 });
-    expect(screen.getByText('向聴数: 0 (国士無双0向聴)')).toBeTruthy();
+    expect(screen.getByText('聴牌 (国士無双0向聴)')).toBeTruthy();
+  });
+
+  it('shows tenpai when shanten is zero', () => {
+    renderBoard({ standard: 0, chiitoi: 2, kokushi: 13 });
+    expect(screen.getByText('聴牌')).toBeTruthy();
   });
 
   it('shows kokushi label for 2-shanten', () => {

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -139,7 +139,9 @@ export const UIBoard: React.FC<UIBoardProps> = ({
             } else if (shanten.kokushi === base && base < shanten.standard) {
               label = `国士無双${base}向聴`;
             }
-            return <>向聴数: {base}{label && ` (${label})`}</>;
+            return base === 0
+              ? <>聴牌{label && ` (${label})`}</>
+              : <>向聴数: {base}{label && ` (${label})`}</>;
           })()}
         </div>
         {(() => {


### PR DESCRIPTION
## Summary
- show `聴牌` if shanten reaches zero
- update tests for new display text

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_6857c71f4c38832a9a4e7ce342ba2707