### PR TITLE
Add board state loading sample

### DIFF
--- a/src/components/GameController.loadBoard.test.tsx
+++ b/src/components/GameController.loadBoard.test.tsx
@@ -1,0 +1,16 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { GameController } from './GameController';
+
+describe('GameController load board', () => {
+  it('loads sample board data', async () => {
+    const { container } = render(<GameController gameLength="tonnan" />);
+    await screen.findAllByText('手牌');
+    fireEvent.click(screen.getByText('盤面読み込み'));
+    const melds = container.querySelectorAll('div.bg-gray-50');
+    expect(melds.length).toBeGreaterThan(0);
+    expect(screen.getByText('盤面を読み込みました')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- allow loading board status from JSON
- include sample setup with chi/pon/kan
- provide textarea and button to load board on UI
- test loading behavior

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a57d34ed4832aadde10f83ce2dd30