### PR TITLE
Fix score calculation for ron/tsumo

### DIFF
--- a/src/score/score.ts
+++ b/src/score/score.ts
@@ -175,8 +175,9 @@ export function calculateScore(
   const dora = countDora(allTiles, doraIndicators);
   const han = yaku.reduce((sum, y) => sum + y.han, 0) + dora;
   const fu = calculateFu(hand, melds, opts);
-  const base = fu * Math.pow(2, han + 2);
-  const points = base;
+  const isDealer = opts?.seatWind === 1;
+  const winType = opts?.winType ?? 'ron';
+  const points = calcRoundedScore(han, fu, isDealer, winType);
   return { han, fu, points };
 }
 


### PR DESCRIPTION
## Summary
- compute rounded points in `calculateScore`
- update scoring test to expect child mangan value
- add test for dealer tsumo using calcRoundedScore logic

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857e6c982a8832aa8460fe26e07e10b