### PR TITLE
Refactor scoreboard layout

### DIFF
--- a/src/components/UIBoard.test.tsx
+++ b/src/components/UIBoard.test.tsx
@@ -211,13 +211,13 @@ describe('UIBoard responsiveness', () => {
 });
 
 describe('UIBoard layout', () => {
-  it('uses grid areas for seats and center', () => {
+  it('uses grid areas for seats and info panel', () => {
     renderBoard({ standard: 1, chiitoi: 1, kokushi: 13 });
     const board = screen.getByTestId('ui-board');
     expect(board.style.gridTemplateAreas).toContain('top');
-    expect(board.style.gridTemplateAreas).toContain('center');
-    const center = screen.getByTestId('center-area');
-    expect(center.style.gridArea).toBe('center');
+    expect(board.style.gridTemplateAreas).toContain('info');
+    const info = screen.getByTestId('info-area');
+    expect(info.style.gridArea).toBe('info');
   });
 });
 

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -83,11 +83,12 @@ export const UIBoard: React.FC<UIBoardProps> = ({
   return (
     <div
       data-testid="ui-board"
-      className="w-full grid gap-2 place-items-center"
+      className="w-full grid gap-2 place-items-center mx-auto max-w-screen-md"
       style={{
-        gridTemplateColumns: 'auto 1fr auto',
-        gridTemplateRows: 'auto 1fr auto',
+        gridTemplateColumns: 'auto auto auto',
+        gridTemplateRows: 'auto auto 1fr auto',
         gridTemplateAreas: `
+          'info info info'
           '. top .'
           'left center right'
           '. me .'
@@ -163,9 +164,9 @@ export const UIBoard: React.FC<UIBoardProps> = ({
 
       {/* ドラ表示と局情報 */}
       <div
-        className="flex items-center gap-4"
-        style={{ gridArea: 'center' }}
-        data-testid="center-area"
+        className="flex items-center gap-4 justify-center"
+        style={{ gridArea: 'info' }}
+        data-testid="info-area"
       >
         <ScoreBoard kyoku={kyoku} wallCount={wallCount} kyotaku={kyotaku} honba={honba} />
         <div className="flex flex-col items-center gap-1">


### PR DESCRIPTION
## Summary
- move `<ScoreBoard>` and dora indicator into a new `info` panel at the top of `UIBoard`
- center the board with a narrower max width
- update layout test accordingly

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b40a65798832a9f355895c8277333