### PR TITLE
Fix called tile placement

### DIFF
--- a/src/components/Player.test.ts
+++ b/src/components/Player.test.ts
@@ -158,8 +158,8 @@ describe('claimMeld', () => {
     const fromOpposite = claimMeld(player, tiles, 'pon', 2, 'a');
     const fromLeft = claimMeld(player, tiles, 'pon', 3, 'a');
     expect(fromRight.melds[0].tiles[2].id).toBe('a');
-    expect(fromOpposite.melds[0].tiles[1].id).toBe('a');
-    expect(fromLeft.melds[0].tiles[0].id).toBe('a');
+    expect(fromOpposite.melds[0].tiles[2].id).toBe('a');
+    expect(fromLeft.melds[0].tiles[2].id).toBe('a');
   });
 
   it('orders kan tiles based on caller position', () => {
@@ -180,8 +180,8 @@ describe('claimMeld', () => {
     const fromOpposite = claimMeld(player, tiles, 'kan', 2, 'a', 'daiminkan');
     const fromLeft = claimMeld(player, tiles, 'kan', 3, 'a', 'daiminkan');
     expect(fromRight.melds[0].tiles[3].id).toBe('a');
-    expect(fromOpposite.melds[0].tiles[1].id).toBe('a');
-    expect(fromLeft.melds[0].tiles[0].id).toBe('a');
+    expect(fromOpposite.melds[0].tiles[3].id).toBe('a');
+    expect(fromLeft.melds[0].tiles[3].id).toBe('a');
   });
 });
 

--- a/src/components/Player.ts
+++ b/src/components/Player.ts
@@ -101,34 +101,9 @@ export function claimMeld(
   if (idx >= 0) {
     const called = tiles[idx];
     const others = tiles.filter((_, i) => i !== idx);
-    const relative = (fromPlayer - player.seat + 4) % 4;
-    if (type === 'chi') {
-      // Chi is only possible from the player on the left
-      // Place the called tile at the leftmost position when from left
-      if (relative === 3) {
-        meldTiles = [called, ...others];
-      } else {
-        meldTiles = [...others, called];
-      }
-    } else if (type === 'pon') {
-      // Right -> rightmost, Left -> leftmost, Opposite -> middle
-      if (relative === 1) {
-        meldTiles = [...others, called];
-      } else if (relative === 2) {
-        meldTiles = [others[0], called, others[1]];
-      } else if (relative === 3) {
-        meldTiles = [called, ...others];
-      }
-    } else if (type === 'kan') {
-      // Right -> rightmost, Left -> leftmost, Opposite -> second from left
-      if (relative === 1) {
-        meldTiles = [...others, called];
-      } else if (relative === 2) {
-        meldTiles = [others[0], called, others[1], others[2]];
-      } else if (relative === 3) {
-        meldTiles = [called, ...others];
-      }
-    }
+    // Standard layout places the claimed tile on the right end regardless of
+    // which seat discarded it.
+    meldTiles = [...others, called];
   }
   return {
     ...player,


### PR DESCRIPTION
## Summary
- ensure called tiles are always appended to a meld
- update tests for new meld ordering logic

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f1b568e88832ab6ddc0c1f4193915