### PR TITLE
Add rule status tab to HelpModal

### DIFF
--- a/src/components/HelpModal.test.tsx
+++ b/src/components/HelpModal.test.tsx
@@ -29,4 +29,12 @@ describe('HelpModal', () => {
     expect(screen.getByRole('heading', { name: '役一覧' })).toBeTruthy();
     expect(screen.queryByText('符\\翻')).toBeNull();
   });
+
+  it('displays rule status list', () => {
+    render(<HelpModal isOpen onClose={() => {}} />);
+    fireEvent.click(screen.getByText('ルール対応状況'));
+    expect(screen.getByRole('heading', { name: 'ルール対応状況' })).toBeTruthy();
+    expect(screen.getByText('リーチ')).toBeTruthy();
+    expect(screen.getByText('ドラ')).toBeTruthy();
+  });
 });

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { YAKU_LIST } from '../yaku';
+import { RULE_STATUS } from '../ruleStatus';
 import { ScoreTable } from './ScoreTable';
 
 interface HelpModalProps {
@@ -8,7 +9,7 @@ interface HelpModalProps {
 }
 
 export const HelpModal: React.FC<HelpModalProps> = ({ isOpen, onClose }) => {
-  const [view, setView] = useState<'yaku' | 'score'>('yaku');
+  const [view, setView] = useState<'yaku' | 'score' | 'rules'>('yaku');
   const [isDealer, setIsDealer] = useState(false);
   const [winType, setWinType] = useState<'ron' | 'tsumo'>('ron');
   if (!isOpen) return null;
@@ -16,7 +17,13 @@ export const HelpModal: React.FC<HelpModalProps> = ({ isOpen, onClose }) => {
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
       <div className="bg-white rounded-lg p-4 max-w-md w-full shadow-lg">
         <div className="flex justify-between items-center mb-2">
-          <h2 className="text-lg font-bold">{view === 'yaku' ? '役一覧' : '点数表'}</h2>
+          <h2 className="text-lg font-bold">
+            {view === 'yaku'
+              ? '役一覧'
+              : view === 'score'
+                ? '点数表'
+                : 'ルール対応状況'}
+          </h2>
           <button
             onClick={onClose}
             className="text-gray-500 hover:text-black font-bold"
@@ -37,6 +44,12 @@ export const HelpModal: React.FC<HelpModalProps> = ({ isOpen, onClose }) => {
             onClick={() => setView('score')}
           >
             点数表
+          </button>
+          <button
+            className={`px-2 py-1 rounded ${view === 'rules' ? 'bg-blue-200' : 'bg-gray-200'}`}
+            onClick={() => setView('rules')}
+          >
+            ルール対応状況
           </button>
         </div>
         {view === 'yaku' ? (
@@ -62,7 +75,7 @@ export const HelpModal: React.FC<HelpModalProps> = ({ isOpen, onClose }) => {
               </tbody>
             </table>
           </div>
-        ) : (
+        ) : view === 'score' ? (
           <div className="space-y-2">
             <div className="flex gap-2">
               <label>
@@ -101,6 +114,27 @@ export const HelpModal: React.FC<HelpModalProps> = ({ isOpen, onClose }) => {
             <div className="max-h-96 overflow-y-auto">
               <ScoreTable isDealer={isDealer} winType={winType} />
             </div>
+          </div>
+        ) : (
+          <div className="max-h-96 overflow-y-auto">
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr>
+                  <th className="border px-2 py-1">用語</th>
+                  <th className="border px-2 py-1">実装状況</th>
+                </tr>
+              </thead>
+              <tbody>
+                {RULE_STATUS.map(r => (
+                  <tr key={r.term}>
+                    <td className="border px-2 py-1 font-semibold">{r.term}</td>
+                    <td className="border px-2 py-1 text-center">
+                      {r.implemented ? '○' : '×'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
         )}
       </div>

--- a/src/ruleStatus.ts
+++ b/src/ruleStatus.ts
@@ -1,0 +1,12 @@
+export interface RuleStatus {
+  term: string;
+  implemented: boolean;
+}
+
+export const RULE_STATUS: RuleStatus[] = [
+  { term: 'リーチ', implemented: true },
+  { term: 'ドラ', implemented: true },
+  { term: '本場', implemented: false },
+  { term: '裏ドラ', implemented: false },
+  { term: '一発', implemented: false },
+];


### PR DESCRIPTION
## Summary
- list rule implementation status in new `ruleStatus.ts`
- expose rule status in HelpModal with new tab "ルール対応状況"
- show rule terms and whether implemented
- test rule status tab rendering

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857e9c2ca14832a99e80de91e637e8f