### PR TITLE
Update board layout

### DIFF
--- a/src/components/ScoreBoard.test.tsx
+++ b/src/components/ScoreBoard.test.tsx
@@ -1,0 +1,14 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ScoreBoard } from './ScoreBoard';
+
+describe('ScoreBoard', () => {
+  it('displays kyoku, wall count and kyotaku', () => {
+    render(<ScoreBoard kyoku={1} wallCount={69} kyotaku={0} />);
+    expect(screen.getByText('東1局')).toBeTruthy();
+    expect(screen.getByText('残り69')).toBeTruthy();
+    expect(screen.getByText('供託0')).toBeTruthy();
+  });
+});

--- a/src/components/ScoreBoard.tsx
+++ b/src/components/ScoreBoard.tsx
@@ -1,34 +1,21 @@
 import React from 'react';
-import { PlayerState } from '../types/mahjong';
-
 interface ScoreBoardProps {
-  players: PlayerState[];
   kyoku: number;
   wallCount: number;
   kyotaku: number;
 }
 
 export const ScoreBoard: React.FC<ScoreBoardProps> = ({
-  players,
   kyoku,
   wallCount,
   kyotaku,
 }) => {
   const kyokuStr = ['東1局', '東2局', '東3局', '東4局', '南1局', '南2局', '南3局', '南4局'][kyoku - 1] || '';
   return (
-    <div className="flex justify-between items-center p-2 bg-gray-200 rounded-lg shadow">
-      <div className="flex items-baseline gap-2">
-        <span className="font-bold">{kyokuStr}</span>
-        <span className="text-sm">残り{wallCount}</span>
-        <span className="text-sm">供託{kyotaku}</span>
-      </div>
-      <div className="flex gap-2 items-center">
-        {players.map(p => (
-          <span key={p.name} className="bg-white rounded px-2 py-1 shadow">
-            {p.name}: <span className="font-mono">{p.score}</span>
-          </span>
-        ))}
-      </div>
+    <div className="flex items-baseline gap-2 p-2 bg-gray-200 rounded-lg shadow">
+      <span className="font-bold">{kyokuStr}</span>
+      <span className="text-sm">残り{wallCount}</span>
+      <span className="text-sm">供託{kyotaku}</span>
     </div>
   );
 };

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -64,7 +64,9 @@ export const UIBoard: React.FC<UIBoardProps> = ({
     <div className="w-full grid grid-rows-3 grid-cols-3 gap-2 place-items-center">
       {/* 対面 */}
       <div className="row-start-1 col-start-2 flex flex-col items-center">
-        <div className="text-sm mb-1">{top.name}</div>
+        <div className="text-sm mb-1">
+          {top.name}: <span className="font-mono">{top.score}</span>
+        </div>
         {top.melds.length > 0 && (
           <div className="flex gap-1 mb-1">
             {top.melds.map((m, idx) => (
@@ -82,7 +84,9 @@ export const UIBoard: React.FC<UIBoardProps> = ({
 
       {/* 右側：下家 */}
       <div className="row-start-2 col-start-3 flex flex-col items-center">
-        <div className="text-sm mb-1">{right.name}</div>
+        <div className="text-sm mb-1">
+          {right.name}: <span className="font-mono">{right.score}</span>
+        </div>
         {right.melds.length > 0 && (
           <div className="flex gap-1 mb-1">
             {right.melds.map((m, idx) => (
@@ -100,7 +104,9 @@ export const UIBoard: React.FC<UIBoardProps> = ({
 
       {/* 左側：上家 */}
       <div className="row-start-2 col-start-1 flex flex-col items-center">
-        <div className="text-sm mb-1">{left.name}</div>
+        <div className="text-sm mb-1">
+          {left.name}: <span className="font-mono">{left.score}</span>
+        </div>
         {left.melds.length > 0 && (
           <div className="flex gap-1 mb-1">
             {left.melds.map((m, idx) => (
@@ -116,8 +122,9 @@ export const UIBoard: React.FC<UIBoardProps> = ({
         />
       </div>
 
-      {/* ドラ表示とスコア */}
-      <div className="row-start-2 col-start-2 flex flex-col items-center gap-2">
+      {/* ドラ表示と局情報 */}
+      <div className="row-start-2 col-start-2 flex items-center gap-4">
+        <ScoreBoard kyoku={kyoku} wallCount={wallCount} kyotaku={kyotaku} />
         <div className="flex flex-col items-center gap-1">
           <div className="text-sm">ドラ表示</div>
           <div className="flex gap-1">
@@ -126,12 +133,6 @@ export const UIBoard: React.FC<UIBoardProps> = ({
             ))}
           </div>
         </div>
-        <ScoreBoard
-          players={players}
-          kyoku={kyoku}
-          wallCount={wallCount}
-          kyotaku={kyotaku}
-        />
       </div>
 
       {/* 自分の手牌 */}
@@ -149,6 +150,9 @@ export const UIBoard: React.FC<UIBoardProps> = ({
           lastDiscard={lastDiscard}
           dataTestId="discard-seat-0"
         />
+        <div className="text-sm mb-1">
+          {me.name}: <span className="font-mono">{me.score}</span>
+        </div>
         <div className="text-lg mb-1">あなたの手牌</div>
         <div className="text-sm mb-2">
           {(() => {


### PR DESCRIPTION
## Summary
- compress vertical layout by moving round info next to dora display
- show each player's score beside their discard area
- update ScoreBoard component to only display round information
- add unit test for ScoreBoard

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857d4fdddfc832ab5c0c15154b8d734