### PR TITLE
Implement seedable random

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "seedrandom": "^3.0.5"
       },
       "devDependencies": {
         "@testing-library/react": "^16.3.0",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
+        "@types/seedrandom": "^3.0.8",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
         "@vitejs/plugin-react": "^4.6.0",
@@ -1642,6 +1644,13 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/seedrandom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-3.0.8.tgz",
+      "integrity": "sha512-TY1eezMU2zH2ozQoAFAQFOPpvP15g+ZgSfTZt31AUUH/Rxtnz3H+A/Sv1Snw2/amp//omibc+AEkTaA8KUeOLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
@@ -5842,6 +5851,12 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,14 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "seedrandom": "^3.0.5"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
+    "@types/seedrandom": "^3.0.8",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "@vitejs/plugin-react": "^4.6.0",

--- a/src/e2e/ScoreQuiz.random.e2e.test.tsx
+++ b/src/e2e/ScoreQuiz.random.e2e.test.tsx
@@ -3,32 +3,36 @@ import React from 'react';
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ScoreQuiz } from '../components/ScoreQuiz';
-import { randomModule } from '../utils/random';
+import { randomModule, setRandomSource } from '../utils/random';
 
 const restore = randomModule.random;
 
 describe('ScoreQuiz random control', () => {
   afterEach(() => {
-    randomModule.random = restore;
+    setRandomSource(restore);
   });
 
   it('uses stubbed random for initial question', () => {
-    randomModule.random = vi
-      .fn()
-      .mockReturnValueOnce(0.1) // winType -> ron
-      .mockReturnValueOnce(0.6); // seatWind -> 西
+    setRandomSource(
+      vi
+        .fn()
+        .mockReturnValueOnce(0.1) // winType -> ron
+        .mockReturnValueOnce(0.6) // seatWind -> 西
+    );
     render(<ScoreQuiz initialIndex={0} />);
     expect(screen.getByText(/自風: 西/)).toBeTruthy();
     expect(screen.getByText(/ロン:/)).toBeTruthy();
   });
 
   it('uses stubbed random for nextQuestion', () => {
-    randomModule.random = vi
-      .fn()
-      .mockReturnValueOnce(0.9) // winType -> tsumo
-      .mockReturnValueOnce(0.2) // seatWind -> 東
-      .mockReturnValueOnce(0.3) // next winType -> ron
-      .mockReturnValueOnce(0.7); // next seatWind -> 西
+    setRandomSource(
+      vi
+        .fn()
+        .mockReturnValueOnce(0.9) // winType -> tsumo
+        .mockReturnValueOnce(0.2) // seatWind -> 東
+        .mockReturnValueOnce(0.3) // next winType -> ron
+        .mockReturnValueOnce(0.7) // next seatWind -> 西
+    );
     render(<ScoreQuiz initialIndex={0} />);
     expect(screen.getByText(/自風: 東/)).toBeTruthy();
     expect(screen.getByText(/ツモ/)).toBeTruthy();

--- a/src/utils/random.test.ts
+++ b/src/utils/random.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import seedrandom from 'seedrandom';
+import { random, randomModule, setRandomSource } from './random';
+
+const restore = randomModule.random;
+
+afterEach(() => {
+  setRandomSource(restore);
+});
+
+describe('random module', () => {
+  it('produces deterministic values with a seed', () => {
+    setRandomSource(seedrandom('seed'));
+    const first = random();
+    const second = random();
+    setRandomSource(seedrandom('seed'));
+    expect(random()).toBe(first);
+    expect(random()).toBe(second);
+  });
+});

--- a/src/utils/random.ts
+++ b/src/utils/random.ts
@@ -1,6 +1,22 @@
+import seedrandom from 'seedrandom';
+
+export type RandomSource = () => number;
+
+let rng: seedrandom.PRNG = seedrandom();
+
 export const randomModule = {
-  random: Math.random,
+  random: (): number => rng(),
 };
+
+export function setRandomSource(fn: RandomSource): void {
+  rng = fn as unknown as seedrandom.PRNG;
+  randomModule.random = fn;
+}
+
+export function seedRandom(seed: string): void {
+  rng = seedrandom(seed);
+  randomModule.random = (): number => rng();
+}
 
 export function random(): number {
   return randomModule.random();


### PR DESCRIPTION
## Summary
- integrate seedrandom and expose `setRandomSource`
- update ScoreQuiz tests for new API
- add regression test for deterministic RNG

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_685bd81bffa0832abc8ab52cedf4222e