### PR TITLE
Fix noten payout rule

### DIFF
--- a/src/components/WallLogic.test.ts
+++ b/src/components/WallLogic.test.ts
@@ -55,8 +55,9 @@ describe('exhausted wall ends the round in a draw', () => {
     wall = [];
 
     const tenpai = [true, false, false, true];
-    // 2 players tenpai -> each noten player pays 1000 and each tenpai player gains 1000
+    // 2人テンパイの場合、ノーテン者はそれぞれテンパイ者2人に1000点ずつ支払う
+    // よってテンパイ者は2000点受け取り、ノーテン者は2000点支払いとなるはず
     const { players: updated } = payoutNoten(players, tenpai);
-    expect(updated.map(p => p.score)).toEqual([26000, 24000, 24000, 26000]);
+    expect(updated.map(p => p.score)).toEqual([27000, 23000, 23000, 27000]);
   });
 });

--- a/src/utils/payout.test.ts
+++ b/src/utils/payout.test.ts
@@ -68,10 +68,24 @@ describe('payoutNoten', () => {
     const players = setupPlayers();
     const tenpai = [true, true, false, false];
     const { players: updated } = payoutNoten(players, tenpai);
-    expect(updated[0].score).toBe(players[0].score + 1000);
-    expect(updated[1].score).toBe(players[1].score + 1000);
+    // 2人テンパイ・2人ノーテンの場合、ノーテン者はテンパイ者それぞれに1000点支払う
+    // よってテンパイ者は1000点×2=2000点受け取り、ノーテン者は2000点支払いとなるはず
+    expect(updated[0].score).toBe(players[0].score + 2000);
+    expect(updated[1].score).toBe(players[1].score + 2000);
     for (let i = 2; i < 4; i++) {
-      expect(updated[i].score).toBe(players[i].score - 1000);
+      expect(updated[i].score).toBe(players[i].score - 2000);
+    }
+  });
+
+  it('handles one noten against three tenpai correctly', () => {
+    const players = setupPlayers();
+    const tenpai = [true, true, true, false];
+    const { players: updated } = payoutNoten(players, tenpai);
+    // ノーテン1人が3人に1000点ずつ支払うため計3000点マイナス
+    expect(updated[3].score).toBe(players[3].score - 3000);
+    // テンパイ者はそれぞれ1000点ずつ受け取る
+    for (let i = 0; i < 3; i++) {
+      expect(updated[i].score).toBe(players[i].score + 1000);
     }
   });
 });

--- a/src/utils/payout.ts
+++ b/src/utils/payout.ts
@@ -43,10 +43,11 @@ export function payoutNoten(
   }
   const notenCount = players.length - tenpaiCount;
   const penalty = 1000;
-  const bonus = (notenCount * penalty) / tenpaiCount;
   const updated: PlayerState[] = players.map((p, idx) => {
-    if (tenpai[idx]) return { ...p, score: p.score + bonus };
-    return { ...p, score: p.score - penalty };
+    if (tenpai[idx]) {
+      return { ...p, score: p.score + penalty * notenCount };
+    }
+    return { ...p, score: p.score - penalty * tenpaiCount };
   });
   const changes = updated.map((p, idx) => p.score - players[idx].score);
   return { players: updated, changes };


### PR DESCRIPTION
## Summary
- correct noten payout to pay each tenpai 1000 from each noten player
- update payout tests and wall logic test accordingly

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686284094da8832ab62793e6f50a573c