### PR TITLE
Fix river grid layout

### DIFF
--- a/src/components/RiverView.test.tsx
+++ b/src/components/RiverView.test.tsx
@@ -118,7 +118,7 @@ describe('RiverView', () => {
     render(<RiverView tiles={[]} seat={0} lastDiscard={null} dataTestId="grid" />);
     const div = screen.getByTestId('grid');
     const className = div.getAttribute('class') || '';
-    expect(className).toContain('grid-cols-[repeat(4,_max-content)]');
+    expect(className).toContain('grid-cols-[repeat(6,_max-content)]');
   });
 
   it('applies the same grid size for all seats', () => {

--- a/src/components/RiverView.tsx
+++ b/src/components/RiverView.tsx
@@ -4,9 +4,9 @@ import { TileView } from './TileView';
 import { rotationForSeat } from '../utils/rotation';
 import { calledRotation } from '../utils/calledRotation';
 
-export const RIVER_COLS = 4;
+export const RIVER_COLS = 6;
 export const RIVER_ROWS_MOBILE = 3;
-export const RIVER_ROWS_DESKTOP = 6;
+export const RIVER_ROWS_DESKTOP = 4;
 export const RIVER_GAP_PX = 4;
 /**
  * Offset for called tiles relative to the tile size.
@@ -17,7 +17,7 @@ export const RIVER_GAP_PX = 4;
 export const CALLED_OFFSET = 'calc(var(--tile-font-size) / 5)';
 
 export const GRID_CLASS =
-  'grid grid-cols-[repeat(4,_max-content)] grid-rows-3 sm:grid-rows-6';
+  'grid grid-cols-[repeat(6,_max-content)] grid-rows-3 sm:grid-rows-4';
 
 /**
  * Positional adjustment for a tile claimed from another player's river.


### PR DESCRIPTION
## Summary
- correct river grid to reserve 6 columns by 4 rows
- update tests for new constant values

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686134acbd1c832aa19a53183fbad10a