### PR TITLE
Add debug log for negative shanten state

### DIFF
--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -199,6 +199,7 @@ export const useGame = (gameLength: GameLength) => {
   const riichiPoolRef = useRef(riichiPool);
   const honbaRef = useRef(honba);
   const logRef = useRef<LogEntry[]>(log);
+  const tsumoOptionRef = useRef(tsumoOption);
   const kanDrawRef = useRef<number | null>(null);
   const drawInfoRef = useRef<Record<number, { rinshan: boolean; last: boolean }>>({});
   const recordHeadRef = useRef<RecordHead>({
@@ -261,9 +262,21 @@ export const useGame = (gameLength: GameLength) => {
   }, [log]);
 
   useEffect(() => {
+    tsumoOptionRef.current = tsumoOption;
+  }, [tsumoOption]);
+
+  useEffect(() => {
     playersRef.current = players;
     if (players.length > 0) {
-      setShanten(calcShanten(players[0].hand, players[0].melds.length));
+      const s = calcShanten(players[0].hand, players[0].melds.length);
+      setShanten(s);
+      if (s.standard < 0 && !tsumoOptionRef.current) {
+        console.debug('negative shanten without tsumo option', {
+          player: players[0],
+          hand: players[0].hand,
+          melds: players[0].melds,
+        });
+      }
     }
   }, [players]);
 


### PR DESCRIPTION
## Summary
- track `tsumoOption` in a ref for access inside effects
- when shanten calculation yields a negative value without a tsumo option, log the player hand and melds for debugging

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_685f600d6ea4832abbfb86a279d12869