### PR TITLE
Improve score quiz to use actual payments

### DIFF
--- a/src/components/QuizHelpModal.tsx
+++ b/src/components/QuizHelpModal.tsx
@@ -39,8 +39,9 @@ export const QuizHelpModal: React.FC<QuizHelpModalProps> = ({ isOpen, onClose, s
               <h3 className="font-semibold mb-1">点数計算</h3>
               <ul className="list-disc list-inside space-y-1">
                 <li>基本点 = 符 × 2^(翻 + 2)</li>
-                <li>このクイズではこの基本点を答える</li>
-                <li>例: 20符4翻 → 20 × 2^6 = 1280</li>
+                <li>ロンは子×4 / 親×6、ツモは子×1 / 親×2</li>
+                <li>掛けた後100点単位へ切り上げ</li>
+                <li>例: 30符4翻 親ロン → 30 × 2^6 × 6 = 11520 → 11600</li>
               </ul>
             </div>
           )}

--- a/src/components/ScoreQuiz.test.tsx
+++ b/src/components/ScoreQuiz.test.tsx
@@ -4,7 +4,8 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { ScoreQuiz } from './ScoreQuiz';
 
-// SAMPLE_HANDS[0] をロン和了すると 4翻30符で 1920 点になる
+// SAMPLE_HANDS[0] を親でロン和了すると 4翻30符で
+// 基本点1920 ×6 = 11520 -> 11600点になる
 
 afterEach(() => cleanup());
 
@@ -12,7 +13,7 @@ describe('ScoreQuiz', () => {
   it('shows "正解！" when the guess is correct', () => {
     render(<ScoreQuiz initialIndex={0} initialWinType="ron" />);
     const input = screen.getByPlaceholderText('点数を入力');
-    fireEvent.change(input, { target: { value: '1920' } });
+    fireEvent.change(input, { target: { value: '11600' } });
     const button = screen.getByText('答える');
     fireEvent.click(button);
     expect(screen.getByText('正解！')).toBeTruthy();
@@ -26,7 +27,7 @@ describe('ScoreQuiz', () => {
     fireEvent.change(input, { target: { value: '1000' } });
     const button = screen.getByText('答える');
     fireEvent.click(button);
-    expect(screen.getByText('不正解。正解: 1920点 (4翻 30符)')).toBeTruthy();
+    expect(screen.getByText('不正解。正解: 11600点 (4翻 30符)')).toBeTruthy();
     expect(screen.getByText('Tanyao (1翻)')).toBeTruthy();
     expect(screen.getByText('基本符20')).toBeTruthy();
   });
@@ -40,5 +41,6 @@ describe('ScoreQuiz', () => {
     render(<ScoreQuiz initialIndex={0} initialWinType="ron" />);
     fireEvent.click(screen.getByLabelText('ヘルプ'));
     expect(screen.getByText('基本点 = 符 × 2^(翻 + 2)')).toBeTruthy();
+    expect(screen.getByText('ロンは子×4 / 親×6、ツモは子×1 / 親×2')).toBeTruthy();
   });
 });

--- a/src/components/ScoreQuiz.tsx
+++ b/src/components/ScoreQuiz.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { sortHand } from './Player';
 import { TileView } from './TileView';
 import { detectYaku } from '../score/yaku';
-import { calculateScore } from '../score/score';
+import { calculateScore, calcRoundedScore } from '../score/score';
 import { calculateFuDetail } from '../score/calculateFuDetail';
 import { useAgariQuiz } from '../quiz/useAgariQuiz';
 import { QuizHelpModal } from './QuizHelpModal';
@@ -41,7 +41,7 @@ export const ScoreQuiz: React.FC<ScoreQuizProps> = ({ initialIndex, initialWinTy
       seatWind,
       roundWind,
     });
-    const { han, fu, points } = calculateScore(
+    const { han, fu } = calculateScore(
       question.hand,
       question.melds,
       yaku,
@@ -52,6 +52,7 @@ export const ScoreQuiz: React.FC<ScoreQuizProps> = ({ initialIndex, initialWinTy
         winType,
       },
     );
+    const points = calcRoundedScore(han, fu, seatWind === 1, winType);
     const detail = calculateFuDetail(
       question.hand,
       question.melds,

--- a/src/components/ScoreTable.tsx
+++ b/src/components/ScoreTable.tsx
@@ -1,19 +1,11 @@
 import React from 'react';
+import { calcBase } from '../score/score';
 
 interface ScoreTableProps {
   isDealer: boolean;
   winType: 'ron' | 'tsumo';
 }
 
-function calcBase(han: number, fu: number): number {
-  if (han >= 13) return 8000; // kazoe yakuman
-  if (han >= 11) return 6000; // sanbaiman
-  if (han >= 8) return 4000; // baiman
-  if (han >= 6) return 3000; // haneman
-  const base = fu * Math.pow(2, han + 2);
-  if (han === 5 || base >= 2000) return 2000; // mangan
-  return base;
-}
 
 function formatScore(han: number, fu: number, isDealer: boolean, winType: 'ron' | 'tsumo'): string {
   const base = calcBase(han, fu);

--- a/src/score/score.ts
+++ b/src/score/score.ts
@@ -179,3 +179,24 @@ export function calculateScore(
   const points = base;
   return { han, fu, points };
 }
+
+export function calcBase(han: number, fu: number): number {
+  if (han >= 13) return 8000;
+  if (han >= 11) return 6000;
+  if (han >= 8) return 4000;
+  if (han >= 6) return 3000;
+  const base = fu * Math.pow(2, han + 2);
+  if (han === 5 || base >= 2000) return 2000;
+  return base;
+}
+
+export function calcRoundedScore(
+  han: number,
+  fu: number,
+  isDealer: boolean,
+  winType: 'ron' | 'tsumo',
+): number {
+  const base = calcBase(han, fu);
+  const mult = winType === 'ron' ? (isDealer ? 6 : 4) : isDealer ? 2 : 1;
+  return Math.ceil((base * mult) / 100) * 100;
+}


### PR DESCRIPTION
## Summary
- compute score rounding/bonus in `score.ts`
- reuse `calcBase` in `ScoreTable`
- calculate final payments in ScoreQuiz and update help text
- test ScoreQuiz with dealer ron scoring

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_6857d2bf72f8832aa3316da362a38c65