### PR TITLE
Refactor discard validations and AI turn handling

### DIFF
--- a/src/game/helpers.test.ts
+++ b/src/game/helpers.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { validateDiscard, appendDiscardLog } from './helpers';
+import { Tile, PlayerState, LogEntry } from '../types/mahjong';
+import { createInitialPlayerState } from '../components/Player';
+
+function t(suit: Tile['suit'], rank: number, id: string): Tile {
+  return { suit, rank, id };
+}
+
+describe('validateDiscard', () => {
+  it('blocks non-drawn tiles after riichi', () => {
+    const hand = [t('man', 1, 'a'), t('man', 2, 'b')];
+    const player: PlayerState = {
+      ...createInitialPlayerState('p', false),
+      hand,
+      isRiichi: true,
+      drawnTile: hand[0],
+    };
+    expect(validateDiscard(player, 'b', false)).toBe(
+      'リーチ後はツモ牌しか切れません',
+    );
+    expect(validateDiscard(player, 'a', false)).toBeNull();
+  });
+
+  it('ensures tenpai when declaring riichi', () => {
+    const hand = [
+      t('man', 1, 'a'),
+      t('man', 1, 'a2'),
+      t('man', 2, 'b1'),
+      t('man', 2, 'b2'),
+      t('pin', 3, 'c1'),
+      t('pin', 3, 'c2'),
+      t('pin', 4, 'd1'),
+      t('pin', 4, 'd2'),
+      t('sou', 5, 'e1'),
+      t('sou', 5, 'e2'),
+      t('sou', 6, 'f1'),
+      t('sou', 6, 'f2'),
+      t('man', 7, 'g1'),
+      t('man', 8, 'h1'),
+    ];
+    const player: PlayerState = { ...createInitialPlayerState('p', false), hand };
+    expect(validateDiscard(player, 'h1', true)).toBeNull();
+    expect(validateDiscard(player, 'a', true)).toBe(
+      'その牌ではリーチできません',
+    );
+  });
+});
+
+describe('appendDiscardLog', () => {
+  it('adds a discard entry', () => {
+    const log: LogEntry[] = [];
+    const tile = t('man', 1, 'a');
+    const result = appendDiscardLog(log, 0, tile);
+    expect(result).toEqual([{ type: 'discard', player: 0, tile }]);
+  });
+});

--- a/src/game/helpers.ts
+++ b/src/game/helpers.ts
@@ -1,0 +1,31 @@
+import { PlayerState, Tile, LogEntry } from '../types/mahjong';
+import { canDiscardTile, isTenpaiAfterDiscard } from '../components/Player';
+
+/**
+ * Validate a discard considering riichi state and pending riichi.
+ * @returns error message if invalid, otherwise null
+ */
+export function validateDiscard(
+  player: PlayerState,
+  tileId: string,
+  declaringRiichi: boolean,
+): string | null {
+  if (!declaringRiichi && !canDiscardTile(player, tileId)) {
+    return 'リーチ後はツモ牌しか切れません';
+  }
+  if (declaringRiichi && !isTenpaiAfterDiscard(player, tileId)) {
+    return 'その牌ではリーチできません';
+  }
+  return null;
+}
+
+/**
+ * Append a discard entry to the log.
+ */
+export function appendDiscardLog(
+  log: LogEntry[],
+  player: number,
+  tile: Tile,
+): LogEntry[] {
+  return [...log, { type: 'discard', player, tile }];
+}


### PR DESCRIPTION
## Summary
- add `validateDiscard` and `appendDiscardLog` helpers
- refactor discard logic to use new helpers
- extract AI turn steps into `handleAITurn`
- test helper functions for expected behaviour

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685bd6427aa4832aa2b435a5c2a4f862