### PR TITLE
Fix score reset on new game

### DIFF
--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -856,7 +856,9 @@ const handleCallAction = (action: MeldType | 'pass') => {
 
   // リセット
   const handleRestart = () => {
-    setPhase('init');
+    // Start a completely new game with fresh scores
+    setKyoku(1);
+    startRound(true, 1);
   };
 
   const handleDownloadLog = () => {


### PR DESCRIPTION
## Summary
- ensure scores reset when restarting a game

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_685a640494c8832aa8540fe0ebaf3f4b