### PR TITLE
Fix hand width when drawn tile hidden

### DIFF
--- a/src/components/HandView.test.tsx
+++ b/src/components/HandView.test.tsx
@@ -1,0 +1,24 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { HandView, RESERVED_HAND_SLOTS } from './HandView';
+import { Tile } from '../types/mahjong';
+
+function t(suit: Tile['suit'], rank: number, id: string): Tile {
+  return { suit, rank, id };
+}
+
+describe('HandView', () => {
+  afterEach(() => cleanup());
+
+  it('reserves a slot for the drawn tile even when none is present', () => {
+    const tiles = Array.from({ length: 13 }, (_, i) => t('man', ((i % 9) + 1) as number, `m${i}`));
+    render(<HandView tiles={tiles} drawnTile={null} onDiscard={() => {}} isMyTurn />);
+    const container = screen.getByText('手牌').parentElement as HTMLElement;
+    expect(container.children.length).toBe(RESERVED_HAND_SLOTS + 1);
+    const drawSlot = container.querySelector('span.opacity-0.ml-4');
+    expect(drawSlot).toBeTruthy();
+    expect(drawSlot?.textContent).toBe('🀇');
+  });
+});

--- a/src/components/HandView.tsx
+++ b/src/components/HandView.tsx
@@ -19,7 +19,7 @@ interface HandViewProps {
 
 export const HandView: React.FC<HandViewProps> = ({ tiles, drawnTile, onDiscard, isMyTurn }) => {
   const handTiles = drawnTile ? tiles.filter(t => t.id !== drawnTile.id) : tiles;
-  const placeholders = Math.max(0, RESERVED_HAND_SLOTS - (handTiles.length + (drawnTile ? 1 : 0)));
+  const placeholders = Math.max(0, RESERVED_HAND_SLOTS - handTiles.length - 1);
   const renderButton = (tile: Tile, extraClass: string) => {
     const kanji =
       tile.suit === 'man' || tile.suit === 'pin' || tile.suit === 'sou'
@@ -43,12 +43,23 @@ export const HandView: React.FC<HandViewProps> = ({ tiles, drawnTile, onDiscard,
     <div className="flex gap-2 items-center overflow-x-auto">
       <span className="text-xs text-gray-600">手牌</span>
       {handTiles.map(t => renderButton(t, ''))}
-      {drawnTile && renderButton(drawnTile, 'ml-4')}
+      {drawnTile ? (
+        renderButton(drawnTile, 'ml-4')
+      ) : (
+        <span
+          key="draw-slot"
+          className="inline-block border rounded bg-surface-0 dark:bg-surface-700 px-2 py-1 tile-font-size opacity-0 ml-4 font-emoji"
+        >
+          🀇
+        </span>
+      )}
       {Array.from({ length: placeholders }).map((_, idx) => (
         <span
           key={`ph-${idx}`}
-          className="inline-block border rounded bg-surface-0 dark:bg-surface-700 px-2 py-1 tile-font-size opacity-0"
-        />
+          className="inline-block border rounded bg-surface-0 dark:bg-surface-700 px-2 py-1 tile-font-size opacity-0 font-emoji"
+        >
+          🀇
+        </span>
       ))}
     </div>
   );

--- a/src/components/RiverView.test.tsx
+++ b/src/components/RiverView.test.tsx
@@ -169,6 +169,7 @@ describe('RiverView', () => {
     expect(className).toContain('px-0.5');
     expect(className).toContain('py-px');
     expect(className).not.toContain('border');
+    expect(placeholder?.textContent).toBe('🀇');
   });
 
 });

--- a/src/components/RiverView.tsx
+++ b/src/components/RiverView.tsx
@@ -122,8 +122,10 @@ export const RiverView: React.FC<RiverViewProps> = ({
       {Array.from({ length: placeholdersCount }).map((_, idx) => (
         <span
           key={`placeholder-${idx}`}
-          className="inline-block px-0.5 py-px leading-none bg-white tile-font-size opacity-0"
-        />
+          className="inline-block px-0.5 py-px leading-none bg-white tile-font-size opacity-0 font-emoji"
+        >
+          🀇
+        </span>
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- keep a placeholder for the drawn tile even when none is shown
- render hidden tile emoji in hand placeholders
- test that the drawn tile space is reserved

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f5dfebf44832aa0ba1e51f4a07301