### PR TITLE
Move fu/score help into main HelpModal

### DIFF
--- a/src/components/FuQuiz.test.tsx
+++ b/src/components/FuQuiz.test.tsx
@@ -32,9 +32,4 @@ describe('FuQuiz', () => {
     expect(screen.getByText('場風: 東 / 自風: 東 / ロン')).toBeTruthy();
   });
 
-  it('opens help modal', () => {
-    render(<FuQuiz initialIndex={0} initialWinType="ron" />);
-    fireEvent.click(screen.getByLabelText('ヘルプ'));
-    expect(screen.getByText('基本符20')).toBeTruthy();
-  });
 });

--- a/src/components/FuQuiz.tsx
+++ b/src/components/FuQuiz.tsx
@@ -4,7 +4,6 @@ import { calculateFuDetail } from '../score/calculateFuDetail';
 import { TileView } from './TileView';
 import { sortHand } from './Player';
 import { useAgariQuiz } from '../quiz/useAgariQuiz';
-import { QuizHelpModal } from './QuizHelpModal';
 
 interface FuQuizProps {
   initialIndex?: number;
@@ -23,7 +22,6 @@ export const FuQuiz: React.FC<FuQuizProps> = ({ initialIndex, initialWinType }) 
   const [result, setResult] = useState<{ fu: number; steps: string[]; correct: boolean } | null>(
     null,
   );
-  const [helpOpen, setHelpOpen] = useState(false);
   const fullHand = sortHand([...question.hand, ...question.melds.flatMap(m => m.tiles)]);
 
   const onSubmit = (e: React.FormEvent) => {
@@ -57,13 +55,6 @@ export const FuQuiz: React.FC<FuQuizProps> = ({ initialIndex, initialWinType }) 
           場風: {windNames[roundWind]} / 自風: {windNames[seatWind]} /
           {winType === 'tsumo' ? ' ツモ' : ' ロン'}
         </div>
-        <button
-          onClick={() => setHelpOpen(true)}
-          className="w-6 h-6 flex items-center justify-center rounded-full bg-white shadow text-xs font-bold hover:bg-gray-100"
-          aria-label="ヘルプ"
-        >
-          ?
-        </button>
       </div>
       <div className="flex gap-1 mb-2 flex-wrap">
         {fullHand.map(t => (
@@ -92,7 +83,6 @@ export const FuQuiz: React.FC<FuQuizProps> = ({ initialIndex, initialWinType }) 
       <button onClick={handleNext} className="mt-2 px-2 py-1 bg-green-200 rounded">
         次の問題
       </button>
-      <QuizHelpModal isOpen={helpOpen} onClose={() => setHelpOpen(false)} />
     </div>
   );
 };

--- a/src/components/HelpModal.test.tsx
+++ b/src/components/HelpModal.test.tsx
@@ -25,6 +25,9 @@ describe('HelpModal', () => {
     fireEvent.click(screen.getByText('点数表'));
     expect(screen.getByRole('heading', { name: '点数表' })).toBeTruthy();
     expect(screen.getByText('符\\翻')).toBeTruthy();
+    fireEvent.click(screen.getByText('計算方法'));
+    expect(screen.getByRole('heading', { name: '計算方法' })).toBeTruthy();
+    expect(screen.getByText('基本符20')).toBeTruthy();
     fireEvent.click(screen.getByText('役一覧'));
     expect(screen.getByRole('heading', { name: '役一覧' })).toBeTruthy();
     expect(screen.queryByText('符\\翻')).toBeNull();

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -8,7 +8,7 @@ interface HelpModalProps {
 }
 
 export const HelpModal: React.FC<HelpModalProps> = ({ isOpen, onClose }) => {
-  const [view, setView] = useState<'yaku' | 'score'>('yaku');
+  const [view, setView] = useState<'yaku' | 'score' | 'calc'>('yaku');
   const [isDealer, setIsDealer] = useState(false);
   const [winType, setWinType] = useState<'ron' | 'tsumo'>('ron');
   if (!isOpen) return null;
@@ -16,7 +16,9 @@ export const HelpModal: React.FC<HelpModalProps> = ({ isOpen, onClose }) => {
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
       <div className="bg-white rounded-lg p-4 max-w-md w-full shadow-lg">
         <div className="flex justify-between items-center mb-2">
-          <h2 className="text-lg font-bold">{view === 'yaku' ? '役一覧' : '点数表'}</h2>
+          <h2 className="text-lg font-bold">
+            {view === 'yaku' ? '役一覧' : view === 'score' ? '点数表' : '計算方法'}
+          </h2>
           <button
             onClick={onClose}
             className="text-gray-500 hover:text-black font-bold"
@@ -37,6 +39,12 @@ export const HelpModal: React.FC<HelpModalProps> = ({ isOpen, onClose }) => {
             onClick={() => setView('score')}
           >
             点数表
+          </button>
+          <button
+            className={`px-2 py-1 rounded ${view === 'calc' ? 'bg-blue-200' : 'bg-gray-200'}`}
+            onClick={() => setView('calc')}
+          >
+            計算方法
           </button>
         </div>
         {view === 'yaku' ? (
@@ -62,7 +70,7 @@ export const HelpModal: React.FC<HelpModalProps> = ({ isOpen, onClose }) => {
               </tbody>
             </table>
           </div>
-        ) : (
+        ) : view === 'score' ? (
           <div className="space-y-2">
             <div className="flex gap-2">
               <label>
@@ -100,6 +108,30 @@ export const HelpModal: React.FC<HelpModalProps> = ({ isOpen, onClose }) => {
             </div>
             <div className="max-h-96 overflow-y-auto">
               <ScoreTable isDealer={isDealer} winType={winType} />
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-2 text-sm">
+            <div>
+              <h3 className="font-semibold mb-1">符計算</h3>
+              <ul className="list-disc list-inside space-y-1">
+                <li>基本符20</li>
+                <li>雀頭が三元牌なら+2、自風なら+2、場風なら+2</li>
+                <li>刻子: 中張牌4符 / 么九牌8符</li>
+                <li>カン: 中張牌16符 / 么九牌32符</li>
+                <li>ツモ上がり +2</li>
+                <li>面前ロン +10</li>
+                <li>最後に10の位へ切り上げ</li>
+              </ul>
+            </div>
+            <div>
+              <h3 className="font-semibold mb-1">点数計算</h3>
+              <ul className="list-disc list-inside space-y-1">
+                <li>基本点 = 符 × 2^(翻 + 2)</li>
+                <li>ロンは子×4 / 親×6、ツモは子×1 / 親×2</li>
+                <li>掛けた後100点単位へ切り上げ</li>
+                <li>例: 30符4翻 親ロン → 30 × 2^6 × 6 = 11520 → 11600</li>
+              </ul>
             </div>
           </div>
         )}

--- a/src/components/ScoreQuiz.test.tsx
+++ b/src/components/ScoreQuiz.test.tsx
@@ -37,10 +37,4 @@ describe('ScoreQuiz', () => {
     expect(screen.getByText('場風: 東 / 自風: 東 / ロン')).toBeTruthy();
   });
 
-  it('opens help modal with score info', () => {
-    render(<ScoreQuiz initialIndex={0} initialWinType="ron" />);
-    fireEvent.click(screen.getByLabelText('ヘルプ'));
-    expect(screen.getByText('基本点 = 符 × 2^(翻 + 2)')).toBeTruthy();
-    expect(screen.getByText('ロンは子×4 / 親×6、ツモは子×1 / 親×2')).toBeTruthy();
-  });
 });

--- a/src/components/ScoreQuiz.tsx
+++ b/src/components/ScoreQuiz.tsx
@@ -5,7 +5,6 @@ import { detectYaku } from '../score/yaku';
 import { calculateScore, calcRoundedScore } from '../score/score';
 import { calculateFuDetail } from '../score/calculateFuDetail';
 import { useAgariQuiz } from '../quiz/useAgariQuiz';
-import { QuizHelpModal } from './QuizHelpModal';
 
 interface ScoreQuizProps {
   initialIndex?: number;
@@ -29,7 +28,6 @@ export const ScoreQuiz: React.FC<ScoreQuizProps> = ({ initialIndex, initialWinTy
       }
     | null
   >(null);
-  const [helpOpen, setHelpOpen] = useState(false);
 
   const fullHand = sortHand([...question.hand, ...question.melds.flatMap(m => m.tiles)]);
 
@@ -84,13 +82,6 @@ export const ScoreQuiz: React.FC<ScoreQuizProps> = ({ initialIndex, initialWinTy
           場風: {windNames[roundWind]} / 自風: {windNames[seatWind]} /
           {winType === 'tsumo' ? ' ツモ' : ' ロン'}
         </div>
-        <button
-          onClick={() => setHelpOpen(true)}
-          className="w-6 h-6 flex items-center justify-center rounded-full bg-white shadow text-xs font-bold hover:bg-gray-100"
-          aria-label="ヘルプ"
-        >
-          ?
-        </button>
       </div>
       <div className="flex gap-1 mb-2 flex-wrap">
         {fullHand.map(t => (
@@ -130,11 +121,6 @@ export const ScoreQuiz: React.FC<ScoreQuizProps> = ({ initialIndex, initialWinTy
       <button onClick={handleNext} className="mt-2 px-2 py-1 bg-green-200 rounded">
         次の問題
       </button>
-      <QuizHelpModal
-        isOpen={helpOpen}
-        onClose={() => setHelpOpen(false)}
-        showScore
-      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add "計算方法" tab to HelpModal and include fu/score help content
- remove per-quiz help buttons
- update tests for new tab and removed buttons

## Testing
- `npx -y -p node@20 npm run lint`
- `npx -y -p node@20 npm run type-check`
- `npx -y -p node@20 npm run build`
- `npx -y -p node@20 npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857e90fdf88832abf59fdc03bcc0e43