### PR TITLE
Fix river layout width

### DIFF
--- a/src/components/RiverView.test.tsx
+++ b/src/components/RiverView.test.tsx
@@ -161,4 +161,14 @@ describe('RiverView', () => {
     expect(filledDiv.style.height).toBe(expected);
   });
 
+  it('renders tile-sized placeholders for empty slots', () => {
+    render(<RiverView tiles={[]} seat={0} lastDiscard={null} dataTestId="rv-pl" />);
+    const div = screen.getByTestId('rv-pl');
+    const placeholder = div.querySelector('span.opacity-0');
+    const className = placeholder?.getAttribute('class') || '';
+    expect(className).toContain('px-0.5');
+    expect(className).toContain('py-px');
+    expect(className).not.toContain('border');
+  });
+
 });

--- a/src/components/RiverView.tsx
+++ b/src/components/RiverView.tsx
@@ -122,7 +122,7 @@ export const RiverView: React.FC<RiverViewProps> = ({
       {Array.from({ length: placeholdersCount }).map((_, idx) => (
         <span
           key={`placeholder-${idx}`}
-          className="inline-block border px-1 py-0.5 bg-white tile-font-size opacity-0"
+          className="inline-block px-0.5 py-px leading-none bg-white tile-font-size opacity-0"
         />
       ))}
     </div>

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -118,7 +118,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
       </div>
 
       {/* 右側：下家 */}
-      <div className="flex items-start gap-2" style={{ gridArea: 'right' }}>
+      <div className="flex items-start gap-2 justify-self-start" style={{ gridArea: 'right' }}>
         <div className="flex flex-col items-center">
           {right.melds.length > 0 && (
             <div className="flex gap-1 mb-1">
@@ -145,7 +145,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
       </div>
 
       {/* 左側：上家 */}
-      <div className="flex items-start gap-2" style={{ gridArea: 'left' }}>
+      <div className="flex items-start gap-2 justify-self-end" style={{ gridArea: 'left' }}>
         <div className="text-sm">
           {left.name}: <span className="font-mono">{left.score}</span>
         </div>


### PR DESCRIPTION
## Summary
- keep discard columns stable by matching placeholder tile styles
- align side player info boxes to reduce empty space
- test placeholder classes in RiverView

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_685f54fd1fe0832a9025d7abc7b56144