### PR TITLE
Improve board layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,11 +12,10 @@ function App() {
 
   return (
     <div
-      className="min-h-screen bg-green-100 flex items-center justify-center py-8"
+      className="min-h-screen bg-green-100 flex items-center justify-center py-2"
       style={{ ['--tile-font-size' as any]: `${tileFont}rem` } as React.CSSProperties}
     >
-      <div className="w-full max-w-4xl mx-auto px-4 space-y-6">
-        <h1 className="text-2xl font-bold text-center">麻雀 Web アプリ（1人用デモ）</h1>
+      <div className="w-full mx-auto px-4 space-y-4">
         <div className="flex flex-wrap items-end gap-4">
           <div className="flex items-center gap-2">
             <label htmlFor="size">牌サイズ</label>

--- a/src/components/ScoreBoard.tsx
+++ b/src/components/ScoreBoard.tsx
@@ -12,7 +12,7 @@ interface ScoreBoardProps {
 export const ScoreBoard: React.FC<ScoreBoardProps> = ({ players, kyoku, wallCount, kyotaku, onHelp }) => {
   const kyokuStr = ['東1局', '東2局', '東3局', '東4局', '南1局', '南2局', '南3局', '南4局'][kyoku - 1] || '';
   return (
-    <div className="flex justify-between items-center p-4 bg-gray-200 rounded-lg shadow">
+    <div className="flex justify-between items-center p-2 bg-gray-200 rounded-lg shadow">
       <div className="flex items-baseline gap-2">
         <span className="font-bold">{kyokuStr}</span>
         <span className="text-sm">残り{wallCount}</span>

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -115,7 +115,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
       </div>
 
       {/* 自分の手牌 */}
-      <div className="row-start-3 col-start-2 flex flex-col items-center mt-4">
+      <div className="row-start-3 col-start-2 flex flex-col items-center mt-2">
         {me.melds.length > 0 && (
           <div className="flex gap-2 mb-2">
             {me.melds.map((m, idx) => (


### PR DESCRIPTION
## Summary
- remove demo heading for more vertical space
- shrink scoreboard and tile section spacing
- reduce padding around entire board

## Testing
- `npx -y -p node@20 npm run lint`
- `npx -y -p node@20 npm run type-check`
- `npx -y -p node@20 npm run build`
- `npx -y -p node@20 npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857c79a46ac832a86a2c7110691eaa1