### PR TITLE
Add kanType attribute and adjust scoring

### DIFF
--- a/src/components/Player.test.ts
+++ b/src/components/Player.test.ts
@@ -176,9 +176,9 @@ describe('claimMeld', () => {
     ];
     const player: PlayerState = { ...createInitialPlayerState('Bob', false), hand };
     const tiles = hand.slice();
-    const fromRight = claimMeld(player, tiles, 'kan', 1, 'a');
-    const fromOpposite = claimMeld(player, tiles, 'kan', 2, 'a');
-    const fromLeft = claimMeld(player, tiles, 'kan', 3, 'a');
+    const fromRight = claimMeld(player, tiles, 'kan', 1, 'a', 'daiminkan');
+    const fromOpposite = claimMeld(player, tiles, 'kan', 2, 'a', 'daiminkan');
+    const fromLeft = claimMeld(player, tiles, 'kan', 3, 'a', 'daiminkan');
     expect(fromRight.melds[0].tiles[3].id).toBe('a');
     expect(fromOpposite.melds[0].tiles[1].id).toBe('a');
     expect(fromLeft.melds[0].tiles[0].id).toBe('a');

--- a/src/components/Player.ts
+++ b/src/components/Player.ts
@@ -92,6 +92,7 @@ export function claimMeld(
   type: MeldType,
   fromPlayer: number,
   calledTileId: string,
+  kanType?: 'ankan' | 'kakan' | 'daiminkan',
 ): PlayerState {
   // remove called tiles from hand
   const hand = player.hand.filter(h => !tiles.some(t => t.id === h.id));
@@ -132,7 +133,10 @@ export function claimMeld(
   return {
     ...player,
     hand: sortHand(hand),
-    melds: [...player.melds, { type, tiles: meldTiles, fromPlayer, calledTileId }],
+    melds: [
+      ...player.melds,
+      { type, tiles: meldTiles, fromPlayer, calledTileId, kanType },
+    ],
   };
 }
 

--- a/src/game/isChankan.test.ts
+++ b/src/game/isChankan.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { isChankan } from './isChankan';
+import { LogEntry, Tile } from '../types/mahjong';
+
+describe('isChankan', () => {
+  const tile: Tile = { suit: 'man', rank: 1, id: 'a' };
+  it('returns true for kakan ron', () => {
+    const prev: LogEntry = {
+      type: 'meld',
+      player: 1,
+      tiles: [tile],
+      meldType: 'kan',
+      from: 1,
+      kanType: 'kakan',
+    };
+    expect(isChankan(prev, 1, tile)).toBe(true);
+  });
+
+  it('returns false for daiminkan', () => {
+    const prev: LogEntry = {
+      type: 'meld',
+      player: 1,
+      tiles: [tile],
+      meldType: 'kan',
+      from: 0,
+      kanType: 'daiminkan',
+    };
+    expect(isChankan(prev, 1, tile)).toBe(false);
+  });
+});

--- a/src/game/isChankan.ts
+++ b/src/game/isChankan.ts
@@ -1,0 +1,12 @@
+import { LogEntry, Tile } from '../types/mahjong';
+
+export function isChankan(prev: LogEntry | undefined, from: number, tile: Tile): boolean {
+  return (
+    !!prev &&
+    prev.type === 'meld' &&
+    prev.meldType === 'kan' &&
+    prev.player === from &&
+    prev.tiles.some(t => t.id === tile.id) &&
+    prev.kanType === 'kakan'
+  );
+}

--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { Tile, PlayerState, LogEntry, MeldType } from '../types/mahjong';
+import { isChankan } from './isChankan';
 import { generateTileWall, drawDoraIndicator } from '../components/TileWall';
 import {
   createInitialPlayerState,
@@ -74,7 +75,9 @@ const boardPresets: Record<string, BoardData> = (() => {
     const p2 = createInitialPlayerState('対面', true, 2);
     const kan = [t('sou', 1), t('sou', 1), t('sou', 1), t('sou', 1)];
     p2.hand = [t('pin', 1), t('pin', 2), t('pin', 3), t('man', 4), t('man', 5), t('man', 6), t('wind', 1), t('wind', 2), t('dragon', 1)];
-    p2.melds = [{ type: 'kan', tiles: kan, fromPlayer: 3, calledTileId: kan[0].id }];
+    p2.melds = [
+      { type: 'kan', tiles: kan, fromPlayer: 3, calledTileId: kan[0].id, kanType: 'daiminkan' },
+    ];
 
     const p3 = createInitialPlayerState('上家', true, 3);
     p3.hand = [t('man', 2), t('pin', 2), t('sou', 2), t('wind', 1), t('wind', 2), t('wind', 3), t('dragon', 1), t('dragon', 2), t('dragon', 3), t('man', 9), t('pin', 9), t('sou', 9), t('man', 1)];
@@ -98,7 +101,9 @@ const boardPresets: Record<string, BoardData> = (() => {
     const p2 = createInitialPlayerState('対面', true, 2);
     const kan = [t('sou', 1), t('sou', 1), t('sou', 1), t('sou', 1)];
     p2.hand = [t('pin', 1), t('pin', 2), t('pin', 3), t('man', 4), t('man', 5), t('man', 6), t('wind', 1), t('wind', 2), t('dragon', 1)];
-    p2.melds = [{ type: 'kan', tiles: kan, fromPlayer: 3, calledTileId: kan[0].id }];
+    p2.melds = [
+      { type: 'kan', tiles: kan, fromPlayer: 3, calledTileId: kan[0].id, kanType: 'daiminkan' },
+    ];
 
     const p3 = createInitialPlayerState('上家', true, 3);
     p3.hand = [t('man', 2), t('pin', 2), t('sou', 2), t('wind', 1), t('wind', 2), t('wind', 3), t('dragon', 1), t('dragon', 2), t('dragon', 3), t('man', 9), t('pin', 9), t('sou', 9), t('man', 1)];
@@ -110,17 +115,23 @@ const boardPresets: Record<string, BoardData> = (() => {
     const p0 = createInitialPlayerState('自分', false, 0);
     const ankan = [t('man', 5), t('man', 5), t('man', 5), t('man', 5)];
     p0.hand = [t('pin', 1), t('pin', 2), t('pin', 3), t('sou', 1), t('sou', 2), t('sou', 3), t('wind', 1), t('wind', 2), t('dragon', 1), t('dragon', 2), t('man', 7), t('man', 8), t('man', 9)];
-    p0.melds = [{ type: 'kan', tiles: ankan, fromPlayer: 0, calledTileId: ankan[0].id }];
+    p0.melds = [
+      { type: 'kan', tiles: ankan, fromPlayer: 0, calledTileId: ankan[0].id, kanType: 'ankan' },
+    ];
 
     const p1 = createInitialPlayerState('下家', true, 1);
     const minkan = [t('pin', 7), t('pin', 7), t('pin', 7), t('pin', 7)];
     p1.hand = [t('man', 1), t('man', 2), t('man', 3), t('sou', 4), t('sou', 5), t('sou', 6), t('wind', 3), t('wind', 4), t('dragon', 3)];
-    p1.melds = [{ type: 'kan', tiles: minkan, fromPlayer: 2, calledTileId: minkan[1].id }];
+    p1.melds = [
+      { type: 'kan', tiles: minkan, fromPlayer: 2, calledTileId: minkan[1].id, kanType: 'daiminkan' },
+    ];
 
     const p2 = createInitialPlayerState('対面', true, 2);
     const kakan = [t('sou', 3), t('sou', 3), t('sou', 3), t('sou', 3)];
     p2.hand = [t('pin', 1), t('pin', 2), t('pin', 3), t('man', 4), t('man', 5), t('man', 6), t('wind', 1), t('wind', 2), t('dragon', 1)];
-    p2.melds = [{ type: 'kan', tiles: kakan, fromPlayer: 1, calledTileId: kakan[0].id }];
+    p2.melds = [
+      { type: 'kan', tiles: kakan, fromPlayer: 1, calledTileId: kakan[0].id, kanType: 'kakan' },
+    ];
 
     const p3 = createInitialPlayerState('上家', true, 3);
     p3.hand = [t('man', 2), t('pin', 2), t('sou', 2), t('wind', 1), t('wind', 2), t('wind', 3), t('dragon', 1), t('dragon', 2), t('dragon', 3), t('man', 9), t('pin', 9), t('sou', 9), t('man', 1)];
@@ -142,7 +153,9 @@ const boardPresets: Record<string, BoardData> = (() => {
     const p2 = createInitialPlayerState('対面', true, 2);
     const kan = [t('sou', 1), t('sou', 1), t('sou', 1), t('sou', 1)];
     p2.hand = [t('pin', 1), t('pin', 2), t('pin', 3), t('man', 4), t('man', 5), t('man', 6), t('wind', 1), t('wind', 2), t('dragon', 1)];
-    p2.melds = [{ type: 'kan', tiles: kan, fromPlayer: 3, calledTileId: kan[0].id }];
+    p2.melds = [
+      { type: 'kan', tiles: kan, fromPlayer: 3, calledTileId: kan[0].id, kanType: 'daiminkan' },
+    ];
 
     const p3 = createInitialPlayerState('上家', true, 3);
     p3.hand = [t('man', 2), t('pin', 2), t('sou', 2), t('wind', 1), t('wind', 2), t('wind', 3), t('dragon', 1), t('dragon', 2), t('dragon', 3), t('man', 9), t('pin', 9), t('sou', 9), t('man', 1)];
@@ -546,6 +559,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
     action,
     discarder,
     lastDiscard.tile.id,
+    action === 'kan' ? 'daiminkan' : undefined,
   );
   setPlayers(p);
   playersRef.current = p;
@@ -557,6 +571,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
       tiles: [...meldTiles, lastDiscard.tile],
       meldType: action,
       from: discarder,
+      kanType: action === 'kan' ? 'daiminkan' : undefined,
     },
   ]);
   logRef.current = [
@@ -594,16 +609,16 @@ const handleCallAction = (action: MeldType | 'pass') => {
     if (!canCallMeld(playersRef.current[caller])) return;
     let p = playersRef.current.map(pl => clearIppatsu(pl));
   p = [...p];
-  p[caller] = claimMeld(p[caller], tiles, 'kan', caller, tiles[0].id);
+  p[caller] = claimMeld(p[caller], tiles, 'kan', caller, tiles[0].id, 'ankan');
   setPlayers(p);
   playersRef.current = p;
   setLog(prev => [
     ...prev,
-    { type: 'meld', player: caller, tiles, meldType: 'kan', from: caller },
+    { type: 'meld', player: caller, tiles, meldType: 'kan', from: caller, kanType: 'ankan' },
   ]);
   logRef.current = [
     ...logRef.current,
-    { type: 'meld', player: caller, tiles, meldType: 'kan', from: caller },
+    { type: 'meld', player: caller, tiles, meldType: 'kan', from: caller, kanType: 'ankan' },
   ];
 
   kanDrawRef.current = caller;
@@ -631,6 +646,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
       action,
       discarder,
       lastDiscard.tile.id,
+      action === 'kan' ? 'daiminkan' : undefined,
     );
     setPlayers(p);
     playersRef.current = p;
@@ -642,6 +658,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
         tiles: [...meldTiles, lastDiscard.tile],
         meldType: action,
         from: discarder,
+        kanType: action === 'kan' ? 'daiminkan' : undefined,
       },
     ]);
     logRef.current = [
@@ -652,6 +669,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
         tiles: [...meldTiles, lastDiscard.tile],
         meldType: action,
         from: discarder,
+        kanType: action === 'kan' ? 'daiminkan' : undefined,
       },
     ];
     setMessage(`${p[caller].name} が ${action}しました。`);
@@ -746,7 +764,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
     const fromInfo = drawInfoRef.current[from];
     drawInfoRef.current[from] = { rinshan: false, last: false };
     const prev = logRef.current[logRef.current.length - 1];
-    const chankan = prev && prev.type === 'meld' && prev.meldType === 'kan' && prev.player === from && prev.tiles.some(t => t.id === tile.id);
+    const chankan = isChankan(prev, from, tile);
     const seatWind = p[winner].seat + 1;
     const roundWind = kyokuRef.current <= 4 ? 1 : 2;
     const yaku = detectYaku(fullHand, p[winner].melds, {

--- a/src/quiz/sampleHands.ts
+++ b/src/quiz/sampleHands.ts
@@ -41,7 +41,7 @@ export const SAMPLE_HANDS: SampleHand[] = [
       t('man',5,'m5a'),t('man',5,'m5b'),
     ],
     melds: [
-      { type: 'kan', tiles: [t('dragon',1,'k1a'),t('dragon',1,'k1b'),t('dragon',1,'k1c')], fromPlayer: 2, calledTileId: 'k1a' },
+      { type: 'kan', tiles: [t('dragon',1,'k1a'),t('dragon',1,'k1b'),t('dragon',1,'k1c')], fromPlayer: 2, calledTileId: 'k1a', kanType: 'daiminkan' },
     ],
     winningTile: t('man',5,'m5b'),
   },

--- a/src/score/calculateFu.test.ts
+++ b/src/score/calculateFu.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { SAMPLE_HANDS } from '../quiz/sampleHands';
 import { calculateFu } from './score';
-import { Tile } from '../types/mahjong';
+import { Tile, Meld } from '../types/mahjong';
 
 const t = (suit: Tile['suit'], rank: number, id: string): Tile => ({
   suit,
@@ -24,10 +24,30 @@ describe('calculateFu', () => {
     expect(fu).toBe(30);
   });
 
-  it('computes fu for a hand with a dragon kan', () => {
+  it('computes fu for a daiminkan', () => {
     const { hand, melds } = SAMPLE_HANDS[2];
     const fu = calculateFu(hand, melds);
     // 基本符20 + 明カン(役牌)16 = 36、切り上げで40符になるはず
+    expect(fu).toBe(40);
+  });
+
+  it('computes fu for an ankan', () => {
+    const { hand, melds } = SAMPLE_HANDS[2];
+    const closed: Meld[] = [
+      { ...melds[0], fromPlayer: 0, kanType: 'ankan' },
+    ];
+    const fu = calculateFu(hand, closed);
+    // 基本符20 + 暗カン(役牌)32 = 52、切り上げで60符になるはず
+    expect(fu).toBe(60);
+  });
+
+  it('treats kakan as open kan for fu', () => {
+    const { hand, melds } = SAMPLE_HANDS[2];
+    const added: Meld[] = [
+      { ...melds[0], fromPlayer: 0, kanType: 'kakan' },
+    ];
+    const fu = calculateFu(hand, added, { seatWind: 1 });
+    // 加カンは明カン扱いなので40符になるはず
     expect(fu).toBe(40);
   });
 

--- a/src/score/calculateFuDetail.ts
+++ b/src/score/calculateFuDetail.ts
@@ -164,7 +164,9 @@ export function calculateFuDetail(
         fu += val;
         steps.push(`${label} +${val} (${tilesToString(open.tiles)})`);
       } else if (open.type === 'kan') {
-        const closed = open.fromPlayer === seatIndex;
+        const closed = open.kanType
+          ? open.kanType === 'ankan'
+          : open.fromPlayer === seatIndex;
         const val = isTerminalOrHonor(open.tiles[0])
           ? closed
             ? 32

--- a/src/score/score.ts
+++ b/src/score/score.ts
@@ -157,7 +157,9 @@ export function calculateFu(
       if (open.type === 'pon') {
         fu += isTerminalOrHonor(open.tiles[0]) ? 4 : 2;
       } else if (open.type === 'kan') {
-        const closed = open.fromPlayer === seatIndex;
+        const closed = open.kanType
+          ? open.kanType === 'ankan'
+          : open.fromPlayer === seatIndex;
         if (closed) {
           fu += isTerminalOrHonor(open.tiles[0]) ? 32 : 16;
         } else {

--- a/src/score/yaku.test.ts
+++ b/src/score/yaku.test.ts
@@ -442,7 +442,7 @@ describe('Scoring', () => {
       t('man',5,'m5a'),t('man',5,'m5b'),
     ];
     const melds: Meld[] = [
-      { type: 'kan', tiles: kanTiles, fromPlayer: 2, calledTileId: 'k1a' },
+      { type: 'kan', tiles: kanTiles, fromPlayer: 2, calledTileId: 'k1a', kanType: 'daiminkan' },
     ];
     const fullHand = [...concealed, ...kanTiles];
     const yaku = detectYaku(fullHand, melds, { isTsumo: true });

--- a/src/types/jantama.ts
+++ b/src/types/jantama.ts
@@ -36,6 +36,7 @@ export interface RecordCall extends RecordActionBase {
   tiles: string[];
   meldType: string;
   from: number;
+  kanType?: 'ankan' | 'kakan' | 'daiminkan';
 }
 
 export interface RecordRiichi extends RecordActionBase {

--- a/src/types/mahjong.ts
+++ b/src/types/mahjong.ts
@@ -20,6 +20,8 @@ export interface Meld {
   fromPlayer: number;
   /** id of the tile claimed from another player's discard */
   calledTileId: string;
+  /** type of kan if this meld is a kan */
+  kanType?: 'ankan' | 'kakan' | 'daiminkan';
 }
 
 // プレイヤー状態
@@ -49,6 +51,7 @@ export type LogEntry =
       tiles: Tile[];
       meldType: MeldType;
       from: number;
+      kanType?: 'ankan' | 'kakan' | 'daiminkan';
     }
   | { type: 'riichi'; player: number; tile: Tile }
   | { type: 'tsumo'; player: number; tile: Tile }

--- a/src/utils/paifuExport.test.ts
+++ b/src/utils/paifuExport.test.ts
@@ -16,15 +16,20 @@ const log: LogEntry[] = [
   { type: 'startRound', kyoku: 1 },
   { type: 'draw', player: 0, tile },
   { type: 'discard', player: 0, tile },
+  { type: 'meld', player: 0, tiles: [tile, tile, tile, tile], meldType: 'kan', from: 1, kanType: 'daiminkan' },
 ];
 
 describe('exportLqRecord', () => {
   it('maps log entries to lq actions', () => {
     const result = exportLqRecord(log, sampleHead);
     expect(result.name).toBe('.lq.GameDetailRecords');
-    expect(result.data.length).toBe(3);
+    expect(result.data.length).toBe(4);
     expect(result.data[0].actions[0].name).toBe('.lq.RecordNewRound');
     expect(result.data[1].actions[0].name).toBe('.lq.RecordDrawTile');
     expect(result.data[2].actions[0].name).toBe('.lq.RecordDiscardTile');
+    expect(result.data[3].actions[0]).toMatchObject({
+      name: '.lq.RecordCall',
+      kanType: 'daiminkan',
+    });
   });
 });

--- a/src/utils/paifuExport.ts
+++ b/src/utils/paifuExport.ts
@@ -16,6 +16,7 @@ function convertAction(entry: LogEntry): RecordAction {
         tiles: entry.tiles.map(t => t.id),
         meldType: entry.meldType,
         from: entry.from,
+        kanType: entry.kanType,
       };
     case 'riichi':
       return { name: '.lq.RecordRiichi', seat: entry.player, tile: entry.tile.id };


### PR DESCRIPTION
## Summary
- extend `Meld` with `kanType` and update logs/exports
- support kan type in board presets and sample hands
- adjust fu calculation to use kanType
- detect chankan only for kakan melds
- export kan type in `.lq` records
- add helper `isChankan` with tests
- expand fu tests for each kan type

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a87134dd0832a8d2e10448cfe548d