### PR TITLE
Refactor rotation logic

### DIFF
--- a/src/components/MeldView.tsx
+++ b/src/components/MeldView.tsx
@@ -1,32 +1,10 @@
 import React from 'react';
 import { Meld } from '../types/mahjong';
 import { TileView } from './TileView';
+import { rotationForSeat } from '../utils/rotation';
 
-const seatRotation = (seat: number) => {
-  switch (seat % 4) {
-    case 1:
-      return 270;
-    case 3:
-      return 90;
-    case 2:
-      return 180;
-    default:
-      return 0;
-  }
-};
-
-const seatMeldRotation = (seat: number): number => {
-  switch (seat % 4) {
-    case 1:
-      return 270;
-    case 2:
-      return 180;
-    case 3:
-      return 90;
-    default:
-      return 0;
-  }
-};
+const seatRotation = rotationForSeat;
+const seatMeldRotation = rotationForSeat;
 
 const calledRotation = (seat: number, from: number) => {
   if (from === seat) return 0;

--- a/src/components/RiverView.tsx
+++ b/src/components/RiverView.tsx
@@ -1,32 +1,10 @@
 import React from 'react';
 import { Tile } from '../types/mahjong';
 import { TileView } from './TileView';
+import { rotationForSeat } from '../utils/rotation';
 
-const seatRotation = (seat: number): number => {
-  switch (seat % 4) {
-    case 1:
-      return 270;
-    case 3:
-      return 90;
-    case 2:
-      return 180;
-    default:
-      return 0;
-  }
-};
-
-const seatRiverRotation = (seat: number): number => {
-  switch (seat % 4) {
-    case 1:
-      return 270;
-    case 2:
-      return 180;
-    case 3:
-      return 90;
-    default:
-      return 0;
-  }
-};
+const seatRotation = rotationForSeat;
+const seatRiverRotation = rotationForSeat;
 
 
 const calledOffset = (seat: number): string => {

--- a/src/utils/rotation.ts
+++ b/src/utils/rotation.ts
@@ -1,0 +1,4 @@
+export const rotationForSeat = (seat: number): number => {
+  const rotations = [0, 270, 180, 90];
+  return rotations[(seat % 4 + 4) % 4];
+};


### PR DESCRIPTION
## Summary
- share rotation constants for seat-based view components
- simplify RiverView and MeldView rotation logic

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a91dd1f98832a853ef544bea2a428