### PR TITLE
Fix Help modal background

### DIFF
--- a/src/components/HelpModal.test.tsx
+++ b/src/components/HelpModal.test.tsx
@@ -39,4 +39,10 @@ describe('HelpModal', () => {
     const link = screen.getByRole('link', { name: 'README' });
     expect(link.getAttribute('href')).toContain('#rules-supported');
   });
+
+  it('renders modal window with white background', () => {
+    const { container } = render(<HelpModal isOpen onClose={() => {}} />);
+    const modal = container.querySelector('div.bg-white');
+    expect(modal).not.toBeNull();
+  });
 });

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -15,7 +15,7 @@ export const HelpModal: React.FC<HelpModalProps> = ({ isOpen, onClose }) => {
   if (!isOpen) return null;
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-surface-0 dark:bg-surface-800 rounded-lg p-4 max-w-md w-full shadow-lg">
+      <div className="bg-white rounded-lg p-4 max-w-md w-full shadow-lg">
         <div className="flex justify-between items-center mb-2">
           <h2 className="text-lg font-bold">
             {view === 'yaku'


### PR DESCRIPTION
## Summary
- revert HelpModal background color to `bg-white` to avoid transparency issues
- test that HelpModal uses white background

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a75140bc8832ab9cc314630e96644