### PR TITLE
Rotate RiverView container

### DIFF
--- a/src/components/RiverView.test.tsx
+++ b/src/components/RiverView.test.tsx
@@ -11,6 +11,7 @@ import {
   GRID_CLASS,
 } from './RiverView';
 import { Tile } from '../types/mahjong';
+import { rotationForSeat } from '../utils/rotation';
 
 const t = (suit: Tile['suit'], rank: number, id: string): Tile => ({ suit, rank, id });
 
@@ -73,7 +74,7 @@ describe('RiverView', () => {
     const tile = screen.getByTestId('rv-called').querySelector('[style]');
     const style = tile?.getAttribute('style') || '';
     expect(style).toContain(`translateX(-${CALLED_OFFSET})`);
-    expect(style).toContain('rotate(90deg)');
+    expect(style).toContain('rotate(-90deg)');
   });
 
   it('uses consistent gap for all seats', () => {
@@ -95,6 +96,17 @@ describe('RiverView', () => {
       const div = screen.getByTestId(`grid-${seat}`);
       const className = div.getAttribute('class') || '';
       expect(className).toBe(GRID_CLASS);
+      cleanup();
+    });
+  });
+
+  it('rotates the container for each seat', () => {
+    [0, 1, 2, 3].forEach(seat => {
+      render(
+        <RiverView tiles={[]} seat={seat} lastDiscard={null} dataTestId={`rot-${seat}`} />,
+      );
+      const div = screen.getByTestId(`rot-${seat}`);
+      expect(div.style.transform).toBe(`rotate(${rotationForSeat(seat)}deg)`);
       cleanup();
     });
   });

--- a/src/components/RiverView.tsx
+++ b/src/components/RiverView.tsx
@@ -88,7 +88,10 @@ export const RiverView: React.FC<RiverViewProps> = ({
   return (
     <div
       className={GRID_CLASS}
-      style={{ gap: RIVER_GAP_PX }}
+      style={{
+        gap: RIVER_GAP_PX,
+        transform: `rotate(${rotationForSeat(seat)}deg)`,
+      }}
       data-testid={dataTestId}
     >
       {ordered.map(tile => {
@@ -102,7 +105,7 @@ export const RiverView: React.FC<RiverViewProps> = ({
           <TileView
             key={tile.id}
             tile={tile}
-            rotate={rotationForSeat(seat) + extraRotation}
+            rotate={extraRotation}
             extraTransform={
               tile.called || tile.calledFrom !== undefined ? calledOffset(seat) : ''
             }
@@ -114,7 +117,6 @@ export const RiverView: React.FC<RiverViewProps> = ({
         <span
           key={`placeholder-${idx}`}
           className="inline-block border px-1 py-0.5 bg-white tile-font-size opacity-0"
-          style={{ transform: `rotate(${rotationForSeat(seat)}deg)` }}
         />
       ))}
     </div>


### PR DESCRIPTION
## Summary
- rotate discards container based on seat
- remove seat rotation from TileView instances
- simplify placeholder spans
- test container rotation

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d210ccd8c832a89cca157eec06b79