### PR TITLE
Add modal behavior tests

### DIFF
--- a/src/components/HelpModal.test.tsx
+++ b/src/components/HelpModal.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { HelpModal } from './HelpModal';
+
+describe('HelpModal', () => {
+  afterEach(() => cleanup());
+
+  it('opens and closes via prop and button', () => {
+    const handleClose = vi.fn();
+    const { rerender } = render(
+      <HelpModal isOpen={false} onClose={handleClose} />,
+    );
+    expect(screen.queryByRole('heading', { name: '役一覧' })).toBeNull();
+    rerender(<HelpModal isOpen onClose={handleClose} />);
+    expect(screen.getByRole('heading', { name: '役一覧' })).toBeTruthy();
+    fireEvent.click(screen.getByLabelText('close'));
+    expect(handleClose).toHaveBeenCalled();
+  });
+
+  it('switches between tabs and shows ScoreTable', () => {
+    render(<HelpModal isOpen onClose={() => {}} />);
+    expect(screen.getByRole('heading', { name: '役一覧' })).toBeTruthy();
+    fireEvent.click(screen.getByText('点数表'));
+    expect(screen.getByRole('heading', { name: '点数表' })).toBeTruthy();
+    expect(screen.getByText('符\\翻')).toBeTruthy();
+    fireEvent.click(screen.getByText('役一覧'));
+    expect(screen.getByRole('heading', { name: '役一覧' })).toBeTruthy();
+    expect(screen.queryByText('符\\翻')).toBeNull();
+  });
+});

--- a/src/components/QuizHelpModal.test.tsx
+++ b/src/components/QuizHelpModal.test.tsx
@@ -1,0 +1,21 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { QuizHelpModal } from './QuizHelpModal';
+
+describe('QuizHelpModal', () => {
+  afterEach(() => cleanup());
+
+  it('opens and closes via prop and button', () => {
+    const handleClose = vi.fn();
+    const { rerender } = render(
+      <QuizHelpModal isOpen={false} onClose={handleClose} />,
+    );
+    expect(screen.queryByText('クイズヘルプ')).toBeNull();
+    rerender(<QuizHelpModal isOpen onClose={handleClose} />);
+    expect(screen.getByText('クイズヘルプ')).toBeTruthy();
+    fireEvent.click(screen.getByLabelText('close'));
+    expect(handleClose).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- test HelpModal open/close and tab switching
- test QuizHelpModal open/close behavior

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857d9a36144832ab368f8dd81094750