### PR TITLE
Fix river layout placeholders

### DIFF
--- a/src/components/RiverView.test.tsx
+++ b/src/components/RiverView.test.tsx
@@ -169,6 +169,7 @@ describe('RiverView', () => {
     expect(className).toContain('px-0.5');
     expect(className).toContain('py-px');
     expect(className).not.toContain('border');
+    expect(placeholder?.textContent).toBe('🀇');
   });
 
 });

--- a/src/components/RiverView.tsx
+++ b/src/components/RiverView.tsx
@@ -122,8 +122,10 @@ export const RiverView: React.FC<RiverViewProps> = ({
       {Array.from({ length: placeholdersCount }).map((_, idx) => (
         <span
           key={`placeholder-${idx}`}
-          className="inline-block px-0.5 py-px leading-none bg-white tile-font-size opacity-0"
-        />
+          className="inline-block px-0.5 py-px leading-none bg-white tile-font-size opacity-0 font-emoji"
+        >
+          🀇
+        </span>
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- use hidden tile characters in empty discard slots so early rivers don't resize
- test placeholder width by checking emoji text

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f5dfebf44832aa0ba1e51f4a07301