### PR TITLE
Update rule status documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ npm run lint
 
 - リーチ (Reach)
 - ドラ (Dora)
+- 本場 (Honba)
+- 裏ドラ (Ura Dora)
+- 一発 (Ippatsu)
 
 ## 牌譜エクスポート
 

--- a/src/ruleStatus.ts
+++ b/src/ruleStatus.ts
@@ -6,7 +6,7 @@ export interface RuleStatus {
 export const RULE_STATUS: RuleStatus[] = [
   { term: 'リーチ', implemented: true },
   { term: 'ドラ', implemented: true },
-  { term: '本場', implemented: false },
-  { term: '裏ドラ', implemented: false },
-  { term: '一発', implemented: false },
+  { term: '本場', implemented: true },
+  { term: '裏ドラ', implemented: true },
+  { term: '一発', implemented: true },
 ];


### PR DESCRIPTION
## Summary
- mark honba, ura dora and ippatsu as implemented
- document all implemented rules in README

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_685953a4fb14832aa0d9b18f2b24639f