### PR TITLE
Inline seat rotation helpers

### DIFF
--- a/src/components/MeldView.tsx
+++ b/src/components/MeldView.tsx
@@ -4,15 +4,12 @@ import { TileView } from './TileView';
 import { rotationForSeat } from '../utils/rotation';
 import { calledRotation } from '../utils/calledRotation';
 
-const seatRotation = rotationForSeat;
-const seatMeldRotation = rotationForSeat;
-
 
 export const MeldView: React.FC<{ meld: Meld; seat?: number }> = ({ meld, seat = 0 }) => {
   return (
     <div
       className="flex gap-1 border rounded px-1 bg-gray-50"
-      style={{ transform: `rotate(${seatMeldRotation(seat)}deg)` }}
+      style={{ transform: `rotate(${rotationForSeat(seat)}deg)` }}
     >
       {meld.tiles.map(tile => (
         <TileView
@@ -23,8 +20,8 @@ export const MeldView: React.FC<{ meld: Meld; seat?: number }> = ({ meld, seat =
             (tile === meld.tiles[0] || tile === meld.tiles[3])
           }
           rotate={
-            seatRotation(seat) -
-            seatMeldRotation(seat) +
+            rotationForSeat(seat) -
+            rotationForSeat(seat) +
             (tile.id === meld.calledTileId
               ? meld.kanType === 'kakan'
                 ? 90

--- a/src/components/RiverView.tsx
+++ b/src/components/RiverView.tsx
@@ -4,8 +4,6 @@ import { TileView } from './TileView';
 import { rotationForSeat } from '../utils/rotation';
 import { calledRotation } from '../utils/calledRotation';
 
-const seatRotation = rotationForSeat;
-
 export const RIVER_COLS = 6;
 export const RIVER_ROWS_MOBILE = 3;
 export const RIVER_ROWS_DESKTOP = 6;
@@ -91,7 +89,7 @@ export const RiverView: React.FC<RiverViewProps> = ({
           <TileView
             key={tile.id}
             tile={tile}
-            rotate={seatRotation(seat) + extraRotation}
+            rotate={rotationForSeat(seat) + extraRotation}
             extraTransform={
               tile.called || tile.calledFrom !== undefined ? calledOffset(seat) : ''
             }
@@ -103,7 +101,7 @@ export const RiverView: React.FC<RiverViewProps> = ({
         <span
           key={`placeholder-${idx}`}
           className="inline-block border px-1 py-0.5 bg-white tile-font-size opacity-0"
-          style={{ transform: `rotate(${seatRotation(seat)}deg)` }}
+          style={{ transform: `rotate(${rotationForSeat(seat)}deg)` }}
         />
       ))}
     </div>


### PR DESCRIPTION
## Summary
- inline `rotationForSeat` usage in `RiverView` and `MeldView`

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_685bfd2ccec0832a8f207da9b0ee39e6