### PR TITLE
Adjust meld orientation

### DIFF
--- a/src/components/MeldView.test.tsx
+++ b/src/components/MeldView.test.tsx
@@ -34,14 +34,27 @@ describe('MeldView', () => {
       calledTileId: 'a',
     };
     const htmlRight = renderToStaticMarkup(<MeldView meld={base} seat={0} />);
-    const rotRight = /rotate\(([-0-9]+)deg\)/.exec(htmlRight)![1];
-
     const htmlLeft = renderToStaticMarkup(
       <MeldView meld={{ ...base, fromPlayer: 3 }} seat={0} />,
     );
-    const rotLeft = /rotate\(([-0-9]+)deg\)/.exec(htmlLeft)![1];
 
-    expect(rotRight).not.toBe(rotLeft);
+    expect(htmlRight).toContain('rotate(90deg)');
+    expect(htmlLeft).toContain('rotate(-90deg)');
+  });
+
+  it('rotates the whole meld for side seats', () => {
+    const meld: Meld = {
+      type: 'pon',
+      tiles: [
+        { suit: 'man', rank: 1, id: 'a' },
+        { suit: 'man', rank: 1, id: 'b' },
+        { suit: 'man', rank: 1, id: 'c' },
+      ],
+      fromPlayer: 0,
+      calledTileId: 'a',
+    };
+    const html = renderToStaticMarkup(<MeldView meld={meld} seat={1} />);
+    expect(html).toContain('rotate(270deg)');
   });
 
   // Style-specific rotations are tested elsewhere; focus on tile count here.

--- a/src/components/MeldView.tsx
+++ b/src/components/MeldView.tsx
@@ -15,6 +15,19 @@ const seatRotation = (seat: number) => {
   }
 };
 
+const seatMeldRotation = (seat: number): number => {
+  switch (seat % 4) {
+    case 1:
+      return 270;
+    case 2:
+      return 180;
+    case 3:
+      return 90;
+    default:
+      return 0;
+  }
+};
+
 const calledRotation = (seat: number, from: number) => {
   if (from === seat) return 0;
   const diff = (from - seat + 4) % 4;
@@ -32,13 +45,17 @@ const calledRotation = (seat: number, from: number) => {
 
 export const MeldView: React.FC<{ meld: Meld; seat?: number }> = ({ meld, seat = 0 }) => {
   return (
-    <div className="flex gap-1 border rounded px-1 bg-gray-50">
+    <div
+      className="flex gap-1 border rounded px-1 bg-gray-50"
+      style={{ transform: `rotate(${seatMeldRotation(seat)}deg)` }}
+    >
       {meld.tiles.map(tile => (
         <TileView
           key={tile.id}
           tile={tile}
           rotate={
-            seatRotation(seat) +
+            seatRotation(seat) -
+            seatMeldRotation(seat) +
             (tile.id === meld.calledTileId ? calledRotation(seat, meld.fromPlayer) : 0)
           }
         />


### PR DESCRIPTION
## Summary
- rotate meld containers based on seat
- keep tile orientation consistent within the rotated container
- test meld rotations for side seats

## Testing
- `npx -y -p node@20 npm run lint --if-present`
- `npx -y -p node@20 npm run type-check --if-present`
- `npx -y -p node@20 npm run build`
- `npx -y -p node@20 npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_685a6a6af898832a8a60ef65539d106a