### PR TITLE
Orient meld tiles by relative position

### DIFF
--- a/src/components/MeldView.test.tsx
+++ b/src/components/MeldView.test.tsx
@@ -22,5 +22,27 @@ describe('MeldView', () => {
     expect(count).toBe(3);
   });
 
+  it('rotates called tile based on fromPlayer', () => {
+    const base: Meld = {
+      type: 'pon',
+      tiles: [
+        { suit: 'man', rank: 1, id: 'a' },
+        { suit: 'man', rank: 1, id: 'b' },
+        { suit: 'man', rank: 1, id: 'c' },
+      ],
+      fromPlayer: 1,
+      calledTileId: 'a',
+    };
+    const htmlRight = renderToStaticMarkup(<MeldView meld={base} seat={0} />);
+    const rotRight = /rotate\(([-0-9]+)deg\)/.exec(htmlRight)![1];
+
+    const htmlLeft = renderToStaticMarkup(
+      <MeldView meld={{ ...base, fromPlayer: 3 }} seat={0} />,
+    );
+    const rotLeft = /rotate\(([-0-9]+)deg\)/.exec(htmlLeft)![1];
+
+    expect(rotRight).not.toBe(rotLeft);
+  });
+
   // Style-specific rotations are tested elsewhere; focus on tile count here.
 });

--- a/src/components/MeldView.tsx
+++ b/src/components/MeldView.tsx
@@ -15,6 +15,21 @@ const seatRotation = (seat: number) => {
   }
 };
 
+const calledRotation = (seat: number, from: number) => {
+  if (from === seat) return 0;
+  const diff = (from - seat + 4) % 4;
+  switch (diff) {
+    case 1:
+      return 90; // from right
+    case 2:
+      return 180; // from opposite
+    case 3:
+      return -90; // from left
+    default:
+      return 0;
+  }
+};
+
 export const MeldView: React.FC<{ meld: Meld; seat?: number }> = ({ meld, seat = 0 }) => {
   return (
     <div className="flex gap-1 border rounded px-1 bg-gray-50">
@@ -22,7 +37,10 @@ export const MeldView: React.FC<{ meld: Meld; seat?: number }> = ({ meld, seat =
         <TileView
           key={tile.id}
           tile={tile}
-          rotate={seatRotation(seat) + (tile.id === meld.calledTileId ? 90 : 0)}
+          rotate={
+            seatRotation(seat) +
+            (tile.id === meld.calledTileId ? calledRotation(seat, meld.fromPlayer) : 0)
+          }
         />
       ))}
     </div>

--- a/src/components/Player.test.ts
+++ b/src/components/Player.test.ts
@@ -144,6 +144,45 @@ describe('claimMeld', () => {
       },
     ]);
   });
+
+  it('orders pon tiles based on caller position', () => {
+    const t = (suit: Tile['suit'], rank: number, id: string): Tile => ({
+      suit,
+      rank,
+      id,
+    });
+    const hand: Tile[] = [t('man', 1, 'a'), t('man', 1, 'b'), t('man', 1, 'c')];
+    const player: PlayerState = { ...createInitialPlayerState('Bob', false), hand };
+    const tiles = hand.slice();
+    const fromRight = claimMeld(player, tiles, 'pon', 1, 'a');
+    const fromOpposite = claimMeld(player, tiles, 'pon', 2, 'a');
+    const fromLeft = claimMeld(player, tiles, 'pon', 3, 'a');
+    expect(fromRight.melds[0].tiles[0].id).toBe('a');
+    expect(fromOpposite.melds[0].tiles[1].id).toBe('a');
+    expect(fromLeft.melds[0].tiles[2].id).toBe('a');
+  });
+
+  it('orders kan tiles based on caller position', () => {
+    const t = (suit: Tile['suit'], rank: number, id: string): Tile => ({
+      suit,
+      rank,
+      id,
+    });
+    const hand: Tile[] = [
+      t('man', 1, 'a'),
+      t('man', 1, 'b'),
+      t('man', 1, 'c'),
+      t('man', 1, 'd'),
+    ];
+    const player: PlayerState = { ...createInitialPlayerState('Bob', false), hand };
+    const tiles = hand.slice();
+    const fromRight = claimMeld(player, tiles, 'kan', 1, 'a');
+    const fromOpposite = claimMeld(player, tiles, 'kan', 2, 'a');
+    const fromLeft = claimMeld(player, tiles, 'kan', 3, 'a');
+    expect(fromRight.melds[0].tiles[0].id).toBe('a');
+    expect(fromOpposite.melds[0].tiles[1].id).toBe('a');
+    expect(fromLeft.melds[0].tiles[3].id).toBe('a');
+  });
 });
 
 describe('incrementDiscardCount', () => {

--- a/src/components/Player.ts
+++ b/src/components/Player.ts
@@ -96,16 +96,34 @@ export function claimMeld(
   // remove called tiles from hand
   const hand = player.hand.filter(h => !tiles.some(t => t.id === h.id));
   let meldTiles = tiles;
-  if (type === 'chi') {
-    const idx = tiles.findIndex(t => t.id === calledTileId);
-    if (idx >= 0) {
-      const called = tiles[idx];
-      const others = tiles.filter((_, i) => i !== idx);
-      // when calling from the player on the left (standard chi),
-      // place the called tile at the leftmost position
-      if (fromPlayer === (player.seat + 3) % 4) {
+  const idx = tiles.findIndex(t => t.id === calledTileId);
+  if (idx >= 0) {
+    const called = tiles[idx];
+    const others = tiles.filter((_, i) => i !== idx);
+    const relative = (fromPlayer - player.seat + 4) % 4;
+    if (type === 'chi') {
+      // Chi is only possible from the player on the left
+      // Place the called tile at the leftmost position when from left
+      if (relative === 3) {
         meldTiles = [called, ...others];
       } else {
+        meldTiles = [...others, called];
+      }
+    } else if (type === 'pon') {
+      // Left -> rightmost, Right -> leftmost, Opposite -> middle
+      if (relative === 1) {
+        meldTiles = [called, ...others];
+      } else if (relative === 2) {
+        meldTiles = [others[0], called, others[1]];
+      } else if (relative === 3) {
+        meldTiles = [...others, called];
+      }
+    } else if (type === 'kan') {
+      if (relative === 1) {
+        meldTiles = [called, ...others];
+      } else if (relative === 2) {
+        meldTiles = [others[0], called, others[1], others[2]];
+      } else if (relative === 3) {
         meldTiles = [...others, called];
       }
     }


### PR DESCRIPTION
## Summary
- adjust tile order for pon/kan based on caller's relative seat
- rotate called tiles by relative direction
- cover new ordering and rotation logic in tests

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a5f6bdf28832aaeebb1b7185ca80e