### PR TITLE
Fix tile rotation in meld area

### DIFF
--- a/src/components/MeldView.test.tsx
+++ b/src/components/MeldView.test.tsx
@@ -58,7 +58,7 @@ describe('MeldView', () => {
     expect(html).not.toContain('rotate(180deg)');
   });
 
-  it('rotates the whole meld for side seats', () => {
+  it('does not rotate the meld container', () => {
     const meld: Meld = {
       type: 'pon',
       tiles: [
@@ -70,7 +70,7 @@ describe('MeldView', () => {
       calledTileId: 'a',
     };
     const html = renderToStaticMarkup(<MeldView meld={meld} seat={1} />);
-    expect(html).toContain('rotate(270deg)');
+    expect(html).not.toContain('rotate(270deg)');
   });
 
   it('shows face-down tiles for ankan', () => {

--- a/src/components/MeldView.tsx
+++ b/src/components/MeldView.tsx
@@ -1,17 +1,13 @@
 import React from 'react';
 import { Meld } from '../types/mahjong';
 import { TileView } from './TileView';
-import { rotationForSeat } from '../utils/rotation';
 import { calledRotation } from '../utils/calledRotation';
 
 
 export const MeldView: React.FC<{ meld: Meld; seat?: number }> = ({ meld, seat = 0 }) => {
   const isKakan = meld.type === 'kan' && meld.kanType === 'kakan';
   return (
-    <div
-      className="relative flex gap-1 border rounded px-1 bg-gray-50"
-      style={{ transform: `rotate(${rotationForSeat(seat)}deg)` }}
-    >
+    <div className="relative flex gap-1 border rounded px-1 bg-gray-50">
       {meld.tiles.map(tile => {
         const isCalled = tile.id === meld.calledTileId;
         const rotate = isCalled


### PR DESCRIPTION
## Summary
- remove redundant seat rotation from `MeldView`
- update tests to assert no extra container rotation

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68613c6fcd34832a9f0bdfac3beadf83