### PR TITLE
Render special kan tiles

### DIFF
--- a/src/components/MeldView.test.tsx
+++ b/src/components/MeldView.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { MeldView } from './MeldView';
-import { Meld } from '../types/mahjong';
+import { Meld, Tile } from '../types/mahjong';
 
 describe('MeldView', () => {
   it('renders all tiles in the meld', () => {
@@ -55,6 +55,44 @@ describe('MeldView', () => {
     };
     const html = renderToStaticMarkup(<MeldView meld={meld} seat={1} />);
     expect(html).toContain('rotate(270deg)');
+  });
+
+  it('shows face-down tiles for ankan', () => {
+    const tiles: Tile[] = [
+      { suit: 'man', rank: 9, id: 'a' },
+      { suit: 'man', rank: 9, id: 'b' },
+      { suit: 'man', rank: 9, id: 'c' },
+      { suit: 'man', rank: 9, id: 'd' },
+    ];
+    const meld: Meld = {
+      type: 'kan',
+      tiles,
+      fromPlayer: 0,
+      calledTileId: 'a',
+      kanType: 'ankan',
+    };
+    const html = renderToStaticMarkup(<MeldView meld={meld} />);
+    const count = (html.match(/🂠/g) || []).length;
+    expect(count).toBe(2);
+  });
+
+  it('renders kakan tile vertically', () => {
+    const tiles: Tile[] = [
+      { suit: 'sou', rank: 3, id: 'a' },
+      { suit: 'sou', rank: 3, id: 'b' },
+      { suit: 'sou', rank: 3, id: 'c' },
+      { suit: 'sou', rank: 3, id: 'd' },
+    ];
+    const meld: Meld = {
+      type: 'kan',
+      tiles,
+      fromPlayer: 0,
+      calledTileId: 'd',
+      kanType: 'kakan',
+    };
+    const html = renderToStaticMarkup(<MeldView meld={meld} />);
+    const count = (html.match(/rotate\(90deg\)/g) || []).length;
+    expect(count).toBe(1);
   });
 
   // Style-specific rotations are tested elsewhere; focus on tile count here.

--- a/src/components/MeldView.tsx
+++ b/src/components/MeldView.tsx
@@ -31,10 +31,24 @@ export const MeldView: React.FC<{ meld: Meld; seat?: number }> = ({ meld, seat =
         <TileView
           key={tile.id}
           tile={tile}
+          faceDown={
+            meld.type === 'kan' && meld.kanType === 'ankan' &&
+            (tile === meld.tiles[0] || tile === meld.tiles[3])
+          }
           rotate={
             seatRotation(seat) -
             seatMeldRotation(seat) +
-            (tile.id === meld.calledTileId ? calledRotation(seat, meld.fromPlayer) : 0)
+            (tile.id === meld.calledTileId
+              ? meld.kanType === 'kakan'
+                ? 90
+                : calledRotation(seat, meld.fromPlayer)
+              : 0)
+          }
+          extraTransform={
+            meld.type === 'kan' && meld.kanType === 'kakan' &&
+            tile.id === meld.calledTileId
+              ? 'translateY(-4px)'
+              : ''
           }
         />
       ))}

--- a/src/components/TileView.tsx
+++ b/src/components/TileView.tsx
@@ -4,10 +4,12 @@ import { Tile, Suit } from '../types/mahjong';
 export const TileView: React.FC<{
   tile: Tile;
   isShonpai?: boolean;
+  /** render the tile face-down */
+  faceDown?: boolean;
   className?: string;
   rotate?: number;
   extraTransform?: string;
-}> = ({ tile, isShonpai, className, rotate = 0, extraTransform = '' }) => {
+}> = ({ tile, isShonpai, faceDown = false, className, rotate = 0, extraTransform = '' }) => {
   const suitMap: Record<string, string> = { man: '萬', pin: '筒', sou: '索', wind: '', dragon: '' };
   const honorMap: Record<string, Record<number, string>> = {
     wind: { 1: '東', 2: '南', 3: '西', 4: '北' },
@@ -69,7 +71,9 @@ export const TileView: React.FC<{
       aria-label={kanji}
       style={{ transform: `rotate(${rotate}deg) ${extraTransform}` }}
     >
-      <span className="font-emoji">{emojiMap[tile.suit]?.[tile.rank] ?? kanji}</span>
+      <span className="font-emoji">
+        {faceDown ? '🂠' : emojiMap[tile.suit]?.[tile.rank] ?? kanji}
+      </span>
       {isShonpai && (
         <span className="absolute -top-1 -right-1 text-xs text-yellow-500">
           ★


### PR DESCRIPTION
## Summary
- support face-down tiles in TileView
- show face-down outer tiles for concealed kan melds
- display kakan fourth tile vertically
- test MeldView kan types

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a945772f8832aa96f1cb3f02c6f0d