### PR TITLE
Fix double borders around tiles

### DIFF
--- a/src/components/TileView.tsx
+++ b/src/components/TileView.tsx
@@ -67,7 +67,7 @@ export const TileView: React.FC<{
       : honorMap[tile.suit]?.[tile.rank] ?? '';
   return (
     <span
-      className={`relative inline-block border px-0.5 py-px leading-none bg-white tile-font-size ${className ?? ''}`}
+      className={`relative inline-block px-0.5 py-px leading-none bg-white tile-font-size ${className ?? ''}`}
       aria-label={kanji}
       style={{ transform: `rotate(${rotate}deg) ${extraTransform}` }}
     >


### PR DESCRIPTION
## Summary
- remove redundant border from TileView so only one outline appears around a tile

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_685dd56f6e98832abb37693c9c734f20