### PR TITLE
Fix hand count display for AI

### DIFF
--- a/src/components/UIBoard.test.tsx
+++ b/src/components/UIBoard.test.tsx
@@ -585,7 +585,7 @@ describe('UIBoard hand count', () => {
       { ...createInitialPlayerState('ai2', true, 2), hand: makeTiles(7) },
       {
         ...createInitialPlayerState('ai3', true, 3),
-        hand: makeTiles(13),
+        hand: [...makeTiles(13), t('man', 2, 'draw')],
         drawnTile: t('man', 2, 'draw'),
       },
     ];

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -103,7 +103,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
           data-testid="hand-count-2"
         >
           <span className="font-emoji tile-font-size">🀫</span>
-          {` x ${String(top.hand.length + (top.drawnTile ? 1 : 0)).padStart(2, '0')}`}
+          {` x ${String(top.hand.length).padStart(2, '0')}`}
         </div>
         {top.melds.length > 0 && (
           <div className="flex gap-1 mb-1">
@@ -136,7 +136,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
             data-testid="hand-count-1"
           >
             <span className="font-emoji tile-font-size">🀫</span>
-            {` x ${String(right.hand.length + (right.drawnTile ? 1 : 0)).padStart(2, '0')}`}
+            {` x ${String(right.hand.length).padStart(2, '0')}`}
           </div>
           {right.melds.length > 0 && (
             <div className="flex gap-1 mb-1">
@@ -170,7 +170,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
             data-testid="hand-count-3"
           >
             <span className="font-emoji tile-font-size">🀫</span>
-            {` x ${String(left.hand.length + (left.drawnTile ? 1 : 0)).padStart(2, '0')}`}
+            {` x ${String(left.hand.length).padStart(2, '0')}`}
           </div>
           {left.melds.length > 0 && (
             <div className="flex gap-1 mb-1">


### PR DESCRIPTION
## Summary
- show AI hand counts based only on the hand array
- update hand count test to include drawn tile in the hand

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68610c254abc832a8db966ff0ec3395c