### PR TITLE
Reserve hand width

### DIFF
--- a/src/components/HandView.tsx
+++ b/src/components/HandView.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Tile } from '../types/mahjong';
+import { TileView } from './TileView';
+
+export const RESERVED_HAND_SLOTS = 14;
+
+const suitMap: Record<string, string> = { man: '萬', pin: '筒', sou: '索', wind: '', dragon: '' };
+const honorMap: Record<string, Record<number, string>> = {
+  wind: { 1: '東', 2: '南', 3: '西', 4: '北' },
+  dragon: { 1: '白', 2: '發', 3: '中' },
+};
+
+interface HandViewProps {
+  tiles: Tile[];
+  drawnTile?: Tile | null;
+  onDiscard: (tileId: string) => void;
+  isMyTurn: boolean;
+}
+
+export const HandView: React.FC<HandViewProps> = ({ tiles, drawnTile, onDiscard, isMyTurn }) => {
+  const handTiles = drawnTile ? tiles.filter(t => t.id !== drawnTile.id) : tiles;
+  const placeholders = Math.max(0, RESERVED_HAND_SLOTS - (handTiles.length + (drawnTile ? 1 : 0)));
+  const renderButton = (tile: Tile, extraClass: string) => {
+    const kanji =
+      tile.suit === 'man' || tile.suit === 'pin' || tile.suit === 'sou'
+        ? `${tile.rank}${suitMap[tile.suit]}`
+        : honorMap[tile.suit]?.[tile.rank] ?? '';
+    return (
+      <button
+        key={tile.id}
+        className={`border rounded bg-surface-0 dark:bg-surface-700 px-2 py-1 hover:bg-primary-100 dark:hover:bg-primary-700 ${extraClass} ${
+          isMyTurn ? '' : 'opacity-50 pointer-events-none'
+        }`}
+        onClick={() => onDiscard(tile.id)}
+        disabled={!isMyTurn}
+        aria-label={kanji}
+      >
+        <TileView tile={tile} />
+      </button>
+    );
+  };
+  return (
+    <div className="flex gap-2 items-center overflow-x-auto">
+      <span className="text-xs text-gray-600">手牌</span>
+      {handTiles.map(t => renderButton(t, ''))}
+      {drawnTile && renderButton(drawnTile, 'ml-4')}
+      {Array.from({ length: placeholders }).map((_, idx) => (
+        <span key={`ph-${idx}`} className="inline-block tile-font-size opacity-0" />
+      ))}
+    </div>
+  );
+};

--- a/src/components/UIBoard.test.tsx
+++ b/src/components/UIBoard.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
 import { UIBoard } from './UIBoard';
 import { createInitialPlayerState, canDeclareRiichi } from './Player';
+import { RESERVED_HAND_SLOTS } from './HandView';
 import { Tile } from '../types/mahjong';
 import type { PlayerState } from "../types/mahjong";
 
@@ -207,6 +208,64 @@ describe('UIBoard responsiveness', () => {
     const handLabel = screen.getByText('手牌');
     const container = handLabel.parentElement as HTMLElement;
     expect(container.className).toContain('overflow-x-auto');
+  });
+});
+
+describe('UIBoard hand placeholders', () => {
+  it('uses fixed slot count with few tiles', () => {
+    const me = { ...createInitialPlayerState('me', false) } as PlayerState;
+    me.hand = [t('man', 1, 'a1')];
+    me.drawnTile = null;
+    render(
+      <UIBoard
+        players={[
+          me,
+          createInitialPlayerState('ai1', true, 1),
+          createInitialPlayerState('ai2', true, 2),
+          createInitialPlayerState('ai3', true, 3),
+        ]}
+        dora={[]}
+        kyoku={1}
+        wallCount={70}
+        kyotaku={0}
+        honba={0}
+        onDiscard={() => {}}
+        isMyTurn={true}
+        shanten={{ standard: 0, chiitoi: 0, kokushi: 0 }}
+        lastDiscard={null}
+      />,
+    );
+    const handLabel = screen.getByText('手牌');
+    const container = handLabel.parentElement as HTMLElement;
+    expect(container.children.length).toBe(RESERVED_HAND_SLOTS + 1);
+  });
+
+  it('uses fixed slot count with many tiles', () => {
+    const me = { ...createInitialPlayerState('me', false) } as PlayerState;
+    me.hand = Array.from({ length: 10 }, (_, i) => t('man', i + 1 as number, `m${i}`));
+    me.drawnTile = null;
+    render(
+      <UIBoard
+        players={[
+          me,
+          createInitialPlayerState('ai1', true, 1),
+          createInitialPlayerState('ai2', true, 2),
+          createInitialPlayerState('ai3', true, 3),
+        ]}
+        dora={[]}
+        kyoku={1}
+        wallCount={70}
+        kyotaku={0}
+        honba={0}
+        onDiscard={() => {}}
+        isMyTurn={true}
+        shanten={{ standard: 0, chiitoi: 0, kokushi: 0 }}
+        lastDiscard={null}
+      />,
+    );
+    const handLabel = screen.getByText('手牌');
+    const container = handLabel.parentElement as HTMLElement;
+    expect(container.children.length).toBe(RESERVED_HAND_SLOTS + 1);
   });
 });
 

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -6,6 +6,7 @@ import { MeldView } from './MeldView';
 import { RiverView } from './RiverView';
 import { ScoreBoard } from './ScoreBoard';
 import { RiichiStick } from './RiichiStick';
+import { HandView } from './HandView';
 
 const suitMap: Record<string, string> = { man: '萬', pin: '筒', sou: '索', wind: '', dragon: '' };
 const honorMap: Record<string, Record<number, string>> = {
@@ -227,52 +228,12 @@ export const UIBoard: React.FC<UIBoardProps> = ({
               : <>向聴数: {base}{label && ` (${label})`}</>;
           })()}
         </div>
-        {(() => {
-          const my = me;
-          const handTiles = my.drawnTile
-            ? my.hand.filter(t => t.id !== my.drawnTile?.id)
-            : my.hand;
-          return (
-            <div className="flex gap-2 items-center overflow-x-auto">
-              <span className="text-xs text-gray-600">手牌</span>
-              {handTiles.map(tile => {
-                const kanji =
-                  tile.suit === 'man' || tile.suit === 'pin' || tile.suit === 'sou'
-                    ? `${tile.rank}${suitMap[tile.suit]}`
-                    : honorMap[tile.suit]?.[tile.rank] ?? '';
-                return (
-                  <button
-                    key={tile.id}
-                    className={`border rounded bg-surface-0 dark:bg-surface-700 px-2 py-1 hover:bg-primary-100 dark:hover:bg-primary-700 ${isMyTurn ? '' : 'opacity-50 pointer-events-none'}`}
-                    onClick={() => onDiscard(tile.id)}
-                    disabled={!isMyTurn}
-                    aria-label={kanji}
-                  >
-                    <TileView tile={tile} />
-                  </button>
-                );
-              })}
-              {my.drawnTile && (() => {
-                const t = my.drawnTile;
-                const kanji =
-                  t.suit === 'man' || t.suit === 'pin' || t.suit === 'sou'
-                    ? `${t.rank}${suitMap[t.suit]}`
-                    : honorMap[t.suit]?.[t.rank] ?? '';
-                return (
-                  <button
-                    key={t.id}
-                    className={`border rounded bg-surface-0 dark:bg-surface-700 px-2 py-1 hover:bg-primary-100 dark:hover:bg-primary-700 ml-4 ${isMyTurn ? '' : 'opacity-50 pointer-events-none'}`}
-                    onClick={() => onDiscard(t.id)}
-                    disabled={!isMyTurn}
-                    aria-label={kanji}
-                  >
-                    <TileView tile={t} />
-                  </button>
-                );
-              })()}
-            </div>
-          );
-        })()}
+        <HandView
+          tiles={me.hand}
+          drawnTile={me.drawnTile}
+          onDiscard={onDiscard}
+          isMyTurn={isMyTurn}
+        />
         {callOptions && callOptions.length > 0 && (
           <div className="flex gap-2 mt-2">
             {callOptions.map(act => (


### PR DESCRIPTION
## Summary
- keep hand width constant with a new `HandView` component
- use `HandView` inside `UIBoard`
- test placeholder slots for the hand

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f23046b84832a972add82768e317d