### PR TITLE
Fix chi call leaving tile in river

### DIFF
--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -10,6 +10,7 @@ import {
   isTenpaiAfterDiscard,
   canDiscardTile,
   canCallMeld,
+  removeDiscardTile,
 } from './Player';
 import { MeldType } from '../types/mahjong';
 import {
@@ -368,12 +369,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
     nextTurn();
     return;
     }
-    p[discarder] = {
-      ...p[discarder],
-      discard: p[discarder].discard.map(t =>
-        t.id === lastDiscard.tile.id ? { ...t, called: true } : t,
-      ),
-    };
+  p[discarder] = removeDiscardTile(p[discarder], lastDiscard.tile.id);
     p[caller] = claimMeld(
       p[caller],
       [...meldTiles, lastDiscard.tile],
@@ -422,12 +418,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
     let p = [...playersRef.current];
     const meldTiles = selectMeldTiles(p[caller], lastDiscard.tile, action);
     if (!meldTiles) return;
-    p[discarder] = {
-      ...p[discarder],
-      discard: p[discarder].discard.map(t =>
-        t.id === lastDiscard.tile.id ? { ...t, called: true } : t,
-      ),
-    };
+    p[discarder] = removeDiscardTile(p[discarder], lastDiscard.tile.id);
     p[caller] = claimMeld(
       p[caller],
       [...meldTiles, lastDiscard.tile],
@@ -558,12 +549,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
     const caller = 0;
     const discarder = lastDiscard.player;
     let p = [...playersRef.current];
-    p[discarder] = {
-      ...p[discarder],
-      discard: p[discarder].discard.map(t =>
-        t.id === lastDiscard.tile.id ? { ...t, called: true } : t,
-      ),
-    };
+    p[discarder] = removeDiscardTile(p[discarder], lastDiscard.tile.id);
     p[caller] = claimMeld(
       p[caller],
       [...tiles, lastDiscard.tile],

--- a/src/components/Player.test.ts
+++ b/src/components/Player.test.ts
@@ -11,6 +11,7 @@ import {
   isTenpaiAfterDiscard,
   canDiscardTile,
   canCallMeld,
+  removeDiscardTile,
 } from './Player';
 import { generateTileWall } from './TileWall';
 import { Tile, PlayerState, MeldType } from '../types/mahjong';
@@ -53,6 +54,21 @@ describe('drawTiles', () => {
     const player = createInitialPlayerState('Alice', false);
     const { player: updated } = drawTiles(player, wall, 1);
     expect(updated.drawnTile).toEqual(updated.hand[0]);
+  });
+});
+
+describe('removeDiscardTile', () => {
+  it('removes the specified tile from the discard pile', () => {
+    const player: PlayerState = {
+      ...createInitialPlayerState('test', false),
+      discard: [
+        { suit: 'man', rank: 1, id: 'a' },
+        { suit: 'man', rank: 2, id: 'b' },
+      ],
+    };
+    const updated = removeDiscardTile(player, 'a');
+    expect(updated.discard).toHaveLength(1);
+    expect(updated.discard[0].id).toBe('b');
   });
 });
 

--- a/src/components/Player.ts
+++ b/src/components/Player.ts
@@ -74,6 +74,16 @@ export function canCallMeld(player: PlayerState): boolean {
   return !player.isRiichi;
 }
 
+export function removeDiscardTile(
+  player: PlayerState,
+  tileId: string,
+): PlayerState {
+  return {
+    ...player,
+    discard: player.discard.filter(t => t.id !== tileId),
+  };
+}
+
 export function claimMeld(
   player: PlayerState,
   tiles: Tile[],


### PR DESCRIPTION
## Summary
- add helper `removeDiscardTile` to remove a tile from a player's discards
- use `removeDiscardTile` when claiming a meld so the tile disappears from the discarder
- test removing tiles from the discard pile

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857f84bd48c832a94b5448c99a172e5