### PR TITLE
Remove tsumo message and tweak hand display

### DIFF
--- a/src/components/GameController.autoplay.test.tsx
+++ b/src/components/GameController.autoplay.test.tsx
@@ -12,7 +12,7 @@ describe('GameController auto play', () => {
   it('disables tile buttons when enabled', async () => {
     vi.useRealTimers();
     const { container } = render(<GameController gameLength="tonnan" />);
-    await screen.findAllByText('あなたの手牌');
+    await screen.findAllByText('手牌');
     const checkbox = screen.getAllByLabelText('観戦モード')[0];
     fireEvent.click(checkbox);
     const buttons = container.querySelectorAll('button');
@@ -22,7 +22,7 @@ describe('GameController auto play', () => {
   it('AI discards when toggled during player turn', async () => {
     vi.useRealTimers();
     render(<GameController gameLength="tonnan" />);
-    await screen.findAllByText('あなたの手牌');
+    await screen.findAllByText('手牌');
     vi.useFakeTimers();
     const checkbox = screen.getAllByLabelText('観戦モード')[0];
     fireEvent.click(checkbox);

--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -266,7 +266,7 @@ export const GameController: React.FC<Props> = ({ gameLength }) => {
       setTimeout(nextKyoku, 500);
       return;
     }
-    setMessage(`${p[currentIndex].name} がツモりました。`);
+
   };
 
   // 捨て牌処理（自分／AI共通）

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -159,7 +159,6 @@ export const UIBoard: React.FC<UIBoardProps> = ({
         <div className="text-sm mb-1">
           {me.name}: <span className="font-mono">{me.score}</span>
         </div>
-        <div className="text-lg mb-1">あなたの手牌</div>
         <div className="text-sm mb-2">
           {(() => {
             const base = Math.min(shanten.standard, shanten.chiitoi, shanten.kokushi);
@@ -181,6 +180,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
             : my.hand;
           return (
             <div className="flex gap-2 items-center">
+              <span className="text-xs text-gray-600">手牌</span>
               {handTiles.map(tile => {
                 const kanji =
                   tile.suit === 'man' || tile.suit === 'pin' || tile.suit === 'sou'


### PR DESCRIPTION
## Summary
- drop automatic message shown after drawing a tile
- show small "手牌" label to the left of the player's tiles
- update autoplay test expectations

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_6857e61d7400832aa842676f613187ac