### PR TITLE
Add tsumo/menzen ron fu calculation

### DIFF
--- a/src/components/FuQuiz.test.tsx
+++ b/src/components/FuQuiz.test.tsx
@@ -5,14 +5,14 @@ import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { FuQuiz } from './FuQuiz';
 
 // 固定のサンプルハンドで符計算クイズをテストする
-// SAMPLE_HANDS[0] は calculateFu(...) が 20 になる
+// SAMPLE_HANDS[0] をロン和了すると 30符になる
 
 afterEach(() => cleanup());
 describe('FuQuiz', () => {
   it('shows "正解！" when the guess is correct', () => {
     render(<FuQuiz initialIndex={0} initialWinType="ron" />);
     const input = screen.getByPlaceholderText('符を入力');
-    fireEvent.change(input, { target: { value: '20' } });
+    fireEvent.change(input, { target: { value: '30' } });
     const button = screen.getByText('答える');
     fireEvent.click(button);
     expect(screen.getByText('正解！')).toBeTruthy();
@@ -21,10 +21,10 @@ describe('FuQuiz', () => {
   it('shows the correct answer when the guess is wrong', () => {
     render(<FuQuiz initialIndex={0} initialWinType="ron" />);
     const input = screen.getByPlaceholderText('符を入力');
-    fireEvent.change(input, { target: { value: '30' } });
+    fireEvent.change(input, { target: { value: '20' } });
     const button = screen.getByText('答える');
     fireEvent.click(button);
-    expect(screen.getByText('不正解。正解: 20符')).toBeTruthy();
+    expect(screen.getByText('不正解。正解: 30符')).toBeTruthy();
   });
 
   it('displays seat and round wind and win type', () => {

--- a/src/components/FuQuiz.tsx
+++ b/src/components/FuQuiz.tsx
@@ -28,8 +28,18 @@ export const FuQuiz: React.FC<FuQuizProps> = ({ initialIndex, initialWinType }) 
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    const fu = calculateFu(question.hand, question.melds, { seatWind, roundWind });
-    const detail = calculateFuDetail(question.hand, question.melds, seatWind, roundWind);
+    const fu = calculateFu(question.hand, question.melds, {
+      seatWind,
+      roundWind,
+      winType,
+    });
+    const detail = calculateFuDetail(
+      question.hand,
+      question.melds,
+      seatWind,
+      roundWind,
+      winType,
+    );
     const correct = Number(guess) === fu;
     setResult({ fu, steps: detail.steps, correct });
   };

--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -251,7 +251,7 @@ export const GameController: React.FC<Props> = ({ gameLength }) => {
         p[currentIndex].melds,
         yaku,
         dora,
-        { seatWind, roundWind },
+        { seatWind, roundWind, winType: 'tsumo' },
       );
       let newPlayers = payoutTsumo(p, currentIndex, points);
       if (riichiPoolRef.current > 0) {
@@ -311,7 +311,7 @@ export const GameController: React.FC<Props> = ({ gameLength }) => {
         winningPlayer.melds,
         yaku,
         [],
-        { seatWind, roundWind },
+        { seatWind, roundWind, winType: 'ron' },
       );
       let updated = payoutRon(p, winIdx, idx, points);
       if (riichiPoolRef.current > 0) {

--- a/src/components/QuizHelpModal.tsx
+++ b/src/components/QuizHelpModal.tsx
@@ -27,8 +27,10 @@ export const QuizHelpModal: React.FC<QuizHelpModalProps> = ({ isOpen, onClose, s
             <ul className="list-disc list-inside space-y-1">
               <li>基本符20</li>
               <li>雀頭が三元牌なら+2、自風なら+2、場風なら+2</li>
-              <li>刻子: 数牌4符 / 么九牌8符</li>
-              <li>カン: 数牌16符 / 么九牌32符</li>
+              <li>刻子: 中張牌4符 / 么九牌8符</li>
+              <li>カン: 中張牌16符 / 么九牌32符</li>
+              <li>ツモ上がり +2</li>
+              <li>面前ロン +10</li>
               <li>最後に10の位へ切り上げ</li>
             </ul>
           </div>

--- a/src/components/ScoreQuiz.test.tsx
+++ b/src/components/ScoreQuiz.test.tsx
@@ -4,7 +4,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { ScoreQuiz } from './ScoreQuiz';
 
-// SAMPLE_HANDS[0] をロン和了すると 4翻20符で 1280 点になる
+// SAMPLE_HANDS[0] をロン和了すると 4翻30符で 1920 点になる
 
 afterEach(() => cleanup());
 
@@ -12,7 +12,7 @@ describe('ScoreQuiz', () => {
   it('shows "正解！" when the guess is correct', () => {
     render(<ScoreQuiz initialIndex={0} initialWinType="ron" />);
     const input = screen.getByPlaceholderText('点数を入力');
-    fireEvent.change(input, { target: { value: '1280' } });
+    fireEvent.change(input, { target: { value: '1920' } });
     const button = screen.getByText('答える');
     fireEvent.click(button);
     expect(screen.getByText('正解！')).toBeTruthy();
@@ -26,7 +26,7 @@ describe('ScoreQuiz', () => {
     fireEvent.change(input, { target: { value: '1000' } });
     const button = screen.getByText('答える');
     fireEvent.click(button);
-    expect(screen.getByText('不正解。正解: 1280点 (4翻 20符)')).toBeTruthy();
+    expect(screen.getByText('不正解。正解: 1920点 (4翻 30符)')).toBeTruthy();
     expect(screen.getByText('Tanyao (1翻)')).toBeTruthy();
     expect(screen.getByText('基本符20')).toBeTruthy();
   });

--- a/src/components/ScoreQuiz.tsx
+++ b/src/components/ScoreQuiz.tsx
@@ -41,11 +41,24 @@ export const ScoreQuiz: React.FC<ScoreQuizProps> = ({ initialIndex, initialWinTy
       seatWind,
       roundWind,
     });
-    const { han, fu, points } = calculateScore(question.hand, question.melds, yaku, [], {
+    const { han, fu, points } = calculateScore(
+      question.hand,
+      question.melds,
+      yaku,
+      [],
+      {
+        seatWind,
+        roundWind,
+        winType,
+      },
+    );
+    const detail = calculateFuDetail(
+      question.hand,
+      question.melds,
       seatWind,
       roundWind,
-    });
-    const detail = calculateFuDetail(question.hand, question.melds, seatWind, roundWind);
+      winType,
+    );
     const correct = Number(guess) === points;
     setResult({
       points,

--- a/src/score/calculateFu.test.ts
+++ b/src/score/calculateFu.test.ts
@@ -56,4 +56,18 @@ describe('calculateFu', () => {
     // 基本符20 + ダブ南の雀頭4 = 24、切り上げで30符になるはず
     expect(fu).toBe(30);
   });
+
+  it('adds 10 fu for a closed ron', () => {
+    const { hand, melds } = SAMPLE_HANDS[0];
+    const fu = calculateFu(hand, melds, { winType: 'ron' });
+    // 基本符20 + 面前ロン10 = 30符になるはず
+    expect(fu).toBe(30);
+  });
+
+  it('adds 2 fu for tsumo win', () => {
+    const { hand, melds } = SAMPLE_HANDS[0];
+    const fu = calculateFu(hand, melds, { winType: 'tsumo' });
+    // 基本符20 + ツモ符2 = 22、切り上げで30符になるはず
+    expect(fu).toBe(30);
+  });
 });

--- a/src/score/calculateFuDetail.ts
+++ b/src/score/calculateFuDetail.ts
@@ -93,6 +93,7 @@ export function calculateFuDetail(
   melds: Meld[] = [],
   seatWind = 1,
   roundWind = 1,
+  winType: 'ron' | 'tsumo' = 'ron',
 ): { fu: number; steps: string[] } {
   const allTiles = [...hand, ...melds.flatMap(m => m.tiles)];
   const parsed = decomposeHand(allTiles);
@@ -100,6 +101,14 @@ export function calculateFuDetail(
 
   let fu = 20;
   const steps = ['基本符20'];
+
+  if (winType === 'tsumo') {
+    fu += 2;
+    steps.push('ツモ符 +2');
+  } else if (winType === 'ron' && melds.length === 0) {
+    fu += 10;
+    steps.push('面前ロン +10');
+  }
 
   let pairFu = 0;
   if (parsed.pair[0].suit === 'dragon') {

--- a/src/score/score.ts
+++ b/src/score/score.ts
@@ -97,13 +97,19 @@ function decomposeHand(tiles: Tile[]): { pair: Tile[]; melds: ParsedMeld[] } | n
 export function calculateFu(
   hand: Tile[],
   melds: Meld[] = [],
-  opts?: { seatWind?: number; roundWind?: number },
+  opts?: { seatWind?: number; roundWind?: number; winType?: 'ron' | 'tsumo' },
 ): number {
   const allTiles = [...hand, ...melds.flatMap(m => m.tiles)];
   const parsed = decomposeHand(allTiles);
   if (!parsed) return 0;
 
   let fu = 20; // base fu for a winning hand
+
+  if (opts?.winType === 'tsumo') {
+    fu += 2;
+  } else if (opts?.winType === 'ron' && melds.length === 0) {
+    fu += 10;
+  }
 
   // pair fu (dragons, seat wind, and round wind are value tiles)
   let pairFu = 0;
@@ -163,7 +169,7 @@ export function calculateScore(
   melds: Meld[],
   yaku: Yaku[],
   doraIndicators: Tile[] = [],
-  opts?: { seatWind?: number; roundWind?: number },
+  opts?: { seatWind?: number; roundWind?: number; winType?: 'ron' | 'tsumo' },
 ): { han: number; fu: number; points: number } {
   const allTiles = [...hand, ...melds.flatMap(m => m.tiles)];
   const dora = countDora(allTiles, doraIndicators);


### PR DESCRIPTION
## Summary
- include tsumo and menzen ron bonuses in fu calculation
- show these bonuses in quiz help modal
- pass win type into score/fu calculations
- update fu tests and score quiz logic
- use 中張牌 term in help modal

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857cab312f4832aa4046f3f002db2fc