### PR TITLE
Use constant for called tile offsets

### DIFF
--- a/src/components/RiverView.test.tsx
+++ b/src/components/RiverView.test.tsx
@@ -7,6 +7,7 @@ import {
   RESERVED_RIVER_SLOTS,
   RESERVED_RIVER_SLOTS_MOBILE,
   RIVER_GAP_PX,
+  CALLED_OFFSET_PX,
 } from './RiverView';
 import { Tile } from '../types/mahjong';
 
@@ -53,6 +54,17 @@ describe('RiverView', () => {
     render(<RiverView tiles={tiles} seat={0} lastDiscard={null} dataTestId="rv" />);
     const tileEls = screen.getByTestId('rv').querySelectorAll('[style]');
     expect(tileEls[1].getAttribute('style')).toContain('rotate(90deg)');
+  });
+
+  it('offsets called tiles using the constant', () => {
+    const tiles = [{ ...t('pin', 5, 'c'), called: true }];
+    render(
+      <RiverView tiles={tiles} seat={2} lastDiscard={null} dataTestId="rv-called" />,
+    );
+    const tile = screen.getByTestId('rv-called').querySelector('[style]');
+    expect(tile?.getAttribute('style')).toContain(
+      `translateX(-${CALLED_OFFSET_PX}px)`,
+    );
   });
 
   it('uses consistent gap for all seats', () => {

--- a/src/components/RiverView.tsx
+++ b/src/components/RiverView.tsx
@@ -7,18 +7,19 @@ const seatRotation = rotationForSeat;
 const seatRiverRotation = rotationForSeat;
 
 export const RIVER_GAP_PX = 4;
+export const CALLED_OFFSET_PX = 6;
 
 
 const calledOffset = (seat: number): string => {
   switch (seat % 4) {
     case 1:
-      return 'translateY(-6px)';
+      return `translateY(-${CALLED_OFFSET_PX}px)`;
     case 2:
-      return 'translateX(-6px)';
+      return `translateX(-${CALLED_OFFSET_PX}px)`;
     case 3:
-      return 'translateY(6px)';
+      return `translateY(${CALLED_OFFSET_PX}px)`;
     default:
-      return 'translateX(6px)';
+      return `translateX(${CALLED_OFFSET_PX}px)`;
   }
 };
 


### PR DESCRIPTION
## Summary
- define `CALLED_OFFSET_PX` constant in `RiverView`
- use `CALLED_OFFSET_PX` in `calledOffset`
- verify called tile transform uses the constant

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_685bc111af08832a9897eb20f2b59b98