### PR TITLE
Fix unused vars lint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,13 @@
     "sourceType": "module"
   },
   "plugins": ["react", "@typescript-eslint"],
-  "rules": {},
+  "rules": {
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }
+    ]
+  },
   "settings": {
     "react": {
       "version": "detect"

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -19,22 +19,17 @@ interface UIBoardProps {
   wallCount: number;
   kyotaku: number;
   honba: number;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
-  onDiscard: (tileId: string) => void;
+  onDiscard: (_tileId: string) => void;
   isMyTurn: boolean;
   shanten: { standard: number; chiitoi: number; kokushi: number };
   lastDiscard: { tile: Tile; player: number; isShonpai: boolean } | null;
   callOptions?: (MeldType | 'pass')[];
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
-  onCallAction?: (action: MeldType | 'pass') => void;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
+  onCallAction?: (_action: MeldType | 'pass') => void;
   onRiichi?: () => void;
   selfKanOptions?: Tile[][];
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
-  onSelfKan?: (tiles: Tile[]) => void;
+  onSelfKan?: (_tiles: Tile[]) => void;
   chiOptions?: Tile[][];
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
-  onChi?: (tiles: Tile[]) => void;
+  onChi?: (_tiles: Tile[]) => void;
   tsumoOption?: boolean;
   onTsumo?: () => void;
   onTsumoPass?: () => void;

--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -52,10 +52,8 @@ interface BoardData {
 }
 
 const boardPresets: Record<string, BoardData> = (() => {
-  // eslint-disable-next-line no-unused-vars
-  type TileFactory = (suit: Tile['suit'], rank: number) => Tile;
-  // eslint-disable-next-line no-unused-vars
-  const make = (build: (t: TileFactory) => BoardData): BoardData => {
+  type TileFactory = (_suit: Tile['suit'], _rank: number) => Tile;
+  const make = (build: (_t: TileFactory) => BoardData): BoardData => {
     let id = 1;
     const t = (suit: Tile['suit'], rank: number): Tile => ({ suit, rank, id: `p${id++}` });
     return build(t);


### PR DESCRIPTION
## Summary
- remove inline eslint-disable comments around unused vars
- handle unused parameters with `_` prefix
- enforce `_` exemptions in eslint config

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bd3748480832a8932fb2e26492620