### PR TITLE
Add rule documentation with help link

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,23 @@ npm run lint
 
 ---
 
+## Rules Supported
+
+現在実装されているルールは以下の通りです。
+
+- リーチ (Reach)
+- ドラ (Dora)
+
+## Not Yet Implemented
+
+以下のルールはまだ実装されていません。
+
+- 本場 (Honba)
+- 裏ドラ (Ura Dora)
+- 一発 (Ippatsu)
+
+---
+
 ## 開発メモ
 
 - 基本的な役判定と符計算を含む点数計算を実装。より高度なAIは未実装（PR歓迎）

--- a/src/components/HelpModal.test.tsx
+++ b/src/components/HelpModal.test.tsx
@@ -30,11 +30,13 @@ describe('HelpModal', () => {
     expect(screen.queryByText('符\\翻')).toBeNull();
   });
 
-  it('displays rule status list', () => {
+  it('displays rule status list with README link', () => {
     render(<HelpModal isOpen onClose={() => {}} />);
     fireEvent.click(screen.getByText('ルール対応状況'));
     expect(screen.getByRole('heading', { name: 'ルール対応状況' })).toBeTruthy();
     expect(screen.getByText('リーチ')).toBeTruthy();
     expect(screen.getByText('ドラ')).toBeTruthy();
+    const link = screen.getByRole('link', { name: 'README' });
+    expect(link.getAttribute('href')).toContain('#rules-supported');
   });
 });

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -135,6 +135,18 @@ export const HelpModal: React.FC<HelpModalProps> = ({ isOpen, onClose }) => {
                 ))}
               </tbody>
             </table>
+            <p className="text-sm mt-2">
+              詳細は
+              <a
+                href="https://github.com/KotaroTanabe/MyCodexSample#rules-supported"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 underline ml-1"
+              >
+                README
+              </a>
+              を参照してください。
+            </p>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- document implemented and missing rules in README
- link to rule documentation from the help modal
- update HelpModal tests for README link

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857f2e77238832ab003dc5cb4679aeb