### PR TITLE
Remove seldom-used fu rows

### DIFF
--- a/src/components/ScoreTable.test.tsx
+++ b/src/components/ScoreTable.test.tsx
@@ -25,12 +25,4 @@ describe('ScoreTable', () => {
     expect(cells[2].textContent).toBe('500-1000');
   });
 
-  it('includes 120fu row showing child ron score', () => {
-    render(<ScoreTable isDealer={false} winType="ron" />);
-    const rows = screen.getAllByRole('row');
-    const row120 = rows[12];
-    const cells = within(row120).getAllByRole('cell');
-    // 120fu 1han -> base 120 * 2^3 = 960, ron child => 960*4=3840 -> 3900 after rounding
-    expect(cells[1].textContent).toBe('3900');
-  });
 });

--- a/src/components/ScoreTable.tsx
+++ b/src/components/ScoreTable.tsx
@@ -32,8 +32,8 @@ function formatScore(han: number, fu: number, isDealer: boolean, winType: 'ron' 
 }
 
 export const ScoreTable: React.FC<ScoreTableProps> = ({ isDealer, winType }) => {
-  // Display fu values up to the rarely-seen limit of 130
-  // so that even edge cases are shown in the table.
+  // Display fu values up to 110. Higher fu are extremely rare
+  // and are omitted to keep the table compact.
   const fuList = [
     20,
     25,
@@ -46,8 +46,6 @@ export const ScoreTable: React.FC<ScoreTableProps> = ({ isDealer, winType }) => 
     90,
     100,
     110,
-    120,
-    130,
   ];
   const hanList = [1, 2, 3, 4];
   return (
@@ -73,14 +71,6 @@ export const ScoreTable: React.FC<ScoreTableProps> = ({ isDealer, winType }) => 
             ))}
           </tr>
         ))}
-        <tr>
-          <td className="border px-2 py-1 text-center">満貫以上</td>
-          {hanList.map(h => (
-            <td key={`m${h}`} className="border px-2 py-1 text-center">
-              {formatScore(Math.max(h, 5), 30, isDealer, winType)}
-            </td>
-          ))}
-        </tr>
       </tbody>
     </table>
   );


### PR DESCRIPTION
## Summary
- remove 120+ fu rows and mangan label from score table
- drop related test

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857d375c49c832ab220a728062253cd