### PR TITLE
Update README about Node 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ https://kotarotanabe.github.io/MyCodexSample/
 
 ### 1. クローン & セットアップ
 
-このプロジェクトは **Node.js 20.x** を想定してビルドしています。`nvm` を利用
-している場合はリポジトリ直下の `.nvmrc` に従い以下のように実行してください。
+このプロジェクトは `.nvmrc` で指定している **Node.js 20.x** を前提にビルドして
+います。`nvm` を利用している場合は以下のように実行してください。Node.js 21 以
+降では依存パッケージとの互換性問題でビルドやテストが失敗することがあります。
+動作が不安定な場合は必ず `nvm use` で `.nvmrc` のバージョンに合わせてください。
 
 ```sh
 git clone https://github.com/KotaroTanabe/MyCodexSample.git


### PR DESCRIPTION
## Summary
- clarify that `.nvmrc` pins Node.js 20.x
- warn about possible build/test failures when using newer Node versions

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f5eaece6c832aaab1bc604fe78f2b