### PR TITLE
Shrink river area to 6x4 grid

### DIFF
--- a/src/components/RiverView.test.tsx
+++ b/src/components/RiverView.test.tsx
@@ -118,7 +118,7 @@ describe('RiverView', () => {
     render(<RiverView tiles={[]} seat={0} lastDiscard={null} dataTestId="grid" />);
     const div = screen.getByTestId('grid');
     const className = div.getAttribute('class') || '';
-    expect(className).toContain('grid-cols-[repeat(6,_max-content)]');
+    expect(className).toContain('grid-cols-[repeat(4,_max-content)]');
   });
 
   it('applies the same grid size for all seats', () => {

--- a/src/components/RiverView.tsx
+++ b/src/components/RiverView.tsx
@@ -4,7 +4,7 @@ import { TileView } from './TileView';
 import { rotationForSeat } from '../utils/rotation';
 import { calledRotation } from '../utils/calledRotation';
 
-export const RIVER_COLS = 6;
+export const RIVER_COLS = 4;
 export const RIVER_ROWS_MOBILE = 3;
 export const RIVER_ROWS_DESKTOP = 6;
 export const RIVER_GAP_PX = 4;
@@ -17,7 +17,7 @@ export const RIVER_GAP_PX = 4;
 export const CALLED_OFFSET = 'calc(var(--tile-font-size) / 5)';
 
 export const GRID_CLASS =
-  'grid grid-cols-[repeat(6,_max-content)] grid-rows-3 sm:grid-rows-6';
+  'grid grid-cols-[repeat(4,_max-content)] grid-rows-3 sm:grid-rows-6';
 
 /**
  * Positional adjustment for a tile claimed from another player's river.


### PR DESCRIPTION
## Summary
- reduce river layout to 4 columns while keeping 6 rows
- adjust the grid class used in RiverView
- update unit test to expect 4-column layout

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68612a5f6f40832aba24ebd3f4952321