### PR TITLE
Implement vertical kakan tile layout

### DIFF
--- a/src/components/MeldView.test.tsx
+++ b/src/components/MeldView.test.tsx
@@ -107,6 +107,7 @@ describe('MeldView', () => {
       kanType: 'kakan',
     };
     const html = renderToStaticMarkup(<MeldView meld={meld} />);
+    expect(html).toContain('kakan-called-tile');
     const count = (html.match(/rotate\(90deg\)/g) || []).length;
     expect(count).toBe(1);
   });

--- a/src/components/MeldView.tsx
+++ b/src/components/MeldView.tsx
@@ -6,36 +6,39 @@ import { calledRotation } from '../utils/calledRotation';
 
 
 export const MeldView: React.FC<{ meld: Meld; seat?: number }> = ({ meld, seat = 0 }) => {
+  const isKakan = meld.type === 'kan' && meld.kanType === 'kakan';
   return (
     <div
-      className="flex gap-1 border rounded px-1 bg-gray-50"
+      className="relative flex gap-1 border rounded px-1 bg-gray-50"
       style={{ transform: `rotate(${rotationForSeat(seat)}deg)` }}
     >
-      {meld.tiles.map(tile => (
-        <TileView
-          key={tile.id}
-          tile={tile}
-          faceDown={
-            meld.type === 'kan' && meld.kanType === 'ankan' &&
-            (tile === meld.tiles[0] || tile === meld.tiles[3])
-          }
-          rotate={
-            rotationForSeat(seat) -
-            rotationForSeat(seat) +
-            (tile.id === meld.calledTileId
-              ? meld.kanType === 'kakan'
-                ? 90
-                : calledRotation(seat, meld.fromPlayer)
-              : 0)
-          }
-          extraTransform={
-            meld.type === 'kan' && meld.kanType === 'kakan' &&
-            tile.id === meld.calledTileId
-              ? 'translateY(-4px)'
-              : ''
-          }
-        />
-      ))}
+      {meld.tiles.map(tile => {
+        const isCalled = tile.id === meld.calledTileId;
+        const rotate = isCalled
+          ? isKakan
+            ? 90
+            : calledRotation(seat, meld.fromPlayer)
+          : 0;
+        const faceDown =
+          meld.type === 'kan' && meld.kanType === 'ankan' &&
+          (tile === meld.tiles[0] || tile === meld.tiles[3]);
+        const tileView = (
+          <TileView
+            key={tile.id}
+            tile={tile}
+            faceDown={faceDown}
+            rotate={rotate}
+            extraTransform={isKakan && isCalled ? 'translateX(-50%)' : ''}
+          />
+        );
+        return isKakan && isCalled ? (
+          <span key={`wrapper-${tile.id}`} className="kakan-called-tile">
+            {tileView}
+          </span>
+        ) : (
+          tileView
+        );
+      })}
     </div>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -31,3 +31,10 @@
 .riichi-stick {
   @apply inline-block w-6 h-2 bg-red-500 border border-red-700 rounded-sm;
 }
+
+/* Called tile position for kakan melds */
+.kakan-called-tile {
+  position: absolute;
+  left: 50%;
+  top: calc(var(--tile-font-size) * -1);
+}


### PR DESCRIPTION
## Summary
- stack kakan tiles vertically by absolute positioning
- add `kakan-called-tile` style
- verify markup in `MeldView.test`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f1d3f92e8832abe7b479c9e6f0f3d