### PR TITLE
Fix riichi discard rotation logic

### DIFF
--- a/src/game/riichiUtil.test.ts
+++ b/src/game/riichiUtil.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { shouldRotateRiichi } from './riichiUtil';
+
+describe('shouldRotateRiichi', () => {
+  it('returns true when seat matches pending', () => {
+    expect(shouldRotateRiichi(1, 1, [])).toBe(true);
+  });
+  it('returns true when seat is in indicators', () => {
+    expect(shouldRotateRiichi(2, null, [0, 2])).toBe(true);
+  });
+  it('returns false otherwise', () => {
+    expect(shouldRotateRiichi(0, null, [1])).toBe(false);
+  });
+});

--- a/src/game/riichiUtil.ts
+++ b/src/game/riichiUtil.ts
@@ -1,0 +1,7 @@
+export const shouldRotateRiichi = (
+  seat: number,
+  pending: number | null,
+  indicators: number[],
+): boolean => {
+  return seat === pending || indicators.includes(seat);
+};


### PR DESCRIPTION
## Summary
- mark only the correct discard to show riichi
- add pendingRiichiIndicator tracking when a riichi tile is called
- add `shouldRotateRiichi` helper and tests

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686122fea64c832ab31736e4aec07fbd