### PR TITLE
Implement chiitoitsu fu and open meld fu calculation

### DIFF
--- a/src/quiz/sampleHands.test.ts
+++ b/src/quiz/sampleHands.test.ts
@@ -4,7 +4,7 @@ import { calculateFu } from '../score/score';
 
 describe('SAMPLE_HANDS', () => {
   it('calculates expected fu and includes winning tile', () => {
-    const expected = [20, 30, 60];
+    const expected = [20, 30, 40];
     SAMPLE_HANDS.forEach((hand, i) => {
       const fu = calculateFu(hand.hand, hand.melds);
       // 基本符20のみ、役牌ポンやカンで加算した値になるはず

--- a/src/score/calculateFu.test.ts
+++ b/src/score/calculateFu.test.ts
@@ -27,8 +27,8 @@ describe('calculateFu', () => {
   it('computes fu for a hand with a dragon kan', () => {
     const { hand, melds } = SAMPLE_HANDS[2];
     const fu = calculateFu(hand, melds);
-    // 基本符20 + カン(役牌)32 = 52、切り上げで60符になるはず
-    expect(fu).toBe(60);
+    // 基本符20 + 明カン(役牌)16 = 36、切り上げで40符になるはず
+    expect(fu).toBe(40);
   });
 
   it('adds pair fu for seat wind', () => {

--- a/src/score/calculateFuDetail.test.ts
+++ b/src/score/calculateFuDetail.test.ts
@@ -2,12 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { SAMPLE_HANDS } from '../quiz/sampleHands';
 import { calculateFuDetail } from './calculateFuDetail';
 
-// SAMPLE_HANDS[1] では白ポンがあり、明刻として8符追加される
+// SAMPLE_HANDS[1] では白ポンがあり、明刻として4符追加される
 
 describe('calculateFuDetail', () => {
   it('includes meld description in fu steps', () => {
     const { hand, melds } = SAMPLE_HANDS[1];
     const detail = calculateFuDetail(hand, melds);
-    expect(detail.steps).toContain('么九刻子 +8 (白白白)');
+    expect(detail.steps).toContain('明么九刻子 +4 (白白白)');
   });
 });

--- a/src/score/yaku.test.ts
+++ b/src/score/yaku.test.ts
@@ -120,6 +120,22 @@ describe('Yaku detection', () => {
     expect(yaku.some(y => y.name === 'Chiitoitsu')).toBe(true);
   });
 
+  it('scores Chiitoitsu as 25 fu', () => {
+    const hand: Tile[] = [
+      t('man',1,'m1a'),t('man',1,'m1b'),
+      t('man',2,'m2a'),t('man',2,'m2b'),
+      t('pin',3,'p3a'),t('pin',3,'p3b'),
+      t('pin',4,'p4a'),t('pin',4,'p4b'),
+      t('sou',5,'s5a'),t('sou',5,'s5b'),
+      t('sou',6,'s6a'),t('sou',6,'s6b'),
+      t('dragon',1,'d1a'),t('dragon',1,'d1b'),
+    ];
+    const yaku = detectYaku(hand, [], { isTsumo: true });
+    const { fu } = calculateScore(hand, [], yaku, []);
+    // 七対子は常に25符になるはず
+    expect(fu).toBe(25);
+  });
+
   it('detects Kokushi Musou', () => {
     const hand: Tile[] = [
       t('man',1,'m1a'),t('man',9,'m9a'),
@@ -431,8 +447,8 @@ describe('Scoring', () => {
     const fullHand = [...concealed, ...kanTiles];
     const yaku = detectYaku(fullHand, melds, { isTsumo: true });
     const { fu } = calculateScore(concealed, melds, yaku);
-    // 基本符20 + カン(役牌)32 = 52、切り上げで60符になるはず
-    expect(fu).toBe(60);
+    // 基本符20 + 明カン(役牌)16 = 36、切り上げで40符になるはず
+    expect(fu).toBe(40);
   });
 
   it('adds riichi han when declared', () => {


### PR DESCRIPTION
## Summary
- apply open/closed differentiation for pon/kan fu
- give chiitoitsu hands fixed 25 fu
- update fu calculation details to explain open melds
- adjust sample hands and fu tests for new rules

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_685a325d21b4832a82d3825d53038ae1