### PR TITLE
Fix yaku detection to handle concealed tiles

### DIFF
--- a/src/components/ScoreQuiz.tsx
+++ b/src/components/ScoreQuiz.tsx
@@ -37,8 +37,7 @@ export const ScoreQuiz: React.FC<ScoreQuizProps> = ({ initialIndex, initialWinTy
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    const allTiles = [...question.hand, ...question.melds.flatMap(m => m.tiles)];
-    const yaku = detectYaku(allTiles, question.melds, {
+    const yaku = detectYaku(question.hand, question.melds, {
       isTsumo: winType === 'tsumo',
       seatWind,
       roundWind,

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -230,7 +230,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
               if (!winning || !tsumoOption) {
                 console.warn('negative shanten but not tsumo/win', { hand: full, shanten, tsumoOption });
               }
-              const hasYaku = winning && detectYaku(full, me.melds, { isTsumo: true }).length > 0;
+              const hasYaku = winning && detectYaku(me.hand, me.melds, { isTsumo: true }).length > 0;
               return hasYaku ? <>和了可能</> : <>役なし</>;
             }
             return base === 0

--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -737,12 +737,11 @@ const handleCallAction = (action: MeldType | 'pass') => {
       setDeadWall(uraRes.wall);
       deadWallRef.current = uraRes.wall;
     }
-    const fullHand = [...p[idx].hand, ...p[idx].melds.flatMap(m => m.tiles)];
     const info = drawInfoRef.current[idx];
     drawInfoRef.current[idx] = { rinshan: false, last: false };
     const seatWind = p[idx].seat + 1;
     const roundWind = kyokuRef.current <= 4 ? 1 : 2;
-    const yaku = detectYaku(fullHand, p[idx].melds, {
+    const yaku = detectYaku(p[idx].hand, p[idx].melds, {
       isTsumo: true,
       isRiichi: p[idx].isRiichi,
       doubleRiichi: p[idx].doubleRiichi,
@@ -797,14 +796,13 @@ const handleCallAction = (action: MeldType | 'pass') => {
       setDeadWall(uraRes.wall);
       deadWallRef.current = uraRes.wall;
     }
-    const fullHand = [...p[winner].hand, ...p[winner].melds.flatMap(m => m.tiles), tile];
     const fromInfo = drawInfoRef.current[from];
     drawInfoRef.current[from] = { rinshan: false, last: false };
     const prev = logRef.current[logRef.current.length - 1];
     const chankan = isChankan(prev, from, tile);
     const seatWind = p[winner].seat + 1;
     const roundWind = kyokuRef.current <= 4 ? 1 : 2;
-    const yaku = detectYaku(fullHand, p[winner].melds, {
+    const yaku = detectYaku([...p[winner].hand, tile], p[winner].melds, {
       isTsumo: false,
       isRiichi: p[winner].isRiichi,
       doubleRiichi: p[winner].doubleRiichi,

--- a/src/score/calculateFuDetail.ts
+++ b/src/score/calculateFuDetail.ts
@@ -105,7 +105,7 @@ export function calculateFuDetail(
   const parsed = decomposeHand(allTiles);
   if (!parsed) return { fu: 0, steps: ['invalid hand'] };
 
-  const yaku = detectYaku(allTiles, melds, { seatWind, roundWind });
+  const yaku = detectYaku(hand, melds, { seatWind, roundWind });
   if (yaku.some(y => y.name === 'Chiitoitsu')) {
     return { fu: 25, steps: ['七対子25符'] };
   }

--- a/src/score/score.ts
+++ b/src/score/score.ts
@@ -100,7 +100,7 @@ export function calculateFu(
   opts?: { seatWind?: number; roundWind?: number; winType?: 'ron' | 'tsumo' },
 ): number {
   const allTiles = [...hand, ...melds.flatMap(m => m.tiles)];
-  const yaku = detectYaku(allTiles, melds, {
+  const yaku = detectYaku(hand, melds, {
     seatWind: opts?.seatWind,
     roundWind: opts?.roundWind,
   });

--- a/src/score/yaku.test.ts
+++ b/src/score/yaku.test.ts
@@ -81,6 +81,33 @@ describe('Yaku detection', () => {
     expect(yakuhaiCount).toBe(2); // ダブ東の刻子は2翻になるはず
   });
 
+  it('detects Yakuhai from an open meld', () => {
+    const ponTiles = [t('dragon', 1, 'od1a'), t('dragon', 1, 'od1b'), t('dragon', 1, 'od1c')];
+    const concealed: Tile[] = [
+      t('man', 2, 'o1'), t('man', 3, 'o2'), t('man', 4, 'o3'),
+      t('pin', 2, 'o4'), t('pin', 3, 'o5'), t('pin', 4, 'o6'),
+      t('sou', 2, 'o7'), t('sou', 3, 'o8'), t('sou', 4, 'o9'),
+      t('man', 5, 'o10'), t('man', 5, 'o11'),
+    ];
+    const melds: Meld[] = [{ type: 'pon', tiles: ponTiles, fromPlayer: 1, calledTileId: 'od1a' }];
+    const yaku = detectYaku(concealed, melds, { isTsumo: true });
+    expect(yaku.filter(y => y.name === 'Yakuhai').length).toBe(1);
+  });
+
+  it('detects open Ittsu as 1 han', () => {
+    const chiTiles = [t('man', 1, 'i1'), t('man', 2, 'i2'), t('man', 3, 'i3')];
+    const concealed: Tile[] = [
+      t('man', 4, 'i4'), t('man', 5, 'i5'), t('man', 6, 'i6'),
+      t('man', 7, 'i7'), t('man', 8, 'i8'), t('man', 9, 'i9'),
+      t('pin', 2, 'ip1'), t('pin', 2, 'ip2'), t('pin', 2, 'ip3'),
+      t('pin', 5, 'ip4'), t('pin', 5, 'ip5'),
+    ];
+    const melds: Meld[] = [{ type: 'chi', tiles: chiTiles, fromPlayer: 2, calledTileId: 'i1' }];
+    const yaku = detectYaku(concealed, melds, { isTsumo: true });
+    const ittsu = yaku.find(y => y.name === 'Ittsu');
+    expect(ittsu?.han).toBe(1);
+  });
+
   it('detects Pinfu', () => {
     const hand: Tile[] = [
       t('man',2,'m2a'),t('man',3,'m3a'),t('man',4,'m4a'),
@@ -389,8 +416,7 @@ describe('Scoring', () => {
     const melds: Meld[] = [
       { type: 'pon', tiles: ponTiles, fromPlayer: 1, calledTileId: 'd1a' },
     ];
-    const fullHand = [...concealed, ...ponTiles];
-    const yaku = detectYaku(fullHand, melds, { isTsumo: true });
+    const yaku = detectYaku(concealed, melds, { isTsumo: true });
     expect(yaku.some(y => y.name === 'Menzen Tsumo')).toBe(false);
     const { fu } = calculateScore(concealed, melds, yaku, []);
     // 基本符20 + 明刻(役牌)8 = 28、切り上げで30符になるはず
@@ -444,8 +470,7 @@ describe('Scoring', () => {
     const melds: Meld[] = [
       { type: 'kan', tiles: kanTiles, fromPlayer: 2, calledTileId: 'k1a', kanType: 'daiminkan' },
     ];
-    const fullHand = [...concealed, ...kanTiles];
-    const yaku = detectYaku(fullHand, melds, { isTsumo: true });
+    const yaku = detectYaku(concealed, melds, { isTsumo: true });
     const { fu } = calculateScore(concealed, melds, yaku);
     // 基本符20 + 明カン(役牌)16 = 36、切り上げで40符になるはず
     expect(fu).toBe(40);

--- a/src/score/yaku.ts
+++ b/src/score/yaku.ts
@@ -332,7 +332,7 @@ export function isWinningHand(tiles: Tile[]): boolean {
 }
 
 export function detectYaku(
-  hand: Tile[],
+  concealed: Tile[],
   melds: Meld[] = [],
   opts?: {
     isTsumo?: boolean;
@@ -348,7 +348,7 @@ export function detectYaku(
     uraDoraIndicators?: Tile[];
   },
 ): ScoreYaku[] {
-  const allTiles = [...hand, ...melds.flatMap(m => m.tiles)];
+  const allTiles = [...concealed, ...melds.flatMap(m => m.tiles)];
   const result: ScoreYaku[] = [];
   const counts = countTiles(allTiles);
   const parsed = decomposeHand(allTiles);


### PR DESCRIPTION
## Summary
- ensure `detectYaku` accepts only concealed tiles
- update score helpers and components to call `detectYaku` with concealed tiles
- add tests for open meld yaku detection

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f856755d4832a806a46cf24051fad