### PR TITLE
Refactor RiverView called tile offset

### DIFF
--- a/src/components/RiverView.test.tsx
+++ b/src/components/RiverView.test.tsx
@@ -7,7 +7,7 @@ import {
   RESERVED_RIVER_SLOTS,
   RESERVED_RIVER_SLOTS_MOBILE,
   RIVER_GAP_PX,
-  CALLED_OFFSET_PX,
+  CALLED_OFFSET,
   GRID_CLASS,
 } from './RiverView';
 import { Tile } from '../types/mahjong';
@@ -72,7 +72,7 @@ describe('RiverView', () => {
     );
     const tile = screen.getByTestId('rv-called').querySelector('[style]');
     const style = tile?.getAttribute('style') || '';
-    expect(style).toContain(`translateX(-${CALLED_OFFSET_PX}px)`);
+    expect(style).toContain(`translateX(-${CALLED_OFFSET})`);
     expect(style).toContain('rotate(90deg)');
   });
 

--- a/src/components/RiverView.tsx
+++ b/src/components/RiverView.tsx
@@ -8,7 +8,13 @@ export const RIVER_COLS = 6;
 export const RIVER_ROWS_MOBILE = 3;
 export const RIVER_ROWS_DESKTOP = 6;
 export const RIVER_GAP_PX = 4;
-export const CALLED_OFFSET_PX = 6;
+/**
+ * Offset for called tiles relative to the tile size.
+ *
+ * Using a CSS calculation keeps the spacing consistent when users
+ * change the `--tile-font-size` variable to scale tiles.
+ */
+export const CALLED_OFFSET = 'calc(var(--tile-font-size) / 5)';
 
 export const GRID_CLASS = `grid grid-cols-${RIVER_COLS} grid-rows-${RIVER_ROWS_MOBILE} sm:grid-rows-${RIVER_ROWS_DESKTOP}`;
 
@@ -23,13 +29,13 @@ export const GRID_CLASS = `grid grid-cols-${RIVER_COLS} grid-rows-${RIVER_ROWS_M
 const calledOffset = (seat: number): string => {
   switch (seat % 4) {
     case 1:
-      return `translateY(-${CALLED_OFFSET_PX}px)`;
+      return `translateY(-${CALLED_OFFSET})`;
     case 2:
-      return `translateX(-${CALLED_OFFSET_PX}px)`;
+      return `translateX(-${CALLED_OFFSET})`;
     case 3:
-      return `translateY(${CALLED_OFFSET_PX}px)`;
+      return `translateY(${CALLED_OFFSET})`;
     default:
-      return `translateX(${CALLED_OFFSET_PX}px)`;
+      return `translateX(${CALLED_OFFSET})`;
   }
 };
 


### PR DESCRIPTION
## Summary
- offset called tiles using a CSS calc expression so the spacing scales with `--tile-font-size`
- update `calledOffset` and associated tests

## Testing
- `npx -y -p node@20 npm run lint --if-present`
- `npx -y -p node@20 npm run type-check --if-present`
- `npx -y -p node@20 npm run build`
- `npx -y -p node@20 npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_685c08692ad4832a9eb6b95515a54eca