### PR TITLE
Add selectable tsumo and ron options

### DIFF
--- a/src/components/UIBoard.test.tsx
+++ b/src/components/UIBoard.test.tsx
@@ -242,3 +242,53 @@ describe('UIBoard discard orientation', () => {
     expect(leftTiles[leftTiles.length - 1].getAttribute('aria-label')).toBe('6索');
   });
 });
+
+describe('UIBoard win options', () => {
+  it('shows tsumo and pass buttons when tsumoOption true', () => {
+    render(
+      <UIBoard
+        players={[
+          createInitialPlayerState('me', false, 0),
+          createInitialPlayerState('ai1', true, 1),
+          createInitialPlayerState('ai2', true, 2),
+          createInitialPlayerState('ai3', true, 3),
+        ]}
+        dora={[]}
+        kyoku={1}
+        wallCount={70}
+        kyotaku={0}
+        onDiscard={() => {}}
+        isMyTurn={true}
+        shanten={{ standard: 0, chiitoi: 0, kokushi: 0 }}
+        lastDiscard={null}
+        tsumoOption={true}
+      />,
+    );
+    expect(screen.getByText('ツモ')).toBeTruthy();
+    expect(screen.getByText('スルー')).toBeTruthy();
+  });
+
+  it('shows ron and pass buttons when ronOption true', () => {
+    render(
+      <UIBoard
+        players={[
+          createInitialPlayerState('me', false, 0),
+          createInitialPlayerState('ai1', true, 1),
+          createInitialPlayerState('ai2', true, 2),
+          createInitialPlayerState('ai3', true, 3),
+        ]}
+        dora={[]}
+        kyoku={1}
+        wallCount={70}
+        kyotaku={0}
+        onDiscard={() => {}}
+        isMyTurn={true}
+        shanten={{ standard: 0, chiitoi: 0, kokushi: 0 }}
+        lastDiscard={null}
+        ronOption={true}
+      />,
+    );
+    expect(screen.getByText('ロン')).toBeTruthy();
+    expect(screen.getAllByText('スルー').length).toBe(1);
+  });
+});

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -34,6 +34,12 @@ interface UIBoardProps {
   chiOptions?: Tile[][];
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
   onChi?: (tiles: Tile[]) => void;
+  tsumoOption?: boolean;
+  onTsumo?: () => void;
+  onTsumoPass?: () => void;
+  ronOption?: boolean;
+  onRon?: () => void;
+  onRonPass?: () => void;
   playerIsAI?: boolean;
   onToggleAI?: () => void;
 }
@@ -56,6 +62,12 @@ export const UIBoard: React.FC<UIBoardProps> = ({
   onSelfKan,
   chiOptions,
   onChi,
+  tsumoOption,
+  onTsumo,
+  onTsumoPass,
+  ronOption,
+  onRon,
+  onRonPass,
   playerIsAI,
   onToggleAI,
 }) => {
@@ -269,6 +281,18 @@ export const UIBoard: React.FC<UIBoardProps> = ({
                 カン
               </button>
             ))}
+          </div>
+        )}
+        {tsumoOption && (
+          <div className="flex gap-2 mt-2">
+            <button className="px-2 py-1 bg-blue-200 rounded" onClick={() => onTsumo?.()}>ツモ</button>
+            <button className="px-2 py-1 bg-gray-200 rounded" onClick={() => onTsumoPass?.()}>スルー</button>
+          </div>
+        )}
+        {ronOption && (
+          <div className="flex gap-2 mt-2">
+            <button className="px-2 py-1 bg-red-200 rounded" onClick={() => onRon?.()}>ロン</button>
+            <button className="px-2 py-1 bg-gray-200 rounded" onClick={() => onRonPass?.()}>スルー</button>
           </div>
         )}
         {onRiichi && isMyTurn && canDeclareRiichi(me) && (


### PR DESCRIPTION
## Summary
- let players choose whether to win by tsumo or ron
- surface tsumo/ron buttons in UIBoard
- test new win options

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_6857e8026eb0832aa22ca8d03b219fb5