### PR TITLE
Add action log export feature

### DIFF
--- a/src/components/GameController.autoplay.test.tsx
+++ b/src/components/GameController.autoplay.test.tsx
@@ -31,4 +31,32 @@ describe('GameController auto play', () => {
     const star = await screen.findByText('★');
     expect(star).toBeTruthy();
   });
+
+  it('exports log file with actions', async () => {
+    vi.useRealTimers();
+    const { container } = render(<GameController gameLength="tonnan" />);
+    await screen.findAllByText('手牌');
+    const first = container.querySelector('button[aria-label]') as HTMLButtonElement;
+    fireEvent.click(first);
+    const createObjectURL = vi.fn().mockReturnValue('blob:log');
+    (globalThis as any).URL.createObjectURL = createObjectURL;
+    (globalThis as any).URL.revokeObjectURL = vi.fn();
+    class FakeBlob {
+      constructor(private parts: any[]) {
+        this.parts = parts;
+      }
+      text() { return Promise.resolve(this.parts.join('')); }
+    }
+    (globalThis as any).Blob = FakeBlob as any;
+    const clickSpy = vi.fn();
+    Object.defineProperty(HTMLAnchorElement.prototype, 'click', {
+      configurable: true,
+      value: clickSpy,
+    });
+    fireEvent.click(screen.getAllByText('ログダウンロード')[0]);
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    const text = await blob.text();
+    const entries = JSON.parse(text);
+    expect(entries.some((e: any) => e.type === 'discard')).toBe(true);
+  });
 });

--- a/src/types/mahjong.ts
+++ b/src/types/mahjong.ts
@@ -38,3 +38,18 @@ export interface PlayerState {
   drawnTile: Tile | null;
   seat: number;
 }
+
+export type LogEntry =
+  | { type: 'startRound'; kyoku: number }
+  | { type: 'draw'; player: number; tile: Tile }
+  | { type: 'discard'; player: number; tile: Tile }
+  | {
+      type: 'meld';
+      player: number;
+      tiles: Tile[];
+      meldType: MeldType;
+      from: number;
+    }
+  | { type: 'riichi'; player: number; tile: Tile }
+  | { type: 'tsumo'; player: number; tile: Tile }
+  | { type: 'ron'; player: number; tile: Tile; from: number };

--- a/src/utils/paifuExport.ts
+++ b/src/utils/paifuExport.ts
@@ -1,0 +1,5 @@
+import { LogEntry } from '../types/mahjong';
+
+export function logToJSON(log: LogEntry[]): string {
+  return JSON.stringify(log, null, 2);
+}


### PR DESCRIPTION
## Summary
- add LogEntry types for game actions
- implement logging and download button in GameController
- provide `logToJSON` utility
- test log export via autoplay tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685936b497f0832aab07a510952c8f67