### PR TITLE
Adjust river layout and tile rotation

### DIFF
--- a/src/components/MeldView.tsx
+++ b/src/components/MeldView.tsx
@@ -2,24 +2,11 @@ import React from 'react';
 import { Meld } from '../types/mahjong';
 import { TileView } from './TileView';
 import { rotationForSeat } from '../utils/rotation';
+import { calledRotation } from '../utils/calledRotation';
 
 const seatRotation = rotationForSeat;
 const seatMeldRotation = rotationForSeat;
 
-const calledRotation = (seat: number, from: number) => {
-  if (from === seat) return 0;
-  const diff = (from - seat + 4) % 4;
-  switch (diff) {
-    case 1:
-      return 90; // from right
-    case 2:
-      return 180; // from opposite
-    case 3:
-      return -90; // from left
-    default:
-      return 0;
-  }
-};
 
 export const MeldView: React.FC<{ meld: Meld; seat?: number }> = ({ meld, seat = 0 }) => {
   return (

--- a/src/components/RiverView.test.tsx
+++ b/src/components/RiverView.test.tsx
@@ -57,15 +57,15 @@ describe('RiverView', () => {
     expect(tileEls[1].getAttribute('style')).toContain('rotate(90deg)');
   });
 
-  it('offsets called tiles using the constant', () => {
-    const tiles = [{ ...t('pin', 5, 'c'), called: true }];
+  it('offsets called tiles using the constant and rotates based on caller', () => {
+    const tiles = [{ ...t('pin', 5, 'c'), called: true, calledFrom: 1 }];
     render(
       <RiverView tiles={tiles} seat={2} lastDiscard={null} dataTestId="rv-called" />,
     );
     const tile = screen.getByTestId('rv-called').querySelector('[style]');
-    expect(tile?.getAttribute('style')).toContain(
-      `translateX(-${CALLED_OFFSET_PX}px)`,
-    );
+    const style = tile?.getAttribute('style') || '';
+    expect(style).toContain(`translateX(-${CALLED_OFFSET_PX}px)`);
+    expect(style).toContain('rotate(90deg)');
   });
 
   it('uses consistent gap for all seats', () => {

--- a/src/components/RiverView.tsx
+++ b/src/components/RiverView.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 import { Tile } from '../types/mahjong';
 import { TileView } from './TileView';
 import { rotationForSeat } from '../utils/rotation';
+import { calledRotation } from '../utils/calledRotation';
 
 const seatRotation = rotationForSeat;
 
 export const RIVER_COLS = 6;
 export const RIVER_ROWS_MOBILE = 3;
-export const RIVER_ROWS_DESKTOP = 4;
+export const RIVER_ROWS_DESKTOP = 6;
 export const RIVER_GAP_PX = 4;
 export const CALLED_OFFSET_PX = 6;
 
@@ -79,15 +80,25 @@ export const RiverView: React.FC<RiverViewProps> = ({
       style={{ gap: RIVER_GAP_PX }}
       data-testid={dataTestId}
     >
-      {ordered.map(tile => (
-        <TileView
-          key={tile.id}
-          tile={tile}
-          rotate={seatRotation(seat) + (tile.called || tile.riichiDiscard ? 90 : 0)}
-          extraTransform={tile.called ? calledOffset(seat) : ''}
-          isShonpai={lastDiscard?.tile.id === tile.id && lastDiscard.isShonpai}
-        />
-      ))}
+      {ordered.map(tile => {
+        const extraRotation =
+          tile.calledFrom !== undefined
+            ? calledRotation(seat, tile.calledFrom)
+            : tile.called || tile.riichiDiscard
+              ? 90
+              : 0;
+        return (
+          <TileView
+            key={tile.id}
+            tile={tile}
+            rotate={seatRotation(seat) + extraRotation}
+            extraTransform={
+              tile.called || tile.calledFrom !== undefined ? calledOffset(seat) : ''
+            }
+            isShonpai={lastDiscard?.tile.id === tile.id && lastDiscard.isShonpai}
+          />
+        );
+      })}
       {Array.from({ length: placeholdersCount }).map((_, idx) => (
         <span
           key={`placeholder-${idx}`}

--- a/src/types/mahjong.ts
+++ b/src/types/mahjong.ts
@@ -7,6 +7,8 @@ export interface Tile {
   id: string;   // ユニーク識別子
   /** true if this discard was claimed for a meld */
   called?: boolean;
+  /** seat index of the player who called this tile */
+  calledFrom?: number;
   /** true if discarded after declaring riichi */
   riichiDiscard?: boolean;
 }

--- a/src/utils/calledRotation.ts
+++ b/src/utils/calledRotation.ts
@@ -1,0 +1,14 @@
+export const calledRotation = (seat: number, from: number): number => {
+  if (from === seat) return 0;
+  const diff = (from - seat + 4) % 4;
+  switch (diff) {
+    case 1:
+      return 90; // from right
+    case 2:
+      return 180; // from opposite
+    case 3:
+      return -90; // from left
+    default:
+      return 0;
+  }
+};


### PR DESCRIPTION
## Summary
- reserve six rows of river slots on desktop
- track which seat called a discarded tile
- rotate called tiles based on the caller's seat
- share rotation logic between meld and river views
- update related unit tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685bd2846190832a8e257ab24ffd2ea1