### PR TITLE
Fix chi meld ordering

### DIFF
--- a/src/components/Player.test.ts
+++ b/src/components/Player.test.ts
@@ -118,7 +118,14 @@ describe('claimMeld', () => {
     const updated = claimMeld(player, tiles, 'chi' as MeldType, 1, 'm2');
     expect(updated.hand).toHaveLength(1);
     expect(updated.hand[0].id).toBe('p1');
-    expect(updated.melds).toEqual([{ type: 'chi', tiles, fromPlayer: 1, calledTileId: 'm2' }]);
+    expect(updated.melds).toEqual([
+      {
+        type: 'chi',
+        tiles: [tiles[0], tiles[2], tiles[1]],
+        fromPlayer: 1,
+        calledTileId: 'm2',
+      },
+    ]);
   });
 });
 

--- a/src/components/Player.ts
+++ b/src/components/Player.ts
@@ -83,10 +83,25 @@ export function claimMeld(
 ): PlayerState {
   // remove called tiles from hand
   const hand = player.hand.filter(h => !tiles.some(t => t.id === h.id));
+  let meldTiles = tiles;
+  if (type === 'chi') {
+    const idx = tiles.findIndex(t => t.id === calledTileId);
+    if (idx >= 0) {
+      const called = tiles[idx];
+      const others = tiles.filter((_, i) => i !== idx);
+      // when calling from the player on the left (standard chi),
+      // place the called tile at the leftmost position
+      if (fromPlayer === (player.seat + 3) % 4) {
+        meldTiles = [called, ...others];
+      } else {
+        meldTiles = [...others, called];
+      }
+    }
+  }
   return {
     ...player,
     hand: sortHand(hand),
-    melds: [...player.melds, { type, tiles, fromPlayer, calledTileId }],
+    melds: [...player.melds, { type, tiles: meldTiles, fromPlayer, calledTileId }],
   };
 }
 


### PR DESCRIPTION
## Summary
- adjust ordering logic when claiming a chi meld so that a claimed tile from the left player is positioned first
- update tests for new meld order

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857f296b438832aae7b46a7663a5404