### PR TITLE
Add riichi stick display

### DIFF
--- a/angular/src/app/components/score-board.component.ts
+++ b/angular/src/app/components/score-board.component.ts
@@ -8,7 +8,12 @@ import { Component, Input } from '@angular/core';
       <span class="font-bold">{{ kyokuLabel }}</span>
       <span class="text-sm">残り{{ wallCount }}</span>
       <span class="text-sm">{{ honba }}本場</span>
-      <span class="text-sm">供託{{ kyotaku }}</span>
+      <span class="text-sm flex items-center">
+        供託
+        <span data-testid="kyotaku" class="flex gap-0.5 ml-1">
+          <span class="riichi-stick" *ngFor="let _ of [].constructor(kyotaku); let i = index" aria-label="riichi stick"></span>
+        </span>
+      </span>
     </div>
   `,
 })

--- a/src/components/RiichiStick.tsx
+++ b/src/components/RiichiStick.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const RiichiStick: React.FC<{ className?: string }> = ({ className }) => (
+  <span className={`riichi-stick ${className ?? ''}`} aria-label="riichi stick" />
+);

--- a/src/components/ScoreBoard.test.tsx
+++ b/src/components/ScoreBoard.test.tsx
@@ -5,11 +5,13 @@ import { render, screen } from '@testing-library/react';
 import { ScoreBoard } from './ScoreBoard';
 
 describe('ScoreBoard', () => {
-  it('displays kyoku, wall count, honba and kyotaku', () => {
-    render(<ScoreBoard kyoku={1} wallCount={69} kyotaku={0} honba={2} />);
+  it('displays kyoku, wall count, honba and kyotaku icons', () => {
+    render(<ScoreBoard kyoku={1} wallCount={69} kyotaku={2} honba={2} />);
     expect(screen.getByText('東1局')).toBeTruthy();
     expect(screen.getByText('残り69')).toBeTruthy();
     expect(screen.getByText('2本場')).toBeTruthy();
-    expect(screen.getByText('供託0')).toBeTruthy();
+    expect(screen.getByText('供託')).toBeTruthy();
+    const kyotaku = screen.getByTestId('kyotaku');
+    expect(kyotaku.children.length).toBe(2);
   });
 });

--- a/src/components/ScoreBoard.tsx
+++ b/src/components/ScoreBoard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { RiichiStick } from './RiichiStick';
 interface ScoreBoardProps {
   kyoku: number;
   wallCount: number;
@@ -18,7 +19,14 @@ export const ScoreBoard: React.FC<ScoreBoardProps> = ({
       <span className="font-bold">{kyokuStr}</span>
       <span className="text-sm">残り{wallCount}</span>
       <span className="text-sm">{honba}本場</span>
-      <span className="text-sm">供託{kyotaku}</span>
+      <span className="text-sm flex items-center">
+        供託
+        <span data-testid="kyotaku" className="flex gap-0.5 ml-1">
+          {Array.from({ length: kyotaku }).map((_, i) => (
+            <RiichiStick key={i} />
+          ))}
+        </span>
+      </span>
     </div>
   );
 };

--- a/src/components/UIBoard.test.tsx
+++ b/src/components/UIBoard.test.tsx
@@ -270,7 +270,7 @@ describe('UIBoard discard orientation', () => {
 });
 
 describe('UIBoard riichi indicators', () => {
-  it('shows 1000点棒 in front of rivers', () => {
+  it('shows riichi stick in front of rivers', () => {
     const me = { ...createInitialPlayerState('me', false, 0), isRiichi: true };
     me.discard = [t('man', 1, 'a')];
     const ai = { ...createInitialPlayerState('ai', true, 1), isRiichi: true };
@@ -289,7 +289,7 @@ describe('UIBoard riichi indicators', () => {
         lastDiscard={null}
       />,
     );
-    expect(screen.getAllByText('1000点棒').length).toBe(2);
+    expect(screen.getAllByTestId('riichi-indicator').length).toBe(2);
   });
 });
 

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -5,6 +5,7 @@ import { canDeclareRiichi } from './Player';
 import { MeldView } from './MeldView';
 import { RiverView } from './RiverView';
 import { ScoreBoard } from './ScoreBoard';
+import { RiichiStick } from './RiichiStick';
 
 const suitMap: Record<string, string> = { man: '萬', pin: '筒', sou: '索', wind: '', dragon: '' };
 const honorMap: Record<string, Record<number, string>> = {
@@ -102,7 +103,11 @@ export const UIBoard: React.FC<UIBoardProps> = ({
             ))}
           </div>
         )}
-        {top.isRiichi && <div className="text-xs">1000点棒</div>}
+        {top.isRiichi && (
+          <div className="text-xs" data-testid="riichi-indicator">
+            <RiichiStick />
+          </div>
+        )}
         <RiverView
           tiles={top.discard}
           seat={top.seat}
@@ -121,7 +126,11 @@ export const UIBoard: React.FC<UIBoardProps> = ({
               ))}
             </div>
           )}
-          {right.isRiichi && <div className="text-xs">1000点棒</div>}
+          {right.isRiichi && (
+            <div className="text-xs" data-testid="riichi-indicator">
+              <RiichiStick />
+            </div>
+          )}
           <RiverView
             tiles={right.discard}
             seat={right.seat}
@@ -147,7 +156,11 @@ export const UIBoard: React.FC<UIBoardProps> = ({
               ))}
             </div>
           )}
-          {left.isRiichi && <div className="text-xs">1000点棒</div>}
+          {left.isRiichi && (
+            <div className="text-xs" data-testid="riichi-indicator">
+              <RiichiStick />
+            </div>
+          )}
           <RiverView
             tiles={left.discard}
             seat={left.seat}
@@ -186,7 +199,11 @@ export const UIBoard: React.FC<UIBoardProps> = ({
             ))}
           </div>
         )}
-        {me.isRiichi && <div className="text-xs">1000点棒</div>}
+        {me.isRiichi && (
+          <div className="text-xs" data-testid="riichi-indicator">
+            <RiichiStick />
+          </div>
+        )}
         <RiverView
           tiles={me.discard}
           seat={me.seat}

--- a/src/index.css
+++ b/src/index.css
@@ -26,3 +26,8 @@
 .rotate-270 {
   transform: rotate(270deg);
 }
+
+/* Simple riichi stick icon */
+.riichi-stick {
+  @apply inline-block w-6 h-2 bg-red-500 border border-red-700 rounded-sm;
+}


### PR DESCRIPTION
## Summary
- draw kyotaku using small riichi stick icons
- display riichi stick icons in front of rivers
- adjust Angular scoreboard template
- add simple RiichiStick component and styles
- update tests for new display

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d508d95c4832ab602ab233856fe45