### PR TITLE
Reduce tile padding

### DIFF
--- a/src/components/TileView.test.tsx
+++ b/src/components/TileView.test.tsx
@@ -25,4 +25,12 @@ describe('TileView', () => {
     );
     expect(html).toContain('translateX(5px)');
   });
+
+  it('uses compact tile spacing', () => {
+    const tile: Tile = { suit: 'man', rank: 4, id: 'm4' };
+    const html = renderToStaticMarkup(<TileView tile={tile} />);
+    expect(html).toContain('px-0.5');
+    expect(html).toContain('py-px');
+    expect(html).toContain('leading-none');
+  });
 });

--- a/src/components/TileView.tsx
+++ b/src/components/TileView.tsx
@@ -65,7 +65,7 @@ export const TileView: React.FC<{
       : honorMap[tile.suit]?.[tile.rank] ?? '';
   return (
     <span
-      className={`relative inline-block border px-1 py-0.5 bg-white tile-font-size ${className ?? ''}`}
+      className={`relative inline-block border px-0.5 py-px leading-none bg-white tile-font-size ${className ?? ''}`}
       aria-label={kanji}
       style={{ transform: `rotate(${rotate}deg) ${extraTransform}` }}
     >


### PR DESCRIPTION
## Summary
- use tighter padding in `<TileView>` so each tile takes less space
- test for new compact tile classes

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857daa4e040832aaa0f2256111d3616