### PR TITLE
Reposition scoreboard and move help button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { GameController } from './components/GameController';
 import { FuQuiz } from './components/FuQuiz';
 import { ScoreQuiz } from './components/ScoreQuiz';
+import { HelpModal } from './components/HelpModal';
 
 function App() {
   const [tileFont, setTileFont] = useState(2);
@@ -9,6 +10,7 @@ function App() {
   const [gameLength, setGameLength] = useState<'east1' | 'tonpu' | 'tonnan'>(
     'east1',
   );
+  const [helpOpen, setHelpOpen] = useState(false);
 
   return (
     <div
@@ -44,33 +46,41 @@ function App() {
               <option value="score-quiz">点数クイズ</option>
             </select>
           </div>
-          {mode === 'game' && (
-            <div className="flex items-center gap-2">
-              <label htmlFor="length">試合形式</label>
-              <select
-                id="length"
-                value={gameLength}
-                onChange={e =>
-                  setGameLength(
-                    e.target.value as 'east1' | 'tonpu' | 'tonnan',
-                  )
-                }
-                className="border px-2 py-1"
-              >
-                <option value="east1">東1局のみ</option>
-                <option value="tonpu">東風戦</option>
-                <option value="tonnan">東南戦</option>
-              </select>
-            </div>
-          )}
-        </div>
-        {mode === 'game' ? (
-          <GameController key={gameLength} gameLength={gameLength} />
-        ) : mode === 'fu-quiz' ? (
-          <FuQuiz />
-        ) : (
-          <ScoreQuiz />
+        {mode === 'game' && (
+          <div className="flex items-center gap-2">
+            <label htmlFor="length">試合形式</label>
+            <select
+              id="length"
+              value={gameLength}
+              onChange={e =>
+                setGameLength(
+                  e.target.value as 'east1' | 'tonpu' | 'tonnan',
+                )
+              }
+              className="border px-2 py-1"
+            >
+              <option value="east1">東1局のみ</option>
+              <option value="tonpu">東風戦</option>
+              <option value="tonnan">東南戦</option>
+            </select>
+          </div>
         )}
+        <button
+          onClick={() => setHelpOpen(true)}
+          className="w-6 h-6 flex items-center justify-center rounded-full bg-white shadow text-sm font-bold hover:bg-gray-100"
+          aria-label="ヘルプ"
+        >
+          ?
+        </button>
+      </div>
+      {mode === 'game' ? (
+        <GameController key={gameLength} gameLength={gameLength} />
+      ) : mode === 'fu-quiz' ? (
+        <FuQuiz />
+      ) : (
+        <ScoreQuiz />
+      )}
+      <HelpModal isOpen={helpOpen} onClose={() => setHelpOpen(false)} />
       </div>
     </div>
   );

--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -13,8 +13,6 @@ import { filterChiOptions } from '../utils/table';
 import { isWinningHand, detectYaku } from '../score/yaku';
 import { calculateScore } from '../score/score';
 import { UIBoard } from './UIBoard';
-import { ScoreBoard } from './ScoreBoard';
-import { HelpModal } from './HelpModal';
 import { calcShanten } from '../utils/shanten';
 import { incrementDiscardCount, findRonWinner } from './DiscardUtil';
 import { chooseAICallOption } from '../utils/ai';
@@ -45,7 +43,6 @@ export const GameController: React.FC<Props> = ({ gameLength }) => {
   const [phase, setPhase] = useState<GamePhase>('init');
   const [message, setMessage] = useState<string>('');
   const [kyoku, setKyoku] = useState<number>(1); // 東1局など
-  const [helpOpen, setHelpOpen] = useState(false);
   const [shanten, setShanten] = useState<{ standard: number; chiitoi: number; kokushi: number }>({ standard: 8, chiitoi: 8, kokushi: 13 });
   const [discardCounts, setDiscardCounts] = useState<Record<string, number>>({});
   const [lastDiscard, setLastDiscard] = useState<{ tile: Tile; player: number; isShonpai: boolean } | null>(null);
@@ -553,16 +550,12 @@ const handleCallAction = (action: MeldType | 'pass') => {
   // UI
   return (
     <div className="p-2 flex flex-col gap-4">
-      <ScoreBoard
-        players={players}
-        kyoku={kyoku}
-        wallCount={wall.length}
-        kyotaku={riichiPool}
-        onHelp={() => setHelpOpen(true)}
-      />
       <UIBoard
         players={players}
         dora={dora}
+        kyoku={kyoku}
+        wallCount={wall.length}
+        kyotaku={riichiPool}
         onDiscard={handleDiscard}
         isMyTurn={turn === 0 && !players[0]?.isAI}
         shanten={shanten}
@@ -591,7 +584,6 @@ const handleCallAction = (action: MeldType | 'pass') => {
       {phase === 'end' && (
         <FinalResultModal players={players} onReplay={handleRestart} />
       )}
-      <HelpModal isOpen={helpOpen} onClose={() => setHelpOpen(false)} />
     </div>
   );
 };

--- a/src/components/ScoreBoard.tsx
+++ b/src/components/ScoreBoard.tsx
@@ -6,10 +6,14 @@ interface ScoreBoardProps {
   kyoku: number;
   wallCount: number;
   kyotaku: number;
-  onHelp: () => void;
 }
 
-export const ScoreBoard: React.FC<ScoreBoardProps> = ({ players, kyoku, wallCount, kyotaku, onHelp }) => {
+export const ScoreBoard: React.FC<ScoreBoardProps> = ({
+  players,
+  kyoku,
+  wallCount,
+  kyotaku,
+}) => {
   const kyokuStr = ['東1局', '東2局', '東3局', '東4局', '南1局', '南2局', '南3局', '南4局'][kyoku - 1] || '';
   return (
     <div className="flex justify-between items-center p-2 bg-gray-200 rounded-lg shadow">
@@ -24,13 +28,6 @@ export const ScoreBoard: React.FC<ScoreBoardProps> = ({ players, kyoku, wallCoun
             {p.name}: <span className="font-mono">{p.score}</span>
           </span>
         ))}
-        <button
-          onClick={onHelp}
-          className="ml-2 w-6 h-6 flex items-center justify-center rounded-full bg-white shadow text-sm font-bold hover:bg-gray-100"
-          aria-label="ヘルプ"
-        >
-          ?
-        </button>
       </div>
     </div>
   );

--- a/src/components/UIBoard.test.tsx
+++ b/src/components/UIBoard.test.tsx
@@ -21,6 +21,9 @@ function renderBoard(shanten: { standard: number; chiitoi: number; kokushi: numb
       createInitialPlayerState('ai3', true, 3),
     ],
     dora: [] as Tile[],
+    kyoku: 1,
+    wallCount: 70,
+    kyotaku: 0,
     onDiscard: () => {},
     isMyTurn: true,
     shanten,
@@ -89,6 +92,9 @@ describe('UIBoard riichi button', () => {
           createInitialPlayerState('ai3', true, 3),
         ]}
         dora={[]}
+        kyoku={1}
+        wallCount={70}
+        kyotaku={0}
         onDiscard={() => {}}
         isMyTurn={true}
         shanten={{ standard: 0, chiitoi: 0, kokushi: 13 }}
@@ -118,6 +124,9 @@ describe('UIBoard riichi button', () => {
           createInitialPlayerState('ai3', true, 3),
         ]}
         dora={[]}
+        kyoku={1}
+        wallCount={70}
+        kyotaku={0}
         onDiscard={() => {}}
         isMyTurn={true}
         shanten={{ standard: 1, chiitoi: 4, kokushi: 9 }}
@@ -140,6 +149,9 @@ describe('UIBoard chi options', () => {
           createInitialPlayerState('ai3', true, 3),
         ]}
         dora={[]}
+        kyoku={1}
+        wallCount={70}
+        kyotaku={0}
         onDiscard={() => {}}
         isMyTurn={true}
         shanten={{ standard: 0, chiitoi: 0, kokushi: 0 }}
@@ -167,6 +179,9 @@ describe('UIBoard discard orientation', () => {
           createInitialPlayerState('left', true, 3),
         ]}
         dora={[]}
+        kyoku={1}
+        wallCount={70}
+        kyotaku={0}
         onDiscard={() => {}}
         isMyTurn={true}
         shanten={{ standard: 0, chiitoi: 0, kokushi: 0 }}
@@ -198,6 +213,9 @@ describe('UIBoard discard orientation', () => {
           left,
         ]}
         dora={[]}
+        kyoku={1}
+        wallCount={70}
+        kyotaku={0}
         onDiscard={() => {}}
         isMyTurn={true}
         shanten={{ standard: 0, chiitoi: 0, kokushi: 0 }}

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -4,10 +4,14 @@ import { TileView } from './TileView';
 import { canDeclareRiichi } from './Player';
 import { MeldView } from './MeldView';
 import { RiverView } from './RiverView';
+import { ScoreBoard } from './ScoreBoard';
 
 interface UIBoardProps {
   players: PlayerState[];
   dora: Tile[];
+  kyoku: number;
+  wallCount: number;
+  kyotaku: number;
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
   onDiscard: (tileId: string) => void;
   isMyTurn: boolean;
@@ -32,6 +36,9 @@ interface UIBoardProps {
 export const UIBoard: React.FC<UIBoardProps> = ({
   players,
   dora,
+  kyoku,
+  wallCount,
+  kyotaku,
   onDiscard,
   isMyTurn,
   shanten,
@@ -109,14 +116,22 @@ export const UIBoard: React.FC<UIBoardProps> = ({
         />
       </div>
 
-      {/* ドラ表示 */}
-      <div className="row-start-2 col-start-2 flex flex-col items-center">
-        <div className="text-sm mb-1">ドラ表示</div>
-        <div className="flex gap-1">
-          {dora.map(tile => (
-            <TileView key={tile.id} tile={tile} />
-          ))}
+      {/* ドラ表示とスコア */}
+      <div className="row-start-2 col-start-2 flex flex-col items-center gap-2">
+        <div className="flex flex-col items-center gap-1">
+          <div className="text-sm">ドラ表示</div>
+          <div className="flex gap-1">
+            {dora.map(tile => (
+              <TileView key={tile.id} tile={tile} />
+            ))}
+          </div>
         </div>
+        <ScoreBoard
+          players={players}
+          kyoku={kyoku}
+          wallCount={wallCount}
+          kyotaku={kyotaku}
+        />
       </div>
 
       {/* 自分の手牌 */}


### PR DESCRIPTION
## Summary
- put ScoreBoard next to the dora area in `UIBoard`
- relocate help button to app header
- drop help button from ScoreBoard
- adjust GameController and tests for new props

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857cc81eaf8832a8db74d30e06f36d9