### PR TITLE
Enhance quiz output with winning tile

### DIFF
--- a/src/components/FuQuiz.test.tsx
+++ b/src/components/FuQuiz.test.tsx
@@ -29,7 +29,7 @@ describe('FuQuiz', () => {
 
   it('displays seat and round wind and win type', () => {
     render(<FuQuiz initialIndex={0} initialWinType="ron" />);
-    expect(screen.getByText('場風: 東 / 自風: 東 / ロン')).toBeTruthy();
+    expect(screen.getByText('場風: 東 / 自風: 東 / ロン: 5筒')).toBeTruthy();
   });
 
   it('opens help modal', () => {

--- a/src/components/FuQuiz.tsx
+++ b/src/components/FuQuiz.tsx
@@ -4,6 +4,7 @@ import { calculateFuDetail } from '../score/calculateFuDetail';
 import { TileView } from './TileView';
 import { sortHand } from './Player';
 import { useAgariQuiz } from '../quiz/useAgariQuiz';
+import { tileToKanji } from '../utils/tileString';
 import { QuizHelpModal } from './QuizHelpModal';
 
 interface FuQuizProps {
@@ -55,7 +56,9 @@ export const FuQuiz: React.FC<FuQuizProps> = ({ initialIndex, initialWinType }) 
       <div className="flex justify-between items-center text-sm mb-1">
         <div>
           場風: {windNames[roundWind]} / 自風: {windNames[seatWind]} /
-          {winType === 'tsumo' ? ' ツモ' : ' ロン'}
+          {winType === 'tsumo'
+            ? ' ツモ'
+            : ` ロン: ${tileToKanji(question.winningTile)}`}
         </div>
         <button
           onClick={() => setHelpOpen(true)}

--- a/src/components/ScoreQuiz.test.tsx
+++ b/src/components/ScoreQuiz.test.tsx
@@ -34,7 +34,7 @@ describe('ScoreQuiz', () => {
 
   it('displays seat and round wind and win type', () => {
     render(<ScoreQuiz initialIndex={0} initialWinType="ron" initialSeatWind={1} />);
-    expect(screen.getByText('場風: 東 / 自風: 東 / ロン')).toBeTruthy();
+    expect(screen.getByText('場風: 東 / 自風: 東 / ロン: 5筒')).toBeTruthy();
   });
 
   it('handles tsumo answers with split payments', () => {

--- a/src/components/ScoreQuiz.tsx
+++ b/src/components/ScoreQuiz.tsx
@@ -5,6 +5,7 @@ import { detectYaku } from '../score/yaku';
 import { calculateScore, calcBase } from '../score/score';
 import { calculateFuDetail } from '../score/calculateFuDetail';
 import { useAgariQuiz } from '../quiz/useAgariQuiz';
+import { tileToKanji } from '../utils/tileString';
 import { QuizHelpModal } from './QuizHelpModal';
 
 interface ScoreQuizProps {
@@ -101,7 +102,9 @@ export const ScoreQuiz: React.FC<ScoreQuizProps> = ({ initialIndex, initialWinTy
       <div className="flex justify-between items-center text-sm mb-1">
         <div>
           場風: {windNames[roundWind]} / 自風: {windNames[seatWind]} /
-          {winType === 'tsumo' ? ' ツモ' : ' ロン'}
+          {winType === 'tsumo'
+            ? ' ツモ'
+            : ` ロン: ${tileToKanji(question.winningTile)}`}
         </div>
         <button
           onClick={() => setHelpOpen(true)}

--- a/src/quiz/randomAgari.test.ts
+++ b/src/quiz/randomAgari.test.ts
@@ -3,10 +3,11 @@ import { generateRandomAgari } from './randomAgari';
 import { isWinningHand } from '../score/yaku';
 
 describe('generateRandomAgari', () => {
-  it('creates a 14-tile winning hand', () => {
-    const { hand, melds } = generateRandomAgari();
+  it('creates a 14-tile winning hand with a winning tile', () => {
+    const { hand, melds, winningTile } = generateRandomAgari();
     expect(hand).toHaveLength(14);
     expect(melds).toHaveLength(0);
+    expect(hand.includes(winningTile)).toBe(true);
     expect(isWinningHand(hand)).toBe(true);
   });
 });

--- a/src/quiz/randomAgari.ts
+++ b/src/quiz/randomAgari.ts
@@ -5,6 +5,7 @@ import { sortHand } from '../components/Player';
 export interface AgariHand {
   hand: Tile[];
   melds: Meld[];
+  winningTile: Tile;
 }
 
 function drawTiles(wall: Tile[], suit: Suit, rank: number, count: number): Tile[] {
@@ -68,7 +69,8 @@ export function generateRandomAgari(): AgariHand {
         }
       }
 
-      return { hand: sortHand(hand), melds: [] };
+      const sorted = sortHand(hand);
+      return { hand: sorted, melds: [], winningTile: sorted[sorted.length - 1] };
     } catch (e) {
       // Retry if a draw failed due to insufficient tiles
     }

--- a/src/quiz/sampleHands.test.ts
+++ b/src/quiz/sampleHands.test.ts
@@ -3,12 +3,13 @@ import { SAMPLE_HANDS } from './sampleHands';
 import { calculateFu } from '../score/score';
 
 describe('SAMPLE_HANDS', () => {
-  it('calculates expected fu', () => {
+  it('calculates expected fu and includes winning tile', () => {
     const expected = [20, 30, 60];
     SAMPLE_HANDS.forEach((hand, i) => {
       const fu = calculateFu(hand.hand, hand.melds);
       // 基本符20のみ、役牌ポンやカンで加算した値になるはず
       expect(fu).toBe(expected[i]);
+      expect(hand.hand.some(t => t.id === hand.winningTile.id)).toBe(true);
     });
   });
 });

--- a/src/quiz/sampleHands.ts
+++ b/src/quiz/sampleHands.ts
@@ -5,6 +5,7 @@ const t = (suit: Tile['suit'], rank: number, id: string): Tile => ({ suit, rank,
 export interface SampleHand {
   hand: Tile[];
   melds: Meld[];
+  winningTile: Tile;
 }
 
 export const SAMPLE_HANDS: SampleHand[] = [
@@ -17,6 +18,7 @@ export const SAMPLE_HANDS: SampleHand[] = [
       t('pin',5,'p5a'),t('pin',5,'p5b'),
     ],
     melds: [],
+    winningTile: t('pin',5,'p5b'),
   },
   {
     hand: [
@@ -28,6 +30,7 @@ export const SAMPLE_HANDS: SampleHand[] = [
     melds: [
       { type: 'pon', tiles: [t('dragon',1,'d1a'),t('dragon',1,'d1b'),t('dragon',1,'d1c')], fromPlayer: 1, calledTileId: 'd1a' },
     ],
+    winningTile: t('man',5,'m5b'),
   },
   {
     hand: [
@@ -39,6 +42,7 @@ export const SAMPLE_HANDS: SampleHand[] = [
     melds: [
       { type: 'kan', tiles: [t('dragon',1,'k1a'),t('dragon',1,'k1b'),t('dragon',1,'k1c')], fromPlayer: 2, calledTileId: 'k1a' },
     ],
+    winningTile: t('man',5,'m5b'),
   },
 ];
 
@@ -48,13 +52,15 @@ function rand(): string {
 
 function randomizeIds(hand: SampleHand): SampleHand {
   const handTiles = hand.hand.map(t => ({ ...t, id: rand() }));
+  const winIdx = hand.hand.findIndex(t => t.id === hand.winningTile.id);
+  const winningTile = winIdx >= 0 ? handTiles[winIdx] : { ...hand.winningTile, id: rand() };
   const melds = hand.melds.map(m => {
     const tiles = m.tiles.map(t => ({ ...t, id: rand() }));
     const idx = m.tiles.findIndex(t => t.id === m.calledTileId);
     const calledTileId = idx >= 0 ? tiles[idx].id : rand();
     return { ...m, tiles, calledTileId };
   });
-  return { hand: handTiles, melds };
+  return { hand: handTiles, melds, winningTile };
 }
 
 export function randomizeSampleHands(hands: SampleHand[]): SampleHand[] {

--- a/src/quiz/useAgariQuiz.ts
+++ b/src/quiz/useAgariQuiz.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { SAMPLE_HANDS } from './sampleHands';
-import { generateRandomAgari } from './randomAgari';
+import { generateRandomAgari, AgariHand } from './randomAgari';
 
 interface Options {
   initialIndex?: number;
@@ -8,10 +8,12 @@ interface Options {
   initialSeatWind?: number;
 }
 
+export interface AgariQuestion extends AgariHand {}
+
 export function useAgariQuiz(options: Options = {}) {
   const { initialIndex, initialWinType, initialSeatWind } = options;
   const [idx, setIdx] = useState(initialIndex ?? 0);
-  const [question, setQuestion] = useState(() =>
+  const [question, setQuestion] = useState<AgariQuestion>(() =>
     initialIndex !== undefined ? SAMPLE_HANDS[initialIndex] : generateRandomAgari(),
   );
   const [winType, setWinType] = useState<'ron' | 'tsumo'>(

--- a/src/utils/tileString.ts
+++ b/src/utils/tileString.ts
@@ -1,0 +1,15 @@
+import { Tile } from '../types/mahjong';
+
+const suitMap: Record<string, string> = { man: '萬', pin: '筒', sou: '索', wind: '', dragon: '' };
+const honorMap: Record<string, Record<number, string>> = {
+  wind: { 1: '東', 2: '南', 3: '西', 4: '北' },
+  dragon: { 1: '白', 2: '發', 3: '中' },
+};
+
+export function tileToKanji(tile: Tile): string {
+  if (tile.suit === 'man' || tile.suit === 'pin' || tile.suit === 'sou') {
+    return `${tile.rank}${suitMap[tile.suit]}`;
+  }
+  return honorMap[tile.suit]?.[tile.rank] ?? '';
+}
+


### PR DESCRIPTION
## Summary
- show the winning tile in score/fu quizzes
- export winning tile information for quiz hands
- add helper `tileToKanji` to format tile text
- adjust tests for new output

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857ef13166c832a93cf8c18722d3558