### PR TITLE
Simplify RiverView rotation and layout

### DIFF
--- a/src/components/RiverView.test.tsx
+++ b/src/components/RiverView.test.tsx
@@ -6,11 +6,9 @@ import {
   RiverView,
   RESERVED_RIVER_SLOTS,
   RESERVED_RIVER_SLOTS_MOBILE,
-  RIVER_COLS,
-  RIVER_ROWS_MOBILE,
-  RIVER_ROWS_DESKTOP,
   RIVER_GAP_PX,
   CALLED_OFFSET_PX,
+  GRID_CLASS,
 } from './RiverView';
 import { Tile } from '../types/mahjong';
 
@@ -81,23 +79,14 @@ describe('RiverView', () => {
     });
   });
 
-  it('applies matching grid size for all seats', () => {
+  it('applies the same grid size for all seats', () => {
     [0, 1, 2, 3].forEach(seat => {
       render(
         <RiverView tiles={[]} seat={seat} lastDiscard={null} dataTestId={`grid-${seat}`} />,
       );
       const div = screen.getByTestId(`grid-${seat}`);
       const className = div.getAttribute('class') || '';
-      const expectCols = seat % 2 === 1 ? RIVER_ROWS_MOBILE : RIVER_COLS;
-      const expectRows = seat % 2 === 1 ? RIVER_COLS : RIVER_ROWS_MOBILE;
-      expect(className).toContain(`grid-cols-${expectCols}`);
-      expect(className).toContain(`grid-rows-${expectRows}`);
-      if (seat % 2 === 1) {
-        expect(className).toContain(`sm:grid-cols-${RIVER_ROWS_DESKTOP}`);
-        expect(className).toContain(`sm:grid-rows-${RIVER_COLS}`);
-      } else {
-        expect(className).toContain(`sm:grid-rows-${RIVER_ROWS_DESKTOP}`);
-      }
+      expect(className).toBe(GRID_CLASS);
       cleanup();
     });
   });

--- a/src/components/RiverView.tsx
+++ b/src/components/RiverView.tsx
@@ -4,13 +4,14 @@ import { TileView } from './TileView';
 import { rotationForSeat } from '../utils/rotation';
 
 const seatRotation = rotationForSeat;
-const seatRiverRotation = rotationForSeat;
 
 export const RIVER_COLS = 6;
 export const RIVER_ROWS_MOBILE = 3;
 export const RIVER_ROWS_DESKTOP = 4;
 export const RIVER_GAP_PX = 4;
 export const CALLED_OFFSET_PX = 6;
+
+export const GRID_CLASS = `grid grid-cols-${RIVER_COLS} grid-rows-${RIVER_ROWS_MOBILE} sm:grid-rows-${RIVER_ROWS_DESKTOP}`;
 
 
 const calledOffset = (seat: number): string => {
@@ -72,24 +73,17 @@ export const RiverView: React.FC<RiverViewProps> = ({
   const ordered = tiles;
   const reservedSlots = useResponsiveRiverSlots();
   const placeholdersCount = Math.max(0, reservedSlots - ordered.length);
-  const GRID_CLASS_EVEN = 'grid grid-cols-6 grid-rows-3 sm:grid-rows-4';
-  const GRID_CLASS_ODD = 'grid grid-cols-3 grid-rows-6 sm:grid-cols-4 sm:grid-rows-6';
-  const gridClass = seat % 2 === 1 ? GRID_CLASS_ODD : GRID_CLASS_EVEN;
   return (
     <div
-      className={gridClass}
-      style={{ transform: `rotate(${seatRiverRotation(seat)}deg)`, gap: RIVER_GAP_PX }}
+      className={GRID_CLASS}
+      style={{ gap: RIVER_GAP_PX }}
       data-testid={dataTestId}
     >
       {ordered.map(tile => (
         <TileView
           key={tile.id}
           tile={tile}
-          rotate={
-            seatRotation(seat) -
-            seatRiverRotation(seat) +
-            (tile.called || tile.riichiDiscard ? 90 : 0)
-          }
+          rotate={seatRotation(seat) + (tile.called || tile.riichiDiscard ? 90 : 0)}
           extraTransform={tile.called ? calledOffset(seat) : ''}
           isShonpai={lastDiscard?.tile.id === tile.id && lastDiscard.isShonpai}
         />
@@ -98,7 +92,7 @@ export const RiverView: React.FC<RiverViewProps> = ({
         <span
           key={`placeholder-${idx}`}
           className="inline-block border px-1 py-0.5 bg-white tile-font-size opacity-0"
-          style={{ transform: `rotate(${seatRotation(seat) - seatRiverRotation(seat)}deg)` }}
+          style={{ transform: `rotate(${seatRotation(seat)}deg)` }}
         />
       ))}
     </div>


### PR DESCRIPTION
## Summary
- make the river grid constant for every seat
- rotate tiles directly without rotating the container
- update tests to expect uniform grid classes

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bc9e342c4832a8534515fbd7eface