### PR TITLE
Implement win result modal

### DIFF
--- a/src/components/WinResultModal.test.tsx
+++ b/src/components/WinResultModal.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { WinResultModal } from './WinResultModal';
+import { PlayerState } from '../types/mahjong';
+
+const players: PlayerState[] = [
+  { hand: [], discard: [], melds: [], score: 32000, isRiichi: false, name: 'A', isAI: false, drawnTile: null, seat: 0 },
+  { hand: [], discard: [], melds: [], score: 28000, isRiichi: false, name: 'B', isAI: true, drawnTile: null, seat: 1 },
+];
+
+describe('WinResultModal', () => {
+  it('shows custom next label', () => {
+    render(
+      <WinResultModal
+        players={players}
+        winner={0}
+        winType="tsumo"
+        yaku={['立直']}
+        han={1}
+        fu={30}
+        points={1000}
+        onNext={() => {}}
+        nextLabel="次へ"
+      />,
+    );
+    expect(screen.getByText('次へ')).toBeTruthy();
+  });
+});

--- a/src/components/WinResultModal.tsx
+++ b/src/components/WinResultModal.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { PlayerState } from '../types/mahjong';
+
+export interface WinResult {
+  players: PlayerState[];
+  winner: number;
+  winType: 'ron' | 'tsumo';
+  yaku: string[];
+  han: number;
+  fu: number;
+  points: number;
+}
+
+interface Props extends WinResult {
+  onNext: () => void;
+  nextLabel?: string;
+}
+
+export const WinResultModal: React.FC<Props> = ({
+  players,
+  winner,
+  winType,
+  yaku,
+  han,
+  fu,
+  points,
+  onNext,
+  nextLabel = '次局へ',
+}) => {
+  if (players.length === 0) return null;
+  const title = winType === 'ron' ? 'ロン和了' : 'ツモ和了';
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg p-4 shadow-lg">
+        <h2 className="text-lg font-bold mb-2">{title}</h2>
+        <div className="mb-2 text-sm">
+          {yaku.join('、')} {han}翻 {fu}符 {points}点
+        </div>
+        <table className="border-collapse text-sm mb-2">
+          <thead>
+            <tr>
+              <th className="border px-2 py-1">プレイヤー</th>
+              <th className="border px-2 py-1">点数</th>
+            </tr>
+          </thead>
+          <tbody>
+            {players.map((p, idx) => (
+              <tr key={p.name} className={idx === winner ? 'font-bold' : ''}>
+                <td className="border px-2 py-1">{p.name}</td>
+                <td className="border px-2 py-1 text-right">{p.score}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <button className="mt-2 px-4 py-1 bg-blue-500 text-white rounded" onClick={onNext}>
+          {nextLabel}
+        </button>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add a WinResultModal component to show yaku and scores before advancing
- show the new modal when a hand is won
- test WinResultModal

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857f3fbef0c832aafbd20ebb49d6940