### PR TITLE
Fix called tile placement

### DIFF
--- a/src/components/Player.test.ts
+++ b/src/components/Player.test.ts
@@ -13,6 +13,7 @@ import {
   canDiscardTile,
   canCallMeld,
   removeDiscardTile,
+  markDiscardCalled,
 } from './Player';
 import { generateTileWall } from './TileWall';
 import { Tile, PlayerState, MeldType } from '../types/mahjong';
@@ -70,6 +71,18 @@ describe('removeDiscardTile', () => {
     const updated = removeDiscardTile(player, 'a');
     expect(updated.discard).toHaveLength(1);
     expect(updated.discard[0].id).toBe('b');
+  });
+});
+
+describe('markDiscardCalled', () => {
+  it('marks the specified tile as called with the caller seat', () => {
+    const player: PlayerState = {
+      ...createInitialPlayerState('test', false),
+      discard: [{ suit: 'man', rank: 1, id: 'a' }],
+    };
+    const updated = markDiscardCalled(player, 'a', 3);
+    expect(updated.discard[0].called).toBe(true);
+    expect(updated.discard[0].calledFrom).toBe(3);
   });
 });
 

--- a/src/components/Player.ts
+++ b/src/components/Player.ts
@@ -86,6 +86,19 @@ export function removeDiscardTile(
   };
 }
 
+export function markDiscardCalled(
+  player: PlayerState,
+  tileId: string,
+  callerSeat: number,
+): PlayerState {
+  return {
+    ...player,
+    discard: player.discard.map(t =>
+      t.id === tileId ? { ...t, called: true, calledFrom: callerSeat } : t,
+    ),
+  };
+}
+
 function arrangeChiTiles(
   tiles: Tile[],
   calledTileId: string,

--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -10,7 +10,7 @@ import {
   declareRiichi,
   clearIppatsu,
   canCallMeld,
-  removeDiscardTile,
+  markDiscardCalled,
 } from '../components/Player';
 import { validateDiscard, appendDiscardLog } from './helpers';
 import {
@@ -581,7 +581,11 @@ const handleCallAction = (action: MeldType | 'pass') => {
     nextTurn();
     return;
     }
-  p[discarder] = removeDiscardTile(p[discarder], lastDiscard.tile.id);
+  p[discarder] = markDiscardCalled(
+    p[discarder],
+    lastDiscard.tile.id,
+    caller,
+  );
   if (lastDiscard.tile.riichiDiscard) {
     setPendingRiichiIndicator(prev => Array.from(new Set([...prev, discarder])));
   }
@@ -693,7 +697,11 @@ const handleCallAction = (action: MeldType | 'pass') => {
     p = [...p];
     const meldTiles = selectMeldTiles(p[caller], lastDiscard.tile, action);
     if (!meldTiles) return;
-    p[discarder] = removeDiscardTile(p[discarder], lastDiscard.tile.id);
+    p[discarder] = markDiscardCalled(
+      p[discarder],
+      lastDiscard.tile.id,
+      caller,
+    );
     if (lastDiscard.tile.riichiDiscard) {
       setPendingRiichiIndicator(prev => Array.from(new Set([...prev, discarder])));
     }
@@ -891,7 +899,11 @@ const handleCallAction = (action: MeldType | 'pass') => {
     const caller = 0;
     const discarder = lastDiscard.player;
     let p = [...playersRef.current];
-  p[discarder] = removeDiscardTile(p[discarder], lastDiscard.tile.id);
+  p[discarder] = markDiscardCalled(
+    p[discarder],
+    lastDiscard.tile.id,
+    caller,
+  );
   if (lastDiscard.tile.riichiDiscard) {
     setPendingRiichiIndicator(prev => Array.from(new Set([...prev, discarder])));
   }


### PR DESCRIPTION
## Summary
- keep called tiles in discarder rivers via new `markDiscardCalled`
- mark tiles instead of removing them when melding
- test `markDiscardCalled`

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_68612739e4b8832ab20ebae1450f98a2