### PR TITLE
Fix meld ordering for called tiles

### DIFF
--- a/src/components/Player.test.ts
+++ b/src/components/Player.test.ts
@@ -157,9 +157,9 @@ describe('claimMeld', () => {
     const fromRight = claimMeld(player, tiles, 'pon', 1, 'a');
     const fromOpposite = claimMeld(player, tiles, 'pon', 2, 'a');
     const fromLeft = claimMeld(player, tiles, 'pon', 3, 'a');
-    expect(fromRight.melds[0].tiles[0].id).toBe('a');
+    expect(fromRight.melds[0].tiles[2].id).toBe('a');
     expect(fromOpposite.melds[0].tiles[1].id).toBe('a');
-    expect(fromLeft.melds[0].tiles[2].id).toBe('a');
+    expect(fromLeft.melds[0].tiles[0].id).toBe('a');
   });
 
   it('orders kan tiles based on caller position', () => {
@@ -179,9 +179,9 @@ describe('claimMeld', () => {
     const fromRight = claimMeld(player, tiles, 'kan', 1, 'a');
     const fromOpposite = claimMeld(player, tiles, 'kan', 2, 'a');
     const fromLeft = claimMeld(player, tiles, 'kan', 3, 'a');
-    expect(fromRight.melds[0].tiles[0].id).toBe('a');
+    expect(fromRight.melds[0].tiles[3].id).toBe('a');
     expect(fromOpposite.melds[0].tiles[1].id).toBe('a');
-    expect(fromLeft.melds[0].tiles[3].id).toBe('a');
+    expect(fromLeft.melds[0].tiles[0].id).toBe('a');
   });
 });
 

--- a/src/components/Player.ts
+++ b/src/components/Player.ts
@@ -110,21 +110,22 @@ export function claimMeld(
         meldTiles = [...others, called];
       }
     } else if (type === 'pon') {
-      // Left -> rightmost, Right -> leftmost, Opposite -> middle
+      // Right -> rightmost, Left -> leftmost, Opposite -> middle
       if (relative === 1) {
-        meldTiles = [called, ...others];
+        meldTiles = [...others, called];
       } else if (relative === 2) {
         meldTiles = [others[0], called, others[1]];
       } else if (relative === 3) {
-        meldTiles = [...others, called];
+        meldTiles = [called, ...others];
       }
     } else if (type === 'kan') {
+      // Right -> rightmost, Left -> leftmost, Opposite -> second from left
       if (relative === 1) {
-        meldTiles = [called, ...others];
+        meldTiles = [...others, called];
       } else if (relative === 2) {
         meldTiles = [others[0], called, others[1], others[2]];
       } else if (relative === 3) {
-        meldTiles = [...others, called];
+        meldTiles = [called, ...others];
       }
     }
   }


### PR DESCRIPTION
## Summary
- fix order when claiming melds so tiles from the right are placed on the right
- update tests for new meld ordering logic

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_685a74b168f8832a81ff19d72fba80b0