### PR TITLE
Refactor Yaku interface naming

### DIFF
--- a/src/score/score.ts
+++ b/src/score/score.ts
@@ -1,5 +1,5 @@
 import { Tile, Meld } from '../types/mahjong';
-import { Yaku } from './yaku';
+import { ScoreYaku } from './yaku';
 
 function tileKey(t: Tile): string {
   return `${t.suit}-${t.rank}`;
@@ -167,7 +167,7 @@ function countDora(allTiles: Tile[], indicators: Tile[]): number {
 export function calculateScore(
   hand: Tile[],
   melds: Meld[],
-  yaku: Yaku[],
+  yaku: ScoreYaku[],
   doraIndicators: Tile[] = [],
   opts?: { seatWind?: number; roundWind?: number; winType?: 'ron' | 'tsumo' },
 ): { han: number; fu: number; points: number } {

--- a/src/score/yaku.ts
+++ b/src/score/yaku.ts
@@ -1,6 +1,6 @@
 import { Tile, Meld } from '../types/mahjong';
 
-export interface Yaku {
+export interface ScoreYaku {
   name: string;
   han: number;
 }
@@ -317,9 +317,9 @@ export function detectYaku(
     seatWind?: number;
     roundWind?: number;
   },
-): Yaku[] {
+): ScoreYaku[] {
   const allTiles = [...hand, ...melds.flatMap(m => m.tiles)];
-  const result: Yaku[] = [];
+  const result: ScoreYaku[] = [];
   const counts = countTiles(allTiles);
   const parsed = decomposeHand(allTiles);
   const isClosed = melds.length === 0;


### PR DESCRIPTION
## Summary
- rename scoring interface to `ScoreYaku`
- update all references to the new name

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857d9a96248832abe420ec9fa36e50e