### PR TITLE
Fix mobile overflow of player hand

### DIFF
--- a/src/components/UIBoard.test.tsx
+++ b/src/components/UIBoard.test.tsx
@@ -201,6 +201,15 @@ describe('UIBoard aria labels', () => {
   });
 });
 
+describe('UIBoard responsiveness', () => {
+  it('hand container can scroll horizontally', () => {
+    renderBoard({ standard: 1, chiitoi: 1, kokushi: 13 });
+    const handLabel = screen.getByText('手牌');
+    const container = handLabel.parentElement as HTMLElement;
+    expect(container.className).toContain('overflow-x-auto');
+  });
+});
+
 describe('UIBoard discard orientation', () => {
 
 

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -201,7 +201,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
             ? my.hand.filter(t => t.id !== my.drawnTile?.id)
             : my.hand;
           return (
-            <div className="flex gap-2 items-center">
+            <div className="flex gap-2 items-center overflow-x-auto">
               <span className="text-xs text-gray-600">手牌</span>
               {handTiles.map(tile => {
                 const kanji =


### PR DESCRIPTION
## Summary
- enable horizontal scrolling for hand tile container
- test responsive hand container class

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859d7f78a14832ab93d34788da78139