### PR TITLE
Add ura-dora support

### DIFF
--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -537,6 +537,13 @@ const handleCallAction = (action: MeldType | 'pass') => {
 
   const performTsumo = (idx: number) => {
     const p = [...playersRef.current];
+    let ura: Tile[] = [];
+    if (p[idx].isRiichi) {
+      const uraRes = drawDoraIndicator(deadWallRef.current, dora.length);
+      ura = uraRes.dora;
+      setDeadWall(uraRes.wall);
+      deadWallRef.current = uraRes.wall;
+    }
     const fullHand = [...p[idx].hand, ...p[idx].melds.flatMap(m => m.tiles)];
     const seatWind = p[idx].seat + 1;
     const roundWind = kyokuRef.current <= 4 ? 1 : 2;
@@ -547,6 +554,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
       ippatsu: p[idx].ippatsu,
       seatWind,
       roundWind,
+      uraDoraIndicators: ura,
     });
     const { han, fu, points } = calculateScore(
       p[idx].hand,
@@ -579,11 +587,19 @@ const handleCallAction = (action: MeldType | 'pass') => {
       han,
       fu,
       points,
+      uraDora: ura,
     });
   };
 
   const performRon = (winner: number, from: number, tile: Tile) => {
     const p = [...playersRef.current];
+    let ura: Tile[] = [];
+    if (p[winner].isRiichi) {
+      const uraRes = drawDoraIndicator(deadWallRef.current, dora.length);
+      ura = uraRes.dora;
+      setDeadWall(uraRes.wall);
+      deadWallRef.current = uraRes.wall;
+    }
     const fullHand = [...p[winner].hand, ...p[winner].melds.flatMap(m => m.tiles), tile];
     const seatWind = p[winner].seat + 1;
     const roundWind = kyokuRef.current <= 4 ? 1 : 2;
@@ -594,6 +610,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
       ippatsu: p[winner].ippatsu,
       seatWind,
       roundWind,
+      uraDoraIndicators: ura,
     });
     const { han, fu, points } = calculateScore(
       [...p[winner].hand, tile],
@@ -625,6 +642,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
       han,
       fu,
       points,
+      uraDora: ura,
     });
   };
 

--- a/src/components/WinResultModal.test.tsx
+++ b/src/components/WinResultModal.test.tsx
@@ -27,4 +27,21 @@ describe('WinResultModal', () => {
     );
     expect(screen.getByText('次へ')).toBeTruthy();
   });
+
+  it('displays ura-dora tiles when provided', () => {
+    render(
+      <WinResultModal
+        players={players}
+        winner={0}
+        winType="tsumo"
+        yaku={['立直']}
+        han={1}
+        fu={30}
+        points={1000}
+        uraDora={[{ suit: 'man', rank: 1, id: 'u1' }]}
+        onNext={() => {}}
+      />,
+    );
+    expect(screen.getByLabelText('1萬')).toBeTruthy();
+  });
 });

--- a/src/components/WinResultModal.tsx
+++ b/src/components/WinResultModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { PlayerState } from '../types/mahjong';
+import { PlayerState, Tile } from '../types/mahjong';
+import { TileView } from './TileView';
 
 export interface WinResult {
   players: PlayerState[];
@@ -9,6 +10,8 @@ export interface WinResult {
   han: number;
   fu: number;
   points: number;
+  /** ura-dora indicators revealed after a riichi win */
+  uraDora?: Tile[];
 }
 
 interface Props extends WinResult {
@@ -24,6 +27,7 @@ export const WinResultModal: React.FC<Props> = ({
   han,
   fu,
   points,
+  uraDora,
   onNext,
   nextLabel = '次局へ',
 }) => {
@@ -36,6 +40,14 @@ export const WinResultModal: React.FC<Props> = ({
         <div className="mb-2 text-sm">
           {yaku.join('、')} {han}翻 {fu}符 {points}点
         </div>
+        {uraDora && uraDora.length > 0 && (
+          <div className="mb-2 text-sm flex items-center gap-1">
+            <span>裏ドラ:</span>
+            {uraDora.map(t => (
+              <TileView key={t.id} tile={t} />
+            ))}
+          </div>
+        )}
         <table className="border-collapse text-sm mb-2">
           <thead>
             <tr>


### PR DESCRIPTION
## Summary
- draw ura-dora indicators when a riichi win occurs
- display ura-dora tiles in WinResultModal
- test WinResultModal's ura-dora display

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a2f9d6f10832a88b090c5308a84b9