### PR TITLE
Add Double Riichi yaku support

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,15 +134,6 @@ npm run lint
 - リーチ (Reach)
 - ドラ (Dora)
 
-## Not Yet Implemented
-
-以下のルールはまだ実装されていません。
-
-- 本場 (Honba)
-- 裏ドラ (Ura Dora)
-
----
-
 ## 開発メモ
 
 - 基本的な役判定と符計算を含む点数計算を実装。より高度なAIは未実装（PR歓迎）

--- a/src/components/FinalResultModal.test.tsx
+++ b/src/components/FinalResultModal.test.tsx
@@ -6,8 +6,8 @@ import { FinalResultModal } from './FinalResultModal';
 import { PlayerState } from '../types/mahjong';
 
 const players: PlayerState[] = [
-  { hand: [], discard: [], melds: [], score: 30000, isRiichi: false, ippatsu: false, name: 'A', isAI: false, drawnTile: null, seat: 0 },
-  { hand: [], discard: [], melds: [], score: 20000, isRiichi: false, ippatsu: false, name: 'B', isAI: true, drawnTile: null, seat: 1 },
+  { hand: [], discard: [], melds: [], score: 30000, isRiichi: false, ippatsu: false, doubleRiichi: false, name: 'A', isAI: false, drawnTile: null, seat: 0 },
+  { hand: [], discard: [], melds: [], score: 20000, isRiichi: false, ippatsu: false, doubleRiichi: false, name: 'B', isAI: true, drawnTile: null, seat: 1 },
 ];
 
 describe('FinalResultModal', () => {

--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -462,6 +462,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
     const yaku = detectYaku(fullHand, p[idx].melds, {
       isTsumo: true,
       isRiichi: p[idx].isRiichi,
+      doubleRiichi: p[idx].doubleRiichi,
       ippatsu: p[idx].ippatsu,
       seatWind,
       roundWind,
@@ -506,6 +507,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
     const yaku = detectYaku(fullHand, p[winner].melds, {
       isTsumo: false,
       isRiichi: p[winner].isRiichi,
+      doubleRiichi: p[winner].doubleRiichi,
       ippatsu: p[winner].ippatsu,
       seatWind,
       roundWind,
@@ -543,7 +545,8 @@ const handleCallAction = (action: MeldType | 'pass') => {
 
   const handleRiichi = () => {
     let p = [...playersRef.current];
-    p[0] = declareRiichi(p[0]);
+    const isDouble = playersRef.current.every(pl => pl.discard.length === 0);
+    p[0] = declareRiichi(p[0], isDouble);
     setPlayers(p);
     playersRef.current = p;
     setPendingRiichi(0);

--- a/src/components/Player.test.ts
+++ b/src/components/Player.test.ts
@@ -192,6 +192,10 @@ describe('initial hand distribution', () => {
     const p = createInitialPlayerState('foo', false);
     expect(p.ippatsu).toBe(false);
   });
+  it('initializes doubleRiichi to false', () => {
+    const p = createInitialPlayerState('foo', false);
+    expect(p.doubleRiichi).toBe(false);
+  });
 });
 
 describe('declareRiichi', () => {
@@ -200,6 +204,13 @@ describe('declareRiichi', () => {
     const updated = declareRiichi(player);
     expect(updated.isRiichi).toBe(true);
     expect(updated.ippatsu).toBe(true);
+    expect(updated.doubleRiichi).toBe(false);
+  });
+
+  it('can mark double riichi when specified', () => {
+    const player = createInitialPlayerState('RiichiMan', false);
+    const updated = declareRiichi(player, true);
+    expect(updated.doubleRiichi).toBe(true);
   });
 });
 

--- a/src/components/Player.ts
+++ b/src/components/Player.ts
@@ -28,6 +28,7 @@ export function createInitialPlayerState(
     score: 25000,
     isRiichi: false,
     ippatsu: false,
+    doubleRiichi: false,
     name,
     isAI,
     drawnTile: null,
@@ -116,9 +117,12 @@ export function claimMeld(
   };
 }
 
-export function declareRiichi(player: PlayerState): PlayerState {
+export function declareRiichi(
+  player: PlayerState,
+  doubleRiichi = false,
+): PlayerState {
   if (player.isRiichi) return player;
-  return { ...player, isRiichi: true, ippatsu: true };
+  return { ...player, isRiichi: true, ippatsu: true, doubleRiichi };
 }
 
 export function canDeclareRiichi(player: PlayerState): boolean {

--- a/src/components/WinResultModal.test.tsx
+++ b/src/components/WinResultModal.test.tsx
@@ -6,8 +6,8 @@ import { WinResultModal } from './WinResultModal';
 import { PlayerState } from '../types/mahjong';
 
 const players: PlayerState[] = [
-  { hand: [], discard: [], melds: [], score: 32000, isRiichi: false, ippatsu: false, name: 'A', isAI: false, drawnTile: null, seat: 0 },
-  { hand: [], discard: [], melds: [], score: 28000, isRiichi: false, ippatsu: false, name: 'B', isAI: true, drawnTile: null, seat: 1 },
+  { hand: [], discard: [], melds: [], score: 32000, isRiichi: false, ippatsu: false, doubleRiichi: false, name: 'A', isAI: false, drawnTile: null, seat: 0 },
+  { hand: [], discard: [], melds: [], score: 28000, isRiichi: false, ippatsu: false, doubleRiichi: false, name: 'B', isAI: true, drawnTile: null, seat: 1 },
 ];
 
 describe('WinResultModal', () => {

--- a/src/score/yaku.test.ts
+++ b/src/score/yaku.test.ts
@@ -242,6 +242,18 @@ describe('Yaku detection', () => {
     expect(yaku.some(y => y.name === 'Ippatsu')).toBe(true);
   });
 
+  it('detects Double Riichi', () => {
+    const hand: Tile[] = [
+      t('man',2,'dr2a'),t('man',3,'dr3a'),t('man',4,'dr4a'),
+      t('pin',2,'dr2b'),t('pin',3,'dr3b'),t('pin',4,'dr4b'),
+      t('sou',2,'dr2c'),t('sou',3,'dr3c'),t('sou',4,'dr4c'),
+      t('man',6,'dr6a'),t('man',7,'dr7a'),t('man',8,'dr8a'),
+      t('pin',5,'dr5a'),t('pin',5,'dr5b'),
+    ];
+    const yaku = detectYaku(hand, [], { isTsumo: true, isRiichi: true, doubleRiichi: true });
+    expect(yaku.some(y => y.name === 'Double Riichi')).toBe(true);
+  });
+
   it('detects Rinshan Kaihou', () => {
     const hand: Tile[] = [
       t('man',2,'r2a'),t('man',3,'r3a'),t('man',4,'r4a'),

--- a/src/score/yaku.ts
+++ b/src/score/yaku.ts
@@ -337,6 +337,7 @@ export function detectYaku(
   opts?: {
     isTsumo?: boolean;
     isRiichi?: boolean;
+    doubleRiichi?: boolean;
     seatWind?: number;
     roundWind?: number;
     ippatsu?: boolean;
@@ -391,6 +392,9 @@ export function detectYaku(
   }
   if (opts?.isRiichi && isClosed) {
     result.push({ name: 'Riichi', han: 1 });
+  }
+  if (opts?.doubleRiichi && isClosed) {
+    result.push({ name: 'Double Riichi', han: 2 });
   }
   if (opts?.ippatsu && opts?.isRiichi && isClosed) {
     result.push({ name: 'Ippatsu', han: 1 });

--- a/src/types/mahjong.ts
+++ b/src/types/mahjong.ts
@@ -31,6 +31,8 @@ export interface PlayerState {
   isRiichi: boolean;
   /** true if ippatsu is still possible after declaring riichi */
   ippatsu: boolean;
+  /** true if this riichi was declared on the very first turn */
+  doubleRiichi: boolean;
   name: string;
   isAI: boolean;
   drawnTile: Tile | null;

--- a/src/yaku.ts
+++ b/src/yaku.ts
@@ -91,6 +91,12 @@ export const YAKU_LIST: Yaku[] = [
     hanOpen: 5,
   },
   {
+    name: 'Double Riichi',
+    description: '一巡目でリーチ',
+    hanClosed: 2,
+    hanOpen: 0,
+  },
+  {
     name: 'Ippatsu',
     description: 'リーチ後一巡以内に和了',
     hanClosed: 1,


### PR DESCRIPTION
## Summary
- support double riichi in yaku detection
- track `doubleRiichi` in player state and mark on riichi
- update GameController to set double riichi flag
- cover new behavior with tests
- clean up README to remove outdated not implemented section

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_6859335a30e8832a93382b211923f154