### PR TITLE
Add controllable randomness for E2E tests

### DIFF
--- a/src/components/TileWall.ts
+++ b/src/components/TileWall.ts
@@ -1,4 +1,5 @@
 import { Tile, Suit } from '../types/mahjong';
+import { random } from '../utils/random';
 
 const suits: Suit[] = ['man', 'pin', 'sou'];
 const honors: { suit: Suit; rank: number }[] = [
@@ -53,7 +54,7 @@ export function drawDoraIndicator(
 function shuffle<T>(array: T[]): T[] {
   let arr = [...array];
   for (let i = arr.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
+    const j = Math.floor(random() * (i + 1));
     [arr[i], arr[j]] = [arr[j], arr[i]];
   }
   return arr;

--- a/src/e2e/ScoreQuiz.random.e2e.test.tsx
+++ b/src/e2e/ScoreQuiz.random.e2e.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ScoreQuiz } from '../components/ScoreQuiz';
+import { randomModule } from '../utils/random';
+
+const restore = randomModule.random;
+
+describe('ScoreQuiz random control', () => {
+  afterEach(() => {
+    randomModule.random = restore;
+  });
+
+  it('uses stubbed random for initial question', () => {
+    randomModule.random = vi
+      .fn()
+      .mockReturnValueOnce(0.1) // winType -> ron
+      .mockReturnValueOnce(0.6); // seatWind -> 西
+    render(<ScoreQuiz initialIndex={0} />);
+    expect(screen.getByText(/自風: 西/)).toBeTruthy();
+    expect(screen.getByText(/ロン:/)).toBeTruthy();
+  });
+
+  it('uses stubbed random for nextQuestion', () => {
+    randomModule.random = vi
+      .fn()
+      .mockReturnValueOnce(0.9) // winType -> tsumo
+      .mockReturnValueOnce(0.2) // seatWind -> 東
+      .mockReturnValueOnce(0.3) // next winType -> ron
+      .mockReturnValueOnce(0.7); // next seatWind -> 西
+    render(<ScoreQuiz initialIndex={0} />);
+    expect(screen.getByText(/自風: 東/)).toBeTruthy();
+    expect(screen.getByText(/ツモ/)).toBeTruthy();
+    fireEvent.click(screen.getAllByText('次の問題')[0]);
+    expect(screen.getByText(/自風: 西/)).toBeTruthy();
+    expect(screen.getByText(/ロン:/)).toBeTruthy();
+  });
+});

--- a/src/quiz/randomAgari.ts
+++ b/src/quiz/randomAgari.ts
@@ -1,6 +1,7 @@
 import { Tile, Meld, Suit } from '../types/mahjong';
 import { generateTileWall } from '../components/TileWall';
 import { sortHand } from '../components/Player';
+import { random } from '../utils/random';
 
 export interface AgariHand {
   hand: Tile[];
@@ -23,7 +24,7 @@ function drawTiles(wall: Tile[], suit: Suit, rank: number, count: number): Tile[
 }
 
 function randomFrom<T>(arr: T[]): T {
-  return arr[Math.floor(Math.random() * arr.length)];
+  return arr[Math.floor(random() * arr.length)];
 }
 
 export function generateRandomAgari(): AgariHand {
@@ -36,9 +37,9 @@ export function generateRandomAgari(): AgariHand {
       const allSuits: Suit[] = ['man', 'pin', 'sou', 'wind', 'dragon'];
 
       for (let i = 0; i < 4; i++) {
-        if (Math.random() < 0.5) {
+        if (random() < 0.5) {
           const suit = randomFrom(suits);
-          const base = 1 + Math.floor(Math.random() * 7);
+          const base = 1 + Math.floor(random() * 7);
           hand.push(...drawTiles(wall, suit, base, 1));
           hand.push(...drawTiles(wall, suit, base + 1, 1));
           hand.push(...drawTiles(wall, suit, base + 2, 1));
@@ -47,7 +48,7 @@ export function generateRandomAgari(): AgariHand {
           while (!added) {
             const suit = randomFrom(allSuits);
             const maxRank = suit === 'wind' ? 4 : suit === 'dragon' ? 3 : 9;
-            const rank = 1 + Math.floor(Math.random() * maxRank);
+            const rank = 1 + Math.floor(random() * maxRank);
             const count = wall.filter(t => t.suit === suit && t.rank === rank).length;
             if (count >= 3) {
               hand.push(...drawTiles(wall, suit, rank, 3));
@@ -61,7 +62,7 @@ export function generateRandomAgari(): AgariHand {
       while (!paired) {
         const suit = randomFrom(allSuits);
         const maxRank = suit === 'wind' ? 4 : suit === 'dragon' ? 3 : 9;
-        const rank = 1 + Math.floor(Math.random() * maxRank);
+        const rank = 1 + Math.floor(random() * maxRank);
         const count = wall.filter(t => t.suit === suit && t.rank === rank).length;
         if (count >= 2) {
           hand.push(...drawTiles(wall, suit, rank, 2));

--- a/src/quiz/sampleHands.ts
+++ b/src/quiz/sampleHands.ts
@@ -1,4 +1,5 @@
 import { Tile, Meld } from '../types/mahjong';
+import { random } from '../utils/random';
 
 const t = (suit: Tile['suit'], rank: number, id: string): Tile => ({ suit, rank, id });
 
@@ -47,7 +48,7 @@ export const SAMPLE_HANDS: SampleHand[] = [
 ];
 
 function rand(): string {
-  return Math.random().toString(36).slice(2, 8);
+  return random().toString(36).slice(2, 8);
 }
 
 function randomizeIds(hand: SampleHand): SampleHand {

--- a/src/quiz/useAgariQuiz.ts
+++ b/src/quiz/useAgariQuiz.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { SAMPLE_HANDS } from './sampleHands';
 import { generateRandomAgari, AgariHand } from './randomAgari';
+import { random } from '../utils/random';
 
 interface Options {
   initialIndex?: number;
@@ -17,9 +18,9 @@ export function useAgariQuiz(options: Options = {}) {
     initialIndex !== undefined ? SAMPLE_HANDS[initialIndex] : generateRandomAgari(),
   );
   const [winType, setWinType] = useState<'ron' | 'tsumo'>(
-    initialWinType ?? (Math.random() < 0.5 ? 'ron' : 'tsumo'),
+    initialWinType ?? (random() < 0.5 ? 'ron' : 'tsumo'),
   );
-  const randomSeat = () => Math.ceil(Math.random() * 4);
+  const randomSeat = () => Math.ceil(random() * 4);
   const [seatWind, setSeatWind] = useState<number>(
     initialSeatWind ?? randomSeat(),
   );
@@ -32,7 +33,7 @@ export function useAgariQuiz(options: Options = {}) {
     } else {
       setQuestion(generateRandomAgari());
     }
-    setWinType(Math.random() < 0.5 ? 'ron' : 'tsumo');
+    setWinType(random() < 0.5 ? 'ron' : 'tsumo');
     setSeatWind(randomSeat());
   };
 

--- a/src/utils/random.ts
+++ b/src/utils/random.ts
@@ -1,0 +1,7 @@
+export const randomModule = {
+  random: Math.random,
+};
+
+export function random(): number {
+  return randomModule.random();
+}


### PR DESCRIPTION
## Summary
- add `randomModule` wrapper and expose `random()` function
- migrate existing uses of `Math.random` to the wrapper
- add ScoreQuiz E2E tests demonstrating random stubbing

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68591e7d28e0832ab6846ef42c271d2d