### PR TITLE
Fix riichi calling rule

### DIFF
--- a/src/utils/meld.test.ts
+++ b/src/utils/meld.test.ts
@@ -57,6 +57,20 @@ describe('getValidCallOptions', () => {
     };
     expect(getValidCallOptions(player, discard)).toEqual([]);
   });
+
+  it('returns empty array when player has declared riichi', () => {
+    const discard: Tile = { suit: 'man', rank: 5, id: 'd5' };
+    const hand: Tile[] = [
+      { suit: 'man', rank: 5, id: 'a' },
+      { suit: 'man', rank: 5, id: 'b' },
+    ];
+    const player: PlayerState = {
+      ...createInitialPlayerState('you', false),
+      hand,
+      isRiichi: true,
+    };
+    expect(getValidCallOptions(player, discard)).toEqual([]);
+  });
 });
 
 describe('selectMeldTiles', () => {

--- a/src/utils/meld.ts
+++ b/src/utils/meld.ts
@@ -41,6 +41,7 @@ export function getValidCallOptions(
   player: PlayerState,
   tile: Tile,
 ): (MeldType | 'pass')[] {
+  if (player.isRiichi) return [];
   const actions: (MeldType | 'pass')[] = [];
   (['pon', 'chi', 'kan'] as MeldType[]).forEach(t => {
     if (selectMeldTiles(player, tile, t)) actions.push(t);


### PR DESCRIPTION
## Summary
- prevent calling other players' discards after declaring riichi
- test call options block when player is in riichi

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d4ff863ec832a8c435115681d0c90