### PR TITLE
Fix orientation for pon from opposite seat

### DIFF
--- a/src/components/MeldView.test.tsx
+++ b/src/components/MeldView.test.tsx
@@ -42,6 +42,22 @@ describe('MeldView', () => {
     expect(htmlLeft).toContain('rotate(-90deg)');
   });
 
+  it('rotates called tile horizontally when from opposite seat', () => {
+    const base: Meld = {
+      type: 'pon',
+      tiles: [
+        { suit: 'man', rank: 1, id: 'x' },
+        { suit: 'man', rank: 1, id: 'y' },
+        { suit: 'man', rank: 1, id: 'z' },
+      ],
+      fromPlayer: 2,
+      calledTileId: 'y',
+    };
+    const html = renderToStaticMarkup(<MeldView meld={base} seat={0} />);
+    expect(html).toContain('rotate(90deg)');
+    expect(html).not.toContain('rotate(180deg)');
+  });
+
   it('rotates the whole meld for side seats', () => {
     const meld: Meld = {
       type: 'pon',

--- a/src/components/RiverView.test.tsx
+++ b/src/components/RiverView.test.tsx
@@ -77,6 +77,17 @@ describe('RiverView', () => {
     expect(style).toContain('rotate(-90deg)');
   });
 
+  it('rotates called tile horizontally when from opposite seat', () => {
+    const tiles = [{ ...t('pin', 5, 'd'), called: true, calledFrom: 2 }];
+    render(
+      <RiverView tiles={tiles} seat={0} lastDiscard={null} dataTestId="rv-opp" />,
+    );
+    const tile = screen.getByTestId('rv-opp').querySelector('[style]');
+    const style = tile?.getAttribute('style') || '';
+    expect(style).toContain('rotate(90deg)');
+    expect(style).not.toContain('rotate(180deg)');
+  });
+
   it('uses consistent gap for all seats', () => {
     [0, 1, 2, 3].forEach(seat => {
       render(

--- a/src/utils/calledRotation.ts
+++ b/src/utils/calledRotation.ts
@@ -12,7 +12,7 @@ export const calledRotation = (seat: number, from: number): number => {
     case 1:
       return 90; // from right
     case 2:
-      return 180; // from opposite
+      return 90; // from opposite
     case 3:
       return -90; // from left
     default:


### PR DESCRIPTION
## Summary
- ensure called tiles from across the table are rotated horizontally
- add regression tests for MeldView and RiverView

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d40c78a24832a9cd2951f39aecb2e