### PR TITLE
Improve river tile spacing

### DIFF
--- a/src/components/RiverView.test.tsx
+++ b/src/components/RiverView.test.tsx
@@ -88,6 +88,13 @@ describe('RiverView', () => {
     });
   });
 
+  it('uses content-width columns for the river grid', () => {
+    render(<RiverView tiles={[]} seat={0} lastDiscard={null} dataTestId="grid" />);
+    const div = screen.getByTestId('grid');
+    const className = div.getAttribute('class') || '';
+    expect(className).toContain('grid-cols-[repeat(6,_max-content)]');
+  });
+
   it('applies the same grid size for all seats', () => {
     [0, 1, 2, 3].forEach(seat => {
       render(

--- a/src/components/RiverView.tsx
+++ b/src/components/RiverView.tsx
@@ -16,7 +16,12 @@ export const RIVER_GAP_PX = 4;
  */
 export const CALLED_OFFSET = 'calc(var(--tile-font-size) / 5)';
 
-export const GRID_CLASS = `grid grid-cols-${RIVER_COLS} grid-rows-${RIVER_ROWS_MOBILE} sm:grid-rows-${RIVER_ROWS_DESKTOP}`;
+// Explicit class string ensures Tailwind includes the grid utilities while
+// keeping columns sized to their contents rather than stretching to fill the
+// container. The bracket notation is statically analyzable, so the necessary
+// classes are generated during build.
+export const GRID_CLASS =
+  'grid grid-cols-[repeat(6,_max-content)] grid-rows-3 sm:grid-rows-6';
 
 
 /**


### PR DESCRIPTION
## Summary
- resize RiverView columns to fit tile width using Tailwind's arbitrary grid template
- test that river grid uses content-width columns

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d3c6fc634832aa21d43dcb0c86d20