### PR TITLE
Fix endgame flow on final-round draws

### DIFF
--- a/src/game/store.test.ts
+++ b/src/game/store.test.ts
@@ -11,4 +11,25 @@ describe('game store', () => {
     });
     expect(result.current.kyoku).toBe(2);
   });
+
+  it('ends game after final round draw', () => {
+    const { result } = renderHook(() => useGame('tonpu'));
+    act(() => {
+      result.current.nextKyoku(false); // 1 -> 2
+    });
+    act(() => {
+      result.current.nextKyoku(false); // 2 -> 3
+    });
+    act(() => {
+      result.current.nextKyoku(false); // 3 -> 4 (final)
+    });
+    expect(result.current.kyoku).toBe(4);
+
+    act(() => {
+      // Dealer continues on draw in final round should trigger end phase
+      result.current.nextKyoku(true);
+    });
+
+    expect(result.current.phase).toBe('end');
+  });
 });

--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -357,12 +357,20 @@ export const useGame = (gameLength: GameLength) => {
 
   const maxKyoku = maxKyokuForLength(gameLength);
   const nextKyoku = (dealerContinues = false) => {
+    // If we've reached the final round, always end the game regardless of dealer
+    // continuation rules.
+    if (kyokuRef.current >= maxKyoku) {
+      setPhase('end');
+      return;
+    }
+
     if (dealerContinues) {
       setHonba(h => h + 1);
       honbaRef.current += 1;
       startRound(false, kyokuRef.current);
       return;
     }
+
     setHonba(0);
     honbaRef.current = 0;
     const next = kyokuRef.current + 1;


### PR DESCRIPTION
## Summary
- ensure `nextKyoku` ends the game when the last round is finished
- test final round draw transitions to end phase

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f20485a1c832ab976236f768cf22f