### PR TITLE
Add riichi discard logic and UI indicators

### DIFF
--- a/src/components/Player.ts
+++ b/src/components/Player.ts
@@ -47,10 +47,14 @@ export function drawTiles(player: PlayerState, wall: Tile[], count: number): { p
   };
 }
 
-export function discardTile(player: PlayerState, tileId: string): PlayerState {
+export function discardTile(
+  player: PlayerState,
+  tileId: string,
+  riichiDiscard = false,
+): PlayerState {
   const idx = player.hand.findIndex(t => t.id === tileId);
   if (idx === -1) return player;
-  const tile = player.hand[idx];
+  const tile = { ...player.hand[idx], riichiDiscard };
   const newHand = [...player.hand];
   newHand.splice(idx, 1);
   return {
@@ -59,6 +63,15 @@ export function discardTile(player: PlayerState, tileId: string): PlayerState {
     discard: [...player.discard, tile],
     drawnTile: null,
   };
+}
+
+export function canDiscardTile(player: PlayerState, tileId: string): boolean {
+  if (!player.isRiichi) return true;
+  return player.drawnTile?.id === tileId;
+}
+
+export function canCallMeld(player: PlayerState): boolean {
+  return !player.isRiichi;
 }
 
 export function claimMeld(

--- a/src/components/RiverView.test.tsx
+++ b/src/components/RiverView.test.tsx
@@ -35,4 +35,11 @@ describe('RiverView', () => {
     expect(div.children.length).toBe(RESERVED_RIVER_SLOTS);
   });
 
+  it('rotates riichi discards', () => {
+    const tiles = [t('man', 1, 'a'), { ...t('man', 2, 'b'), riichiDiscard: true }];
+    render(<RiverView tiles={tiles} seat={0} lastDiscard={null} dataTestId="rv" />);
+    const tileEls = screen.getByTestId('rv').querySelectorAll('[style]');
+    expect(tileEls[1].getAttribute('style')).toContain('rotate(90deg)');
+  });
+
 });

--- a/src/components/RiverView.tsx
+++ b/src/components/RiverView.tsx
@@ -70,7 +70,11 @@ export const RiverView: React.FC<RiverViewProps> = ({
         <TileView
           key={tile.id}
           tile={tile}
-          rotate={seatRotation(seat) - seatRiverRotation(seat) + (tile.called ? 90 : 0)}
+          rotate={
+            seatRotation(seat) -
+            seatRiverRotation(seat) +
+            (tile.called || tile.riichiDiscard ? 90 : 0)
+          }
           extraTransform={tile.called ? calledOffset(seat) : ''}
           isShonpai={lastDiscard?.tile.id === tile.id && lastDiscard.isShonpai}
         />

--- a/src/components/UIBoard.test.tsx
+++ b/src/components/UIBoard.test.tsx
@@ -249,6 +249,30 @@ describe('UIBoard discard orientation', () => {
   });
 });
 
+describe('UIBoard riichi indicators', () => {
+  it('shows 1000点棒 in front of rivers', () => {
+    const me = { ...createInitialPlayerState('me', false, 0), isRiichi: true };
+    me.discard = [t('man', 1, 'a')];
+    const ai = { ...createInitialPlayerState('ai', true, 1), isRiichi: true };
+    ai.discard = [t('pin', 2, 'b')];
+    render(
+      <UIBoard
+        players={[me, ai, createInitialPlayerState('ai2', true, 2), createInitialPlayerState('ai3', true, 3)]}
+        dora={[]}
+        kyoku={1}
+        wallCount={70}
+        kyotaku={0}
+        honba={0}
+        onDiscard={() => {}}
+        isMyTurn={true}
+        shanten={{ standard: 0, chiitoi: 0, kokushi: 0 }}
+        lastDiscard={null}
+      />,
+    );
+    expect(screen.getAllByText('1000点棒').length).toBe(2);
+  });
+});
+
 describe('UIBoard win options', () => {
   it('shows tsumo and pass buttons when tsumoOption true', () => {
     render(

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -94,6 +94,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
             ))}
           </div>
         )}
+        {top.isRiichi && <div className="text-xs">1000点棒</div>}
         <RiverView
           tiles={top.discard}
           seat={top.seat}
@@ -114,6 +115,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
             ))}
           </div>
         )}
+        {right.isRiichi && <div className="text-xs">1000点棒</div>}
         <RiverView
           tiles={right.discard}
           seat={right.seat}
@@ -134,6 +136,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
             ))}
           </div>
         )}
+        {left.isRiichi && <div className="text-xs">1000点棒</div>}
         <RiverView
           tiles={left.discard}
           seat={left.seat}
@@ -164,6 +167,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
             ))}
           </div>
         )}
+        {me.isRiichi && <div className="text-xs">1000点棒</div>}
         <RiverView
           tiles={me.discard}
           seat={me.seat}

--- a/src/types/mahjong.ts
+++ b/src/types/mahjong.ts
@@ -7,6 +7,8 @@ export interface Tile {
   id: string;   // ユニーク識別子
   /** true if this discard was claimed for a meld */
   called?: boolean;
+  /** true if discarded after declaring riichi */
+  riichiDiscard?: boolean;
 }
 
 export type MeldType = 'pon' | 'chi' | 'kan';


### PR DESCRIPTION
## Summary
- extend `Tile` interface with `riichiDiscard` flag
- add discard/call restrictions after riichi
- rotate riichi discards sideways and show riichi sticks on board
- provide helper functions and tests for new behaviour

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_6857eefef978832abd8081fd2e2c2830