### PR TITLE
Improve fu step descriptions

### DIFF
--- a/src/score/calculateFuDetail.test.ts
+++ b/src/score/calculateFuDetail.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { SAMPLE_HANDS } from '../quiz/sampleHands';
+import { calculateFuDetail } from './calculateFuDetail';
+
+// SAMPLE_HANDS[1] では白ポンがあり、明刻として8符追加される
+
+describe('calculateFuDetail', () => {
+  it('includes meld description in fu steps', () => {
+    const { hand, melds } = SAMPLE_HANDS[1];
+    const detail = calculateFuDetail(hand, melds);
+    expect(detail.steps).toContain('么九刻子 +8 (白白白)');
+  });
+});

--- a/src/score/calculateFuDetail.ts
+++ b/src/score/calculateFuDetail.ts
@@ -1,4 +1,5 @@
 import { Tile, Meld } from '../types/mahjong';
+import { tileToKanji } from '../utils/tileString';
 
 function tileKey(t: Tile): string {
   return `${t.suit}-${t.rank}`;
@@ -72,6 +73,10 @@ function findMelds(counts: Record<string, number>): ParsedMeld[] | null {
   return null;
 }
 
+function tilesToString(tiles: Tile[]): string {
+  return tiles.map(tileToKanji).join('');
+}
+
 function decomposeHand(tiles: Tile[]): { pair: Tile[]; melds: ParsedMeld[] } | null {
   const counts = countTiles(tiles);
   const tileKeys = Object.keys(counts);
@@ -126,10 +131,10 @@ export function calculateFuDetail(
     if (meld.type === 'pon') {
       if (isTerminalOrHonor(meld.tiles[0])) {
         fu += 8;
-        steps.push('么九刻子 +8');
+        steps.push(`么九刻子 +8 (${tilesToString(meld.tiles)})`);
       } else {
         fu += 4;
-        steps.push('刻子 +4');
+        steps.push(`刻子 +4 (${tilesToString(meld.tiles)})`);
       }
     }
   }
@@ -139,7 +144,7 @@ export function calculateFuDetail(
       const base = isTerminalOrHonor(meld.tiles[0]) ? 8 : 4;
       const kanFu = isTerminalOrHonor(meld.tiles[0]) ? 32 : 16;
       fu += kanFu - base;
-      steps.push(`カンボーナス +${kanFu - base}`);
+      steps.push(`カンボーナス +${kanFu - base} (${tilesToString(meld.tiles)})`);
     }
   }
 


### PR DESCRIPTION
## Summary
- display meld tiles when listing fu steps
- test calculateFuDetail meld output

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857f7b2c4dc832a8a732e53a0acae9b