### PR TITLE
Adjust river slot count

### DIFF
--- a/src/components/RiverView.test.tsx
+++ b/src/components/RiverView.test.tsx
@@ -2,7 +2,11 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import React from 'react';
 import { render, screen, cleanup } from '@testing-library/react';
-import { RiverView, RESERVED_RIVER_SLOTS } from './RiverView';
+import {
+  RiverView,
+  RESERVED_RIVER_SLOTS,
+  RESERVED_RIVER_SLOTS_MOBILE,
+} from './RiverView';
 import { Tile } from '../types/mahjong';
 
 const t = (suit: Tile['suit'], rank: number, id: string): Tile => ({ suit, rank, id });
@@ -33,6 +37,14 @@ describe('RiverView', () => {
     render(<RiverView tiles={[]} seat={0} lastDiscard={null} dataTestId="rv" />);
     const div = screen.getByTestId('rv');
     expect(div.children.length).toBe(RESERVED_RIVER_SLOTS);
+  });
+
+  it('uses fewer slots on small screens', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 500, writable: true });
+    render(<RiverView tiles={[]} seat={0} lastDiscard={null} dataTestId="rv-m" />);
+    const div = screen.getByTestId('rv-m');
+    expect(div.children.length).toBe(RESERVED_RIVER_SLOTS_MOBILE);
+    Object.defineProperty(window, 'innerWidth', { value: 1024, writable: true });
   });
 
   it('rotates riichi discards', () => {

--- a/src/components/RiverView.tsx
+++ b/src/components/RiverView.tsx
@@ -20,8 +20,35 @@ const calledOffset = (seat: number): string => {
   }
 };
 
-/** minimum cells to reserve for a player's discard area */
-export const RESERVED_RIVER_SLOTS = 20;
+/**
+ * Minimum cells to reserve for a player's discard area on large screens.
+ * Mobile layouts typically only show three rows of discards, so fewer
+ * placeholders are required.
+ */
+export const RESERVED_RIVER_SLOTS = 24;
+export const RESERVED_RIVER_SLOTS_MOBILE = 18;
+
+const smallScreen = ():
+  boolean => typeof window !== 'undefined' && window.innerWidth < 640;
+
+/**
+ * Returns a slot count that updates when the window is resized.
+ */
+export const useResponsiveRiverSlots = (): number => {
+  const [slots, setSlots] = React.useState(
+    smallScreen() ? RESERVED_RIVER_SLOTS_MOBILE : RESERVED_RIVER_SLOTS,
+  );
+  React.useEffect(() => {
+    const handler = () => {
+      setSlots(
+        smallScreen() ? RESERVED_RIVER_SLOTS_MOBILE : RESERVED_RIVER_SLOTS,
+      );
+    };
+    window.addEventListener('resize', handler);
+    return () => window.removeEventListener('resize', handler);
+  }, []);
+  return slots;
+};
 
 interface RiverViewProps {
   tiles: Tile[];
@@ -37,10 +64,11 @@ export const RiverView: React.FC<RiverViewProps> = ({
   dataTestId,
 }) => {
   const ordered = tiles;
-  const placeholdersCount = Math.max(0, RESERVED_RIVER_SLOTS - ordered.length);
+  const reservedSlots = useResponsiveRiverSlots();
+  const placeholdersCount = Math.max(0, reservedSlots - ordered.length);
   return (
     <div
-      className="grid grid-cols-6 gap-1"
+      className="grid grid-cols-6 gap-1 grid-rows-3 sm:grid-rows-4"
       style={{ transform: `rotate(${seatRiverRotation(seat)}deg)` }}
       data-testid={dataTestId}
     >


### PR DESCRIPTION
## Summary
- enlarge RiverView slot reservations to cover full discard count
- make slot count responsive to screen size
- test mobile discard area size

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b41fb095c832ab7cbfe066d3a70af