### PR TITLE
Fix text color in dark mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ function App() {
 
   return (
     <div
-      className="min-h-screen bg-surface-100 dark:bg-surface-900 flex items-center justify-center py-2"
+      className="min-h-screen bg-surface-100 dark:bg-surface-900 text-surface-900 dark:text-surface-100 flex items-center justify-center py-2"
       style={{ ['--tile-font-size' as any]: `${tileFont}rem` } as React.CSSProperties}
     >
       <div className="w-full mx-auto px-4 space-y-4">


### PR DESCRIPTION
## Summary
- use light text color in dark mode to ensure readability

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a78cc9d98832a9d8a10272f4de3f7