### PR TITLE
Orient riichi stick toward table center

### DIFF
--- a/src/components/RiichiStick.tsx
+++ b/src/components/RiichiStick.tsx
@@ -1,5 +1,15 @@
 import React from 'react';
+import { rotationForSeat } from '../utils/rotation';
 
-export const RiichiStick: React.FC<{ className?: string }> = ({ className }) => (
-  <span className={`riichi-stick ${className ?? ''}`} aria-label="riichi stick" />
+interface RiichiStickProps {
+  seat: number;
+  className?: string;
+}
+
+export const RiichiStick: React.FC<RiichiStickProps> = ({ seat, className }) => (
+  <span
+    className={`riichi-stick ${className ?? ''}`}
+    style={{ transform: `rotate(${rotationForSeat(seat) + 90}deg)` }}
+    aria-label="riichi stick"
+  />
 );

--- a/src/components/UIBoard.test.tsx
+++ b/src/components/UIBoard.test.tsx
@@ -6,6 +6,7 @@ import { UIBoard } from './UIBoard';
 import { createInitialPlayerState, canDeclareRiichi } from './Player';
 import { RESERVED_HAND_SLOTS } from './HandView';
 import { Tile } from '../types/mahjong';
+import { rotationForSeat } from '../utils/rotation';
 import type { PlayerState, Meld } from "../types/mahjong";
 
 const t = (suit: Tile['suit'], rank: number, id: string): Tile => ({ suit, rank, id });
@@ -556,6 +557,39 @@ describe('UIBoard riichi indicators', () => {
       />,
     );
     expect(screen.getAllByTestId('riichi-indicator').length).toBe(2);
+  });
+
+  it('rotates riichi stick toward center for each seat', () => {
+    [0, 1, 2, 3].forEach(seat => {
+      const players = [
+        createInitialPlayerState('p0', false, 0),
+        createInitialPlayerState('p1', true, 1),
+        createInitialPlayerState('p2', true, 2),
+        createInitialPlayerState('p3', true, 3),
+      ];
+      players[seat].isRiichi = true;
+      render(
+        <UIBoard
+          players={players}
+          dora={[]}
+          kyoku={1}
+          wallCount={70}
+          kyotaku={0}
+          honba={0}
+          onDiscard={() => {}}
+          isMyTurn={seat === 0}
+          shanten={{ standard: 0, chiitoi: 0, kokushi: 0 }}
+          lastDiscard={null}
+        />,
+      );
+      const stick = screen
+        .getByTestId('riichi-indicator')
+        .firstElementChild as HTMLElement;
+      expect(stick.style.transform).toBe(
+        `rotate(${rotationForSeat(seat) + 90}deg)`,
+      );
+      cleanup();
+    });
   });
 });
 

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -115,7 +115,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
         />
         {top.isRiichi && (
           <div className="text-xs" data-testid="riichi-indicator">
-            <RiichiStick />
+            <RiichiStick seat={top.seat} />
           </div>
         )}
       </div>
@@ -128,7 +128,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
           </div>
           {right.isRiichi && (
             <div className="text-xs" data-testid="riichi-indicator">
-              <RiichiStick />
+              <RiichiStick seat={right.seat} />
             </div>
           )}
           <div className="flex items-start gap-2">
@@ -158,7 +158,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
           </div>
           {left.isRiichi && (
             <div className="text-xs" data-testid="riichi-indicator">
-              <RiichiStick />
+              <RiichiStick seat={left.seat} />
             </div>
           )}
           <div className="flex items-start gap-2">
@@ -218,7 +218,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
         </div>
         {me.isRiichi && (
           <div className="text-xs" data-testid="riichi-indicator">
-            <RiichiStick />
+            <RiichiStick seat={me.seat} />
           </div>
         )}
         <div className="text-sm mb-1">


### PR DESCRIPTION
## Summary
- rotate RiichiStick based on seat so each stick points toward the center of the table
- pass seat prop from UIBoard to RiichiStick
- test orientation for all seats

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686283f58610832abd46cdebeaebf12d