### PR TITLE
Fix river overflow with scrolling

### DIFF
--- a/src/components/RiverView.test.tsx
+++ b/src/components/RiverView.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { render, screen, cleanup } from '@testing-library/react';
 import {
   RiverView,
+  RIVER_COLS,
   RESERVED_RIVER_SLOTS,
   RESERVED_RIVER_SLOTS_MOBILE,
   RIVER_GAP_PX,
@@ -127,6 +128,21 @@ describe('RiverView', () => {
       expect(div.style.transform).toBe(`rotate(${rotationForSeat(seat)}deg)`);
       cleanup();
     });
+  });
+
+  it('scrolls when discards exceed reserved slots', () => {
+    const tiles = Array.from({ length: RESERVED_RIVER_SLOTS + 2 }, (_, i) =>
+      t('man', ((i % 9) + 1) as number, `t${i}`),
+    );
+    render(
+      <RiverView tiles={tiles} seat={0} lastDiscard={null} dataTestId="rv-long" />,
+    );
+    const div = screen.getByTestId('rv-long');
+    const rowCount = RESERVED_RIVER_SLOTS / RIVER_COLS;
+    const gapPx = RIVER_GAP_PX * (rowCount - 1);
+    const expected = `calc((var(--tile-font-size) + 4px) * ${rowCount} + ${gapPx}px)`;
+    expect(div.style.overflowY).toBe('auto');
+    expect(div.style.maxHeight).toBe(expected);
   });
 
 });

--- a/src/components/RiverView.tsx
+++ b/src/components/RiverView.tsx
@@ -84,6 +84,9 @@ export const RiverView: React.FC<RiverViewProps> = ({
 }) => {
   const ordered = tiles;
   const reservedSlots = useResponsiveRiverSlots();
+  const rowCount = reservedSlots / RIVER_COLS;
+  const gapPx = RIVER_GAP_PX * (rowCount - 1);
+  const maxHeight = `calc((var(--tile-font-size) + 4px) * ${rowCount} + ${gapPx}px)`;
   const placeholdersCount = Math.max(0, reservedSlots - ordered.length);
   return (
     <div
@@ -91,6 +94,8 @@ export const RiverView: React.FC<RiverViewProps> = ({
       style={{
         gap: RIVER_GAP_PX,
         transform: `rotate(${rotationForSeat(seat)}deg)`,
+        overflowY: 'auto',
+        maxHeight,
       }}
       data-testid={dataTestId}
     >


### PR DESCRIPTION
## Summary
- add overflow logic to RiverView and compute max height
- test that river scrolling works when discards overflow

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d502f9798832a91e3773d41207a90