### PR TITLE
Add river gap constant and tests

### DIFF
--- a/src/components/RiverView.test.tsx
+++ b/src/components/RiverView.test.tsx
@@ -6,6 +6,7 @@ import {
   RiverView,
   RESERVED_RIVER_SLOTS,
   RESERVED_RIVER_SLOTS_MOBILE,
+  RIVER_GAP_PX,
 } from './RiverView';
 import { Tile } from '../types/mahjong';
 
@@ -52,6 +53,17 @@ describe('RiverView', () => {
     render(<RiverView tiles={tiles} seat={0} lastDiscard={null} dataTestId="rv" />);
     const tileEls = screen.getByTestId('rv').querySelectorAll('[style]');
     expect(tileEls[1].getAttribute('style')).toContain('rotate(90deg)');
+  });
+
+  it('uses consistent gap for all seats', () => {
+    [0, 1, 2, 3].forEach(seat => {
+      render(
+        <RiverView tiles={[]} seat={seat} lastDiscard={null} dataTestId={`gap-${seat}`} />,
+      );
+      const div = screen.getByTestId(`gap-${seat}`);
+      expect(div.style.gap).toBe(`${RIVER_GAP_PX}px`);
+      cleanup();
+    });
   });
 
 });

--- a/src/components/RiverView.tsx
+++ b/src/components/RiverView.tsx
@@ -6,6 +6,8 @@ import { rotationForSeat } from '../utils/rotation';
 const seatRotation = rotationForSeat;
 const seatRiverRotation = rotationForSeat;
 
+export const RIVER_GAP_PX = 4;
+
 
 const calledOffset = (seat: number): string => {
   switch (seat % 4) {
@@ -68,8 +70,8 @@ export const RiverView: React.FC<RiverViewProps> = ({
   const placeholdersCount = Math.max(0, reservedSlots - ordered.length);
   return (
     <div
-      className="grid grid-cols-6 gap-1 grid-rows-3 sm:grid-rows-4"
-      style={{ transform: `rotate(${seatRiverRotation(seat)}deg)` }}
+      className="grid grid-cols-6 grid-rows-3 sm:grid-rows-4"
+      style={{ transform: `rotate(${seatRiverRotation(seat)}deg)`, gap: RIVER_GAP_PX }}
       data-testid={dataTestId}
     >
       {ordered.map(tile => (


### PR DESCRIPTION
## Summary
- expose `RIVER_GAP_PX` constant
- use inline style for river gap
- test that `RiverView` keeps the same gap for all seats

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bbf39dc50832aa099a9e59815b311