### PR TITLE
Enhance ScoreQuiz with dealer randomization

### DIFF
--- a/src/components/ScoreQuiz.test.tsx
+++ b/src/components/ScoreQuiz.test.tsx
@@ -11,7 +11,7 @@ afterEach(() => cleanup());
 
 describe('ScoreQuiz', () => {
   it('shows "正解！" when the guess is correct', () => {
-    render(<ScoreQuiz initialIndex={0} initialWinType="ron" />);
+    render(<ScoreQuiz initialIndex={0} initialWinType="ron" initialSeatWind={1} />);
     const input = screen.getByPlaceholderText('点数を入力');
     fireEvent.change(input, { target: { value: '11600' } });
     const button = screen.getByText('答える');
@@ -22,19 +22,27 @@ describe('ScoreQuiz', () => {
   });
 
   it('shows the correct answer with details when wrong', () => {
-    render(<ScoreQuiz initialIndex={0} initialWinType="ron" />);
+    render(<ScoreQuiz initialIndex={0} initialWinType="ron" initialSeatWind={1} />);
     const input = screen.getByPlaceholderText('点数を入力');
     fireEvent.change(input, { target: { value: '1000' } });
     const button = screen.getByText('答える');
     fireEvent.click(button);
-    expect(screen.getByText('不正解。正解: 11600点 (4翻 30符)')).toBeTruthy();
+    expect(screen.getByText('不正解。正解: 11600 (4翻 30符)')).toBeTruthy();
     expect(screen.getByText('Tanyao (1翻)')).toBeTruthy();
     expect(screen.getByText('基本符20')).toBeTruthy();
   });
 
   it('displays seat and round wind and win type', () => {
-    render(<ScoreQuiz initialIndex={0} initialWinType="ron" />);
+    render(<ScoreQuiz initialIndex={0} initialWinType="ron" initialSeatWind={1} />);
     expect(screen.getByText('場風: 東 / 自風: 東 / ロン')).toBeTruthy();
+  });
+
+  it('handles tsumo answers with split payments', () => {
+    render(<ScoreQuiz initialIndex={0} initialWinType="tsumo" initialSeatWind={2} />);
+    const input = screen.getByPlaceholderText('点数を入力');
+    fireEvent.change(input, { target: { value: '2000-4000' } });
+    fireEvent.click(screen.getByText('答える'));
+    expect(screen.getByText('正解！')).toBeTruthy();
   });
 
   it('opens help modal with score info', () => {

--- a/src/components/ScoreQuiz.tsx
+++ b/src/components/ScoreQuiz.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { sortHand } from './Player';
 import { TileView } from './TileView';
 import { detectYaku } from '../score/yaku';
-import { calculateScore, calcRoundedScore } from '../score/score';
+import { calculateScore, calcBase } from '../score/score';
 import { calculateFuDetail } from '../score/calculateFuDetail';
 import { useAgariQuiz } from '../quiz/useAgariQuiz';
 import { QuizHelpModal } from './QuizHelpModal';
@@ -10,21 +10,22 @@ import { QuizHelpModal } from './QuizHelpModal';
 interface ScoreQuizProps {
   initialIndex?: number;
   initialWinType?: 'ron' | 'tsumo';
+  initialSeatWind?: number;
 }
 
-export const ScoreQuiz: React.FC<ScoreQuizProps> = ({ initialIndex, initialWinType }) => {
-  const { question, winType, nextQuestion } = useAgariQuiz({ initialIndex, initialWinType });
-  const seatWind = 1;
+export const ScoreQuiz: React.FC<ScoreQuizProps> = ({ initialIndex, initialWinType, initialSeatWind }) => {
+  const { question, winType, seatWind, nextQuestion } = useAgariQuiz({ initialIndex, initialWinType, initialSeatWind });
   const roundWind = 1;
   const windNames: Record<number, string> = { 1: '東', 2: '南', 3: '西', 4: '北' };
   const [guess, setGuess] = useState('');
   const [result, setResult] = useState<
     | {
-        points: number;
+        answer: string;
         han: number;
         fu: number;
         yaku: string[];
         fuSteps: string[];
+        explanation: string;
         correct: boolean;
       }
     | null
@@ -52,7 +53,24 @@ export const ScoreQuiz: React.FC<ScoreQuizProps> = ({ initialIndex, initialWinTy
         winType,
       },
     );
-    const points = calcRoundedScore(han, fu, seatWind === 1, winType);
+    const base = calcBase(han, fu);
+    let answer = '';
+    let explanation = '';
+    if (winType === 'ron') {
+      const mult = seatWind === 1 ? 6 : 4;
+      const total = Math.ceil((base * mult) / 100) * 100;
+      answer = total.toString();
+      explanation = `基本点${base}に${seatWind === 1 ? '親' : '子'}のロンなので${mult}倍して、100の位で切り上げて${total}点`;
+    } else if (seatWind === 1) {
+      const each = Math.ceil((base * 2) / 100) * 100;
+      answer = `${each}オール`;
+      explanation = `基本点${base}で親のツモなので2倍の${base * 2}を100の位で切り上げて${each}点オール`;
+    } else {
+      const nonDealer = Math.ceil(base / 100) * 100;
+      const dealerPay = Math.ceil((base * 2) / 100) * 100;
+      answer = `${nonDealer}-${dealerPay}`;
+      explanation = `基本点${base}で子のツモなので他家から${nonDealer}点、親からは2倍の${base * 2}を100の位で切り上げて${dealerPay}点`;
+    }
     const detail = calculateFuDetail(
       question.hand,
       question.melds,
@@ -60,13 +78,14 @@ export const ScoreQuiz: React.FC<ScoreQuizProps> = ({ initialIndex, initialWinTy
       roundWind,
       winType,
     );
-    const correct = Number(guess) === points;
+    const correct = guess.trim() === answer;
     setResult({
-      points,
+      answer,
       han,
       fu,
       yaku: yaku.map(y => `${y.name} (${y.han}翻)`),
       fuSteps: detail.steps,
+      explanation,
       correct,
     });
   };
@@ -113,7 +132,7 @@ export const ScoreQuiz: React.FC<ScoreQuizProps> = ({ initialIndex, initialWinTy
           <div>
             {result.correct
               ? '正解！'
-              : `不正解。正解: ${result.points}点 (${result.han}翻 ${result.fu}符)`}
+              : `不正解。正解: ${result.answer} (${result.han}翻 ${result.fu}符)`}
           </div>
           <ul className="list-disc list-inside text-sm">
             {result.yaku.map((y, i) => (
@@ -125,6 +144,7 @@ export const ScoreQuiz: React.FC<ScoreQuizProps> = ({ initialIndex, initialWinTy
               <li key={`f${i}`}>{s}</li>
             ))}
           </ul>
+          <div className="text-sm mt-1">{result.explanation}</div>
         </div>
       )}
       <button onClick={handleNext} className="mt-2 px-2 py-1 bg-green-200 rounded">

--- a/src/quiz/useAgariQuiz.ts
+++ b/src/quiz/useAgariQuiz.ts
@@ -5,16 +5,21 @@ import { generateRandomAgari } from './randomAgari';
 interface Options {
   initialIndex?: number;
   initialWinType?: 'ron' | 'tsumo';
+  initialSeatWind?: number;
 }
 
 export function useAgariQuiz(options: Options = {}) {
-  const { initialIndex, initialWinType } = options;
+  const { initialIndex, initialWinType, initialSeatWind } = options;
   const [idx, setIdx] = useState(initialIndex ?? 0);
   const [question, setQuestion] = useState(() =>
     initialIndex !== undefined ? SAMPLE_HANDS[initialIndex] : generateRandomAgari(),
   );
   const [winType, setWinType] = useState<'ron' | 'tsumo'>(
     initialWinType ?? (Math.random() < 0.5 ? 'ron' : 'tsumo'),
+  );
+  const randomSeat = () => Math.ceil(Math.random() * 4);
+  const [seatWind, setSeatWind] = useState<number>(
+    initialSeatWind ?? randomSeat(),
   );
 
   const nextQuestion = () => {
@@ -26,7 +31,8 @@ export function useAgariQuiz(options: Options = {}) {
       setQuestion(generateRandomAgari());
     }
     setWinType(Math.random() < 0.5 ? 'ron' : 'tsumo');
+    setSeatWind(randomSeat());
   };
 
-  return { idx, question, winType, nextQuestion };
+  return { idx, question, winType, seatWind, nextQuestion };
 }


### PR DESCRIPTION
## Summary
- randomize seat wind in agari quiz hook
- handle tsumo answers in ScoreQuiz and show scoring explanation
- update ScoreQuiz tests for new behavior

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857e765a410832aa7d04288a8da5741