### PR TITLE
Update rule list with double riichi

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ npm run lint
 現在実装されているルールは以下の通りです。
 
 - リーチ (Reach)
+- ダブルリーチ (Double Riichi)
 - ドラ (Dora)
 - 本場 (Honba)
 - 裏ドラ (Ura Dora)

--- a/src/ruleStatus.ts
+++ b/src/ruleStatus.ts
@@ -5,6 +5,7 @@ export interface RuleStatus {
 
 export const RULE_STATUS: RuleStatus[] = [
   { term: 'リーチ', implemented: true },
+  { term: 'ダブルリーチ', implemented: true },
   { term: 'ドラ', implemented: true },
   { term: '本場', implemented: true },
   { term: '裏ドラ', implemented: true },


### PR DESCRIPTION
## Summary
- document Double Riichi in README
- add Double Riichi to rule status list

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859ef97e034832ab70985795d72fc43