### PR TITLE
Use fake timers in GameController autoplay test

### DIFF
--- a/src/components/GameController.autoplay.test.tsx
+++ b/src/components/GameController.autoplay.test.tsx
@@ -1,11 +1,16 @@
 // @vitest-environment jsdom
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { GameController } from './GameController';
 
 describe('GameController auto play', () => {
+  vi.useFakeTimers();
+  afterEach(() => {
+    vi.useRealTimers();
+  });
   it('disables tile buttons when enabled', async () => {
+    vi.useRealTimers();
     const { container } = render(<GameController gameLength="tonnan" />);
     await screen.findAllByText('あなたの手牌');
     const checkbox = screen.getAllByLabelText('観戦モード')[0];
@@ -15,11 +20,14 @@ describe('GameController auto play', () => {
   });
 
   it('AI discards when toggled during player turn', async () => {
+    vi.useRealTimers();
     render(<GameController gameLength="tonnan" />);
     await screen.findAllByText('あなたの手牌');
+    vi.useFakeTimers();
     const checkbox = screen.getAllByLabelText('観戦モード')[0];
     fireEvent.click(checkbox);
-    await new Promise(r => setTimeout(r, 600));
+    vi.advanceTimersByTime(600);
+    vi.useRealTimers();
     const star = await screen.findByText('★');
     expect(star).toBeTruthy();
   });


### PR DESCRIPTION
## Summary
- enable fake timers and restore after each test
- use `vi.advanceTimersByTime` instead of real time delay in autoplay test

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857db6c89f4832a93826c10baaaf2a1