### PR TITLE
Add help modals for Fu and Score quizzes

### DIFF
--- a/src/components/FuQuiz.test.tsx
+++ b/src/components/FuQuiz.test.tsx
@@ -31,4 +31,10 @@ describe('FuQuiz', () => {
     render(<FuQuiz initialIndex={0} initialWinType="ron" />);
     expect(screen.getByText('場風: 東 / 自風: 東 / ロン')).toBeTruthy();
   });
+
+  it('opens help modal', () => {
+    render(<FuQuiz initialIndex={0} initialWinType="ron" />);
+    fireEvent.click(screen.getByLabelText('ヘルプ'));
+    expect(screen.getByText('基本符20')).toBeTruthy();
+  });
 });

--- a/src/components/FuQuiz.tsx
+++ b/src/components/FuQuiz.tsx
@@ -4,6 +4,7 @@ import { calculateFuDetail } from '../score/calculateFuDetail';
 import { TileView } from './TileView';
 import { sortHand } from './Player';
 import { useAgariQuiz } from '../quiz/useAgariQuiz';
+import { QuizHelpModal } from './QuizHelpModal';
 
 interface FuQuizProps {
   initialIndex?: number;
@@ -22,6 +23,7 @@ export const FuQuiz: React.FC<FuQuizProps> = ({ initialIndex, initialWinType }) 
   const [result, setResult] = useState<{ fu: number; steps: string[]; correct: boolean } | null>(
     null,
   );
+  const [helpOpen, setHelpOpen] = useState(false);
   const fullHand = sortHand([...question.hand, ...question.melds.flatMap(m => m.tiles)]);
 
   const onSubmit = (e: React.FormEvent) => {
@@ -40,9 +42,18 @@ export const FuQuiz: React.FC<FuQuizProps> = ({ initialIndex, initialWinType }) 
 
   return (
     <div className="p-4 border rounded">
-      <div className="text-sm mb-1">
-        場風: {windNames[roundWind]} / 自風: {windNames[seatWind]} /
-        {winType === 'tsumo' ? ' ツモ' : ' ロン'}
+      <div className="flex justify-between items-center text-sm mb-1">
+        <div>
+          場風: {windNames[roundWind]} / 自風: {windNames[seatWind]} /
+          {winType === 'tsumo' ? ' ツモ' : ' ロン'}
+        </div>
+        <button
+          onClick={() => setHelpOpen(true)}
+          className="w-6 h-6 flex items-center justify-center rounded-full bg-white shadow text-xs font-bold hover:bg-gray-100"
+          aria-label="ヘルプ"
+        >
+          ?
+        </button>
       </div>
       <div className="flex gap-1 mb-2 flex-wrap">
         {fullHand.map(t => (
@@ -71,6 +82,7 @@ export const FuQuiz: React.FC<FuQuizProps> = ({ initialIndex, initialWinType }) 
       <button onClick={handleNext} className="mt-2 px-2 py-1 bg-green-200 rounded">
         次の問題
       </button>
+      <QuizHelpModal isOpen={helpOpen} onClose={() => setHelpOpen(false)} />
     </div>
   );
 };

--- a/src/components/QuizHelpModal.tsx
+++ b/src/components/QuizHelpModal.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+interface QuizHelpModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  showScore?: boolean;
+}
+
+export const QuizHelpModal: React.FC<QuizHelpModalProps> = ({ isOpen, onClose, showScore }) => {
+  if (!isOpen) return null;
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg p-4 shadow-lg max-w-md w-full">
+        <div className="flex justify-between items-center mb-2">
+          <h2 className="text-lg font-bold">クイズヘルプ</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-black font-bold"
+            aria-label="close"
+          >
+            ×
+          </button>
+        </div>
+        <div className="space-y-2 text-sm">
+          <div>
+            <h3 className="font-semibold mb-1">符計算</h3>
+            <ul className="list-disc list-inside space-y-1">
+              <li>基本符20</li>
+              <li>雀頭が三元牌なら+2、自風なら+2、場風なら+2</li>
+              <li>刻子: 数牌4符 / 么九牌8符</li>
+              <li>カン: 数牌16符 / 么九牌32符</li>
+              <li>最後に10の位へ切り上げ</li>
+            </ul>
+          </div>
+          {showScore && (
+            <div>
+              <h3 className="font-semibold mb-1">点数計算</h3>
+              <ul className="list-disc list-inside space-y-1">
+                <li>基本点 = 符 × 2^(翻 + 2)</li>
+                <li>このクイズではこの基本点を答える</li>
+                <li>例: 20符4翻 → 20 × 2^6 = 1280</li>
+              </ul>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ScoreQuiz.test.tsx
+++ b/src/components/ScoreQuiz.test.tsx
@@ -35,4 +35,10 @@ describe('ScoreQuiz', () => {
     render(<ScoreQuiz initialIndex={0} initialWinType="ron" />);
     expect(screen.getByText('場風: 東 / 自風: 東 / ロン')).toBeTruthy();
   });
+
+  it('opens help modal with score info', () => {
+    render(<ScoreQuiz initialIndex={0} initialWinType="ron" />);
+    fireEvent.click(screen.getByLabelText('ヘルプ'));
+    expect(screen.getByText('基本点 = 符 × 2^(翻 + 2)')).toBeTruthy();
+  });
 });

--- a/src/components/ScoreQuiz.tsx
+++ b/src/components/ScoreQuiz.tsx
@@ -5,6 +5,7 @@ import { detectYaku } from '../score/yaku';
 import { calculateScore } from '../score/score';
 import { calculateFuDetail } from '../score/calculateFuDetail';
 import { useAgariQuiz } from '../quiz/useAgariQuiz';
+import { QuizHelpModal } from './QuizHelpModal';
 
 interface ScoreQuizProps {
   initialIndex?: number;
@@ -28,6 +29,7 @@ export const ScoreQuiz: React.FC<ScoreQuizProps> = ({ initialIndex, initialWinTy
       }
     | null
   >(null);
+  const [helpOpen, setHelpOpen] = useState(false);
 
   const fullHand = sortHand([...question.hand, ...question.melds.flatMap(m => m.tiles)]);
 
@@ -63,9 +65,18 @@ export const ScoreQuiz: React.FC<ScoreQuizProps> = ({ initialIndex, initialWinTy
 
   return (
     <div className="p-4 border rounded">
-      <div className="text-sm mb-1">
-        場風: {windNames[roundWind]} / 自風: {windNames[seatWind]} /
-        {winType === 'tsumo' ? ' ツモ' : ' ロン'}
+      <div className="flex justify-between items-center text-sm mb-1">
+        <div>
+          場風: {windNames[roundWind]} / 自風: {windNames[seatWind]} /
+          {winType === 'tsumo' ? ' ツモ' : ' ロン'}
+        </div>
+        <button
+          onClick={() => setHelpOpen(true)}
+          className="w-6 h-6 flex items-center justify-center rounded-full bg-white shadow text-xs font-bold hover:bg-gray-100"
+          aria-label="ヘルプ"
+        >
+          ?
+        </button>
       </div>
       <div className="flex gap-1 mb-2 flex-wrap">
         {fullHand.map(t => (
@@ -105,6 +116,11 @@ export const ScoreQuiz: React.FC<ScoreQuizProps> = ({ initialIndex, initialWinTy
       <button onClick={handleNext} className="mt-2 px-2 py-1 bg-green-200 rounded">
         次の問題
       </button>
+      <QuizHelpModal
+        isOpen={helpOpen}
+        onClose={() => setHelpOpen(false)}
+        showScore
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add `QuizHelpModal` component with fu and score explanations
- integrate help modal into FuQuiz and ScoreQuiz
- test opening help modals in quizzes

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present || npx tsc --noEmit`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_6857c8db8644832a90f05cd3169ec2d7