### PR TITLE
Enable dark mode and add theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/fonts/emoji.css" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Poppins:wght@600&display=swap"
+      rel="stylesheet"
+    />
     <title>Mahjong App</title>
   </head>
   <body>

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -14,3 +14,15 @@ describe('App mode selector', () => {
     expect(screen.getByPlaceholderText('符を入力')).toBeTruthy();
   });
 });
+
+describe('Dark mode toggle', () => {
+  it('adds and removes dark class on body', () => {
+    render(<App />);
+    const [toggle] = screen.getAllByLabelText('Dark mode');
+    expect(document.body.classList.contains('dark')).toBe(false);
+    fireEvent.click(toggle);
+    expect(document.body.classList.contains('dark')).toBe(true);
+    fireEvent.click(toggle);
+    expect(document.body.classList.contains('dark')).toBe(false);
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { GameController } from './components/GameController';
 import { FuQuiz } from './components/FuQuiz';
 import { ScoreQuiz } from './components/ScoreQuiz';
@@ -12,10 +12,15 @@ function App() {
     'east1',
   );
   const [helpOpen, setHelpOpen] = useState(false);
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    document.body.classList.toggle('dark', dark);
+  }, [dark]);
 
   return (
     <div
-      className="min-h-screen bg-green-100 flex items-center justify-center py-2"
+      className="min-h-screen bg-surface-100 dark:bg-surface-900 flex items-center justify-center py-2"
       style={{ ['--tile-font-size' as any]: `${tileFont}rem` } as React.CSSProperties}
     >
       <div className="w-full mx-auto px-4 space-y-4">
@@ -72,10 +77,17 @@ function App() {
         )}
         <button
           onClick={() => setHelpOpen(true)}
-          className="w-6 h-6 flex items-center justify-center rounded-full bg-white shadow text-sm font-bold hover:bg-gray-100"
+          className="w-6 h-6 flex items-center justify-center rounded-full bg-surface-0 dark:bg-surface-700 shadow text-sm font-bold hover:bg-surface-100 dark:hover:bg-surface-600"
           aria-label="ヘルプ"
         >
           ?
+        </button>
+        <button
+          onClick={() => setDark(d => !d)}
+          aria-label="Dark mode"
+          className="px-2 py-1 border rounded bg-surface-0 dark:bg-surface-700 hover:bg-surface-100 dark:hover:bg-surface-600"
+        >
+          {dark ? 'Light' : 'Dark'}
         </button>
       </div>
       {mode === 'game' ? (

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -15,7 +15,7 @@ export const HelpModal: React.FC<HelpModalProps> = ({ isOpen, onClose }) => {
   if (!isOpen) return null;
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg p-4 max-w-md w-full shadow-lg">
+      <div className="bg-surface-0 dark:bg-surface-800 rounded-lg p-4 max-w-md w-full shadow-lg">
         <div className="flex justify-between items-center mb-2">
           <h2 className="text-lg font-bold">
             {view === 'yaku'
@@ -34,19 +34,19 @@ export const HelpModal: React.FC<HelpModalProps> = ({ isOpen, onClose }) => {
         </div>
         <div className="flex gap-2 mb-2">
           <button
-            className={`px-2 py-1 rounded ${view === 'yaku' ? 'bg-blue-200' : 'bg-gray-200'}`}
+            className={`px-2 py-1 rounded ${view === 'yaku' ? 'bg-primary-200 dark:bg-primary-700' : 'bg-surface-200 dark:bg-surface-600'}`}
             onClick={() => setView('yaku')}
           >
             役一覧
           </button>
           <button
-            className={`px-2 py-1 rounded ${view === 'score' ? 'bg-blue-200' : 'bg-gray-200'}`}
+            className={`px-2 py-1 rounded ${view === 'score' ? 'bg-primary-200 dark:bg-primary-700' : 'bg-surface-200 dark:bg-surface-600'}`}
             onClick={() => setView('score')}
           >
             点数表
           </button>
           <button
-            className={`px-2 py-1 rounded ${view === 'rules' ? 'bg-blue-200' : 'bg-gray-200'}`}
+            className={`px-2 py-1 rounded ${view === 'rules' ? 'bg-primary-200 dark:bg-primary-700' : 'bg-surface-200 dark:bg-surface-600'}`}
             onClick={() => setView('rules')}
           >
             ルール対応状況

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -211,7 +211,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
                 return (
                   <button
                     key={tile.id}
-                    className={`border rounded bg-white px-2 py-1 hover:bg-blue-100 ${isMyTurn ? '' : 'opacity-50 pointer-events-none'}`}
+                    className={`border rounded bg-surface-0 dark:bg-surface-700 px-2 py-1 hover:bg-primary-100 dark:hover:bg-primary-700 ${isMyTurn ? '' : 'opacity-50 pointer-events-none'}`}
                     onClick={() => onDiscard(tile.id)}
                     disabled={!isMyTurn}
                     aria-label={kanji}
@@ -229,7 +229,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
                 return (
                   <button
                     key={t.id}
-                    className={`border rounded bg-white px-2 py-1 hover:bg-blue-100 ml-4 ${isMyTurn ? '' : 'opacity-50 pointer-events-none'}`}
+                    className={`border rounded bg-surface-0 dark:bg-surface-700 px-2 py-1 hover:bg-primary-100 dark:hover:bg-primary-700 ml-4 ${isMyTurn ? '' : 'opacity-50 pointer-events-none'}`}
                     onClick={() => onDiscard(t.id)}
                     disabled={!isMyTurn}
                     aria-label={kanji}
@@ -246,7 +246,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
             {callOptions.map(act => (
               <button
                 key={act}
-                className="px-2 py-1 bg-yellow-200 rounded"
+                className="px-2 py-1 bg-warning-200 dark:bg-warning-700 rounded"
                 onClick={() => onCallAction?.(act)}
               >
                 {act === 'pon' ? 'ポン' : act === 'chi' ? 'チー' : act === 'kan' ? 'カン' : 'スルー'}
@@ -267,7 +267,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
               return (
                 <button
                   key={idx}
-                  className="px-2 py-1 bg-yellow-200 rounded flex gap-1"
+                  className="px-2 py-1 bg-warning-200 dark:bg-warning-700 rounded flex gap-1"
                   onClick={() => onChi?.(tiles)}
                   aria-label={labels}
                 >
@@ -285,7 +285,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
             {selfKanOptions.map((tiles, idx) => (
               <button
                 key={idx}
-                className="px-2 py-1 bg-green-200 rounded"
+                className="px-2 py-1 bg-secondary-200 dark:bg-secondary-700 rounded"
                 onClick={() => onSelfKan?.(tiles)}
               >
                 カン
@@ -295,19 +295,19 @@ export const UIBoard: React.FC<UIBoardProps> = ({
         )}
         {tsumoOption && (
           <div className="flex gap-2 mt-2">
-            <button className="px-2 py-1 bg-blue-200 rounded" onClick={() => onTsumo?.()}>ツモ</button>
-            <button className="px-2 py-1 bg-gray-200 rounded" onClick={() => onTsumoPass?.()}>スルー</button>
+            <button className="px-2 py-1 bg-primary-200 dark:bg-primary-700 rounded" onClick={() => onTsumo?.()}>ツモ</button>
+            <button className="px-2 py-1 bg-surface-200 dark:bg-surface-600 rounded" onClick={() => onTsumoPass?.()}>スルー</button>
           </div>
         )}
         {ronOption && (
           <div className="flex gap-2 mt-2">
-            <button className="px-2 py-1 bg-red-200 rounded" onClick={() => onRon?.()}>ロン</button>
-            <button className="px-2 py-1 bg-gray-200 rounded" onClick={() => onRonPass?.()}>スルー</button>
+            <button className="px-2 py-1 bg-danger-200 dark:bg-danger-700 rounded" onClick={() => onRon?.()}>ロン</button>
+            <button className="px-2 py-1 bg-surface-200 dark:bg-surface-600 rounded" onClick={() => onRonPass?.()}>スルー</button>
           </div>
         )}
         {onRiichi && isMyTurn && canDeclareRiichi(me) && (
           <button
-            className="mt-2 px-2 py-1 bg-red-200 rounded"
+            className="mt-2 px-2 py-1 bg-danger-200 dark:bg-danger-700 rounded"
             onClick={() => onRiichi()}
           >
             リーチ

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,23 @@
+const colors = require('tailwindcss/colors');
+const defaultTheme = require('tailwindcss/defaultTheme');
+
 module.exports = {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{ts,tsx}'],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      colors: {
+        surface: colors.gray,
+        primary: colors.sky,
+        secondary: colors.emerald,
+        danger: colors.red,
+        warning: colors.amber,
+      },
+      fontFamily: {
+        sans: ['Inter', ...defaultTheme.fontFamily.sans],
+        display: ['Poppins', ...defaultTheme.fontFamily.sans],
+      },
+    },
+  },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- enable class-based dark mode in Tailwind
- extend palette and fonts
- add dark mode toggle to App
- use theme colors in UI components
- test dark mode toggle

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a71583748832ab581a27d6d323961