### PR TITLE
Add agari check for negative shanten

### DIFF
--- a/src/components/UIBoard.test.tsx
+++ b/src/components/UIBoard.test.tsx
@@ -64,6 +64,39 @@ describe('UIBoard shanten display', () => {
     renderBoard({ standard: 3, chiitoi: 3, kokushi: 2 });
     expect(screen.getByText('向聴数: 2 (国士無双2向聴)')).toBeTruthy();
   });
+
+  it('shows agari state when shanten is negative and yaku exist', () => {
+    const player = { ...createInitialPlayerState('you', false) } as PlayerState;
+    player.hand = [
+      t('man',2,'m2a'),t('man',3,'m3a'),t('man',4,'m4a'),
+      t('pin',2,'p2a'),t('pin',3,'p3a'),t('pin',4,'p4a'),
+      t('sou',2,'s2a'),t('sou',3,'s3a'),t('sou',4,'s4a'),
+      t('man',6,'m6a'),t('man',7,'m7a'),t('man',8,'m8a'),
+      t('pin',5,'p5a'),t('pin',5,'p5b'),
+    ];
+    player.drawnTile = player.hand[player.hand.length - 1];
+    render(
+      <UIBoard
+        players={[
+          player,
+          createInitialPlayerState('ai1', true, 1),
+          createInitialPlayerState('ai2', true, 2),
+          createInitialPlayerState('ai3', true, 3),
+        ]}
+        dora={[]}
+        kyoku={1}
+        wallCount={70}
+        kyotaku={0}
+        honba={0}
+        onDiscard={() => {}}
+        isMyTurn={true}
+        shanten={{ standard: -1, chiitoi: 13, kokushi: 13 }}
+        lastDiscard={null}
+        tsumoOption={true}
+      />,
+    );
+    expect(screen.getByText('和了可能')).toBeTruthy();
+  });
 });
 
 describe('UIBoard riichi button', () => {

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -7,6 +7,7 @@ import { RiverView } from './RiverView';
 import { ScoreBoard } from './ScoreBoard';
 import { RiichiStick } from './RiichiStick';
 import { HandView } from './HandView';
+import { isWinningHand, detectYaku } from '../score/yaku';
 
 const suitMap: Record<string, string> = { man: '萬', pin: '筒', sou: '索', wind: '', dragon: '' };
 const honorMap: Record<string, Record<number, string>> = {
@@ -222,6 +223,15 @@ export const UIBoard: React.FC<UIBoardProps> = ({
               label = `七対子${base}向聴`;
             } else if (shanten.kokushi === base && base < shanten.standard) {
               label = `国士無双${base}向聴`;
+            }
+            if (base < 0) {
+              const full = [...me.hand, ...me.melds.flatMap(m => m.tiles)];
+              const winning = isWinningHand(full);
+              if (!winning || !tsumoOption) {
+                console.warn('negative shanten but not tsumo/win', { hand: full, shanten, tsumoOption });
+              }
+              const hasYaku = winning && detectYaku(full, me.melds, { isTsumo: true }).length > 0;
+              return hasYaku ? <>和了可能</> : <>役なし</>;
             }
             return base === 0
               ? <>聴牌{label && ` (${label})`}</>


### PR DESCRIPTION
## Summary
- log and display winning status when shanten count is negative
- warn if negative shanten occurs without tsumo option
- test negative shanten behaviour in UIBoard

## Testing
- `npx -p node@20 npm run lint --if-present`
- `npx -p node@20 npm run type-check --if-present`
- `npx -p node@20 npm run build`
- `npx -p node@20 npm test --if-present`

------
https://chatgpt.com/codex/tasks/task_e_685f547f72dc832a8dcee8c883c86fb8