### PR TITLE
Fix river grid width for rotated seats

### DIFF
--- a/src/components/RiverView.test.tsx
+++ b/src/components/RiverView.test.tsx
@@ -6,6 +6,9 @@ import {
   RiverView,
   RESERVED_RIVER_SLOTS,
   RESERVED_RIVER_SLOTS_MOBILE,
+  RIVER_COLS,
+  RIVER_ROWS_MOBILE,
+  RIVER_ROWS_DESKTOP,
   RIVER_GAP_PX,
   CALLED_OFFSET_PX,
 } from './RiverView';
@@ -74,6 +77,27 @@ describe('RiverView', () => {
       );
       const div = screen.getByTestId(`gap-${seat}`);
       expect(div.style.gap).toBe(`${RIVER_GAP_PX}px`);
+      cleanup();
+    });
+  });
+
+  it('applies matching grid size for all seats', () => {
+    [0, 1, 2, 3].forEach(seat => {
+      render(
+        <RiverView tiles={[]} seat={seat} lastDiscard={null} dataTestId={`grid-${seat}`} />,
+      );
+      const div = screen.getByTestId(`grid-${seat}`);
+      const className = div.getAttribute('class') || '';
+      const expectCols = seat % 2 === 1 ? RIVER_ROWS_MOBILE : RIVER_COLS;
+      const expectRows = seat % 2 === 1 ? RIVER_COLS : RIVER_ROWS_MOBILE;
+      expect(className).toContain(`grid-cols-${expectCols}`);
+      expect(className).toContain(`grid-rows-${expectRows}`);
+      if (seat % 2 === 1) {
+        expect(className).toContain(`sm:grid-cols-${RIVER_ROWS_DESKTOP}`);
+        expect(className).toContain(`sm:grid-rows-${RIVER_COLS}`);
+      } else {
+        expect(className).toContain(`sm:grid-rows-${RIVER_ROWS_DESKTOP}`);
+      }
       cleanup();
     });
   });

--- a/src/components/RiverView.tsx
+++ b/src/components/RiverView.tsx
@@ -6,6 +6,9 @@ import { rotationForSeat } from '../utils/rotation';
 const seatRotation = rotationForSeat;
 const seatRiverRotation = rotationForSeat;
 
+export const RIVER_COLS = 6;
+export const RIVER_ROWS_MOBILE = 3;
+export const RIVER_ROWS_DESKTOP = 4;
 export const RIVER_GAP_PX = 4;
 export const CALLED_OFFSET_PX = 6;
 
@@ -28,8 +31,8 @@ const calledOffset = (seat: number): string => {
  * Mobile layouts typically only show three rows of discards, so fewer
  * placeholders are required.
  */
-export const RESERVED_RIVER_SLOTS = 24;
-export const RESERVED_RIVER_SLOTS_MOBILE = 18;
+export const RESERVED_RIVER_SLOTS = RIVER_COLS * RIVER_ROWS_DESKTOP;
+export const RESERVED_RIVER_SLOTS_MOBILE = RIVER_COLS * RIVER_ROWS_MOBILE;
 
 const smallScreen = ():
   boolean => typeof window !== 'undefined' && window.innerWidth < 640;
@@ -69,9 +72,12 @@ export const RiverView: React.FC<RiverViewProps> = ({
   const ordered = tiles;
   const reservedSlots = useResponsiveRiverSlots();
   const placeholdersCount = Math.max(0, reservedSlots - ordered.length);
+  const GRID_CLASS_EVEN = 'grid grid-cols-6 grid-rows-3 sm:grid-rows-4';
+  const GRID_CLASS_ODD = 'grid grid-cols-3 grid-rows-6 sm:grid-cols-4 sm:grid-rows-6';
+  const gridClass = seat % 2 === 1 ? GRID_CLASS_ODD : GRID_CLASS_EVEN;
   return (
     <div
-      className="grid grid-cols-6 grid-rows-3 sm:grid-rows-4"
+      className={gridClass}
       style={{ transform: `rotate(${seatRiverRotation(seat)}deg)`, gap: RIVER_GAP_PX }}
       data-testid={dataTestId}
     >


### PR DESCRIPTION
## Summary
- handle seat 1/3 by swapping grid rows/cols
- derive river grid size from shared constants
- test that each seat uses correct grid layout

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bc264aee0832a920ba52e5e3d6ef9