### PR TITLE
Fix extra pair count explanation

### DIFF
--- a/src/components/ShantenQuiz.test.tsx
+++ b/src/components/ShantenQuiz.test.tsx
@@ -26,7 +26,7 @@ describe('ShantenQuiz', () => {
     fireEvent.change(input, { target: { value: '1' } });
     fireEvent.click(screen.getByText('答える'));
     expect(screen.getByText('正解！')).toBeTruthy();
-    expect(screen.getByText('向聴数: 1 - 標準形: 面子3組、対子1組、ターツ0組 -> 8 - 3*2 - 0 - 1 = 1')).toBeTruthy();
+    expect(screen.getByText('向聴数: 1 - 標準形: 面子3組、対子2組、ターツ0組 -> 8 - 3*2 - 0 - 1 = 1')).toBeTruthy();
   });
 
   it('shows the correct answer when wrong', () => {
@@ -35,6 +35,6 @@ describe('ShantenQuiz', () => {
     fireEvent.change(input, { target: { value: '2' } });
     fireEvent.click(screen.getByText('答える'));
     expect(screen.getByText('不正解。正解: 1')).toBeTruthy();
-    expect(screen.getByText('向聴数: 1 - 標準形: 面子3組、対子1組、ターツ0組 -> 8 - 3*2 - 0 - 1 = 1')).toBeTruthy();
+    expect(screen.getByText('向聴数: 1 - 標準形: 面子3組、対子2組、ターツ0組 -> 8 - 3*2 - 0 - 1 = 1')).toBeTruthy();
   });
 });

--- a/src/utils/shantenExplain.test.ts
+++ b/src/utils/shantenExplain.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { explainShanten } from './shantenExplain';
+import { Tile } from '../types/mahjong';
+
+describe('explainShanten', () => {
+  const t = (suit: Tile['suit'], rank: number, id: string): Tile => ({ suit, rank, id });
+
+  it('reports all pairs even when more than one', () => {
+    const hand: Tile[] = [
+      t('man', 6, 'a'), t('man', 7, 'b'),
+      t('pin', 1, 'c'), t('pin', 5, 'd'), t('pin', 6, 'e'), t('pin', 8, 'f'),
+      t('sou', 3, 'g'), t('sou', 5, 'h'), t('sou', 6, 'i'),
+      t('wind', 1, 'j'), t('wind', 1, 'k'),
+      t('dragon', 1, 'l'), t('dragon', 1, 'm'),
+      t('dragon', 3, 'n'),
+    ];
+    const { shanten, explanation } = explainShanten(hand);
+    expect(shanten).toBe(4);
+    expect(explanation).toBe('標準形: 面子0組、対子2組、ターツ3組 -> 8 - 0*2 - 3 - 1 = 4');
+  });
+});

--- a/src/utils/shantenExplain.ts
+++ b/src/utils/shantenExplain.ts
@@ -16,7 +16,8 @@ export function calcStandardDetail(hand: Tile[], openMelds = 0) {
   const counts = new Array(34).fill(0);
   for (const t of hand) counts[tileIndex(t)]++;
   let melds = 0;
-  let pairs = 0;
+  let pairs = 0; // pairs actually found in the hand
+  let effectivePairs = 0; // pair count used in shanten calculation (max 1)
   let taatsu = 0;
 
   for (let i = 0; i < 34; i++) {
@@ -59,11 +60,11 @@ export function calcStandardDetail(hand: Tile[], openMelds = 0) {
       taatsu++;
     }
   }
-  if (pairs > 1) pairs = 1;
+  effectivePairs = Math.min(pairs, 1);
   melds += openMelds;
   if (taatsu > 4 - melds) taatsu = 4 - melds;
-  const shanten = 8 - melds * 2 - taatsu - pairs;
-  return { shanten, melds, pairs, taatsu };
+  const shanten = 8 - melds * 2 - taatsu - effectivePairs;
+  return { shanten, melds, pairs, effectivePairs, taatsu };
 }
 
 export function calcChiitoiDetail(hand: Tile[]) {
@@ -139,7 +140,7 @@ export function explainShanten(hand: Tile[], openMelds = 0) {
     explanation =
       `標準形: 面子${standard.melds}組、` +
       `対子${standard.pairs}組、ターツ${standard.taatsu}組 -> ` +
-      `8 - ${standard.melds}*2 - ${standard.taatsu} - ${standard.pairs} = ${standard.shanten}`;
+      `8 - ${standard.melds}*2 - ${standard.taatsu} - ${standard.effectivePairs} = ${standard.shanten}`;
   }
 
   if (shanten === 0) {

--- a/src/utils/shantenExplain.ts
+++ b/src/utils/shantenExplain.ts
@@ -17,7 +17,9 @@ export function calcStandardDetail(hand: Tile[], openMelds = 0) {
   for (const t of hand) counts[tileIndex(t)]++;
   let melds = 0;
   let pairs = 0; // pairs actually found in the hand
-  let effectivePairs = 0; // pair count used in shanten calculation (max 1)
+  // The pair count used in the shanten formula is capped at one.
+  // Extra pairs are still tracked in `pairs` for explanation output.
+  let pairForShanten = 0;
   let taatsu = 0;
 
   for (let i = 0; i < 34; i++) {
@@ -60,11 +62,11 @@ export function calcStandardDetail(hand: Tile[], openMelds = 0) {
       taatsu++;
     }
   }
-  effectivePairs = Math.min(pairs, 1);
+  pairForShanten = Math.min(pairs, 1);
   melds += openMelds;
   if (taatsu > 4 - melds) taatsu = 4 - melds;
-  const shanten = 8 - melds * 2 - taatsu - effectivePairs;
-  return { shanten, melds, pairs, effectivePairs, taatsu };
+  const shanten = 8 - melds * 2 - taatsu - pairForShanten;
+  return { shanten, melds, pairs, pairForShanten, taatsu };
 }
 
 export function calcChiitoiDetail(hand: Tile[]) {
@@ -140,7 +142,7 @@ export function explainShanten(hand: Tile[], openMelds = 0) {
     explanation =
       `標準形: 面子${standard.melds}組、` +
       `対子${standard.pairs}組、ターツ${standard.taatsu}組 -> ` +
-      `8 - ${standard.melds}*2 - ${standard.taatsu} - ${standard.effectivePairs} = ${standard.shanten}`;
+      `8 - ${standard.melds}*2 - ${standard.taatsu} - ${standard.pairForShanten} = ${standard.shanten}`;
   }
 
   if (shanten === 0) {


### PR DESCRIPTION
## Summary
- preserve actual pair count in `calcStandardDetail`
- reference effective pair count separately in formula
- add regression test for two-pair hands
- update ShantenQuiz test expectations

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68580856aabc832a90446d8c63d38e2f