### PR TITLE
Improve AI discard decision heuristics

### DIFF
--- a/src/utils/ai.test.ts
+++ b/src/utils/ai.test.ts
@@ -145,4 +145,26 @@ describe('chooseAIDiscardTile', () => {
     const chosen = chooseAIDiscardTile(player, true);
     expect(isTenpaiAfterDiscard(player, chosen.id)).toBe(true);
   });
+
+  it('prefers isolated tiles when shanten is unchanged', () => {
+    const hand: Tile[] = [
+      t('man', 1, 'p1'),
+      t('man', 1, 'p2'),
+      t('man', 2, 's1'),
+      t('man', 3, 's2'),
+      t('pin', 5, 'i1'),
+      t('sou', 7, 'i2'),
+      t('pin', 9, 'i3'),
+      t('sou', 9, 'i4'),
+      t('wind', 1, 'i5'),
+      t('dragon', 1, 'i6'),
+      t('pin', 1, 'i7'),
+      t('sou', 3, 'i8'),
+      t('man', 7, 'i9'),
+      t('pin', 7, 'i10'),
+    ];
+    const player = makePlayer(hand);
+    const chosen = chooseAIDiscardTile(player);
+    expect(['p1', 'p2', 's1', 's2']).not.toContain(chosen.id);
+  });
 });

--- a/src/utils/ai.ts
+++ b/src/utils/ai.ts
@@ -55,14 +55,33 @@ export function chooseAIDiscardTile(
 ): Tile {
   let best: Tile | null = null;
   let bestShanten = Infinity;
+  let bestSynergy = Infinity;
+
+  function calcSynergy(tile: Tile): number {
+    let score = 0;
+    for (const other of player.hand) {
+      if (other.id === tile.id) continue;
+      if (other.suit !== tile.suit) continue;
+      const diff = Math.abs(other.rank - tile.rank);
+      if (diff === 0) score += 2;
+      else if (diff === 1) score += 1;
+      else if (diff === 2) score += 0.5;
+    }
+    return score;
+  }
   for (const tile of player.hand) {
     if (!declaringRiichi && !canDiscardTile(player, tile.id)) continue;
     const remaining = player.hand.filter(t => t.id !== tile.id);
     const s = calcShanten(remaining, player.melds.length);
     const value = Math.min(s.standard, s.chiitoi, s.kokushi);
     if (player.isRiichi && value > 0) continue;
-    if (value < bestShanten) {
+    const synergy = calcSynergy(tile);
+    if (
+      value < bestShanten ||
+      (value === bestShanten && synergy < bestSynergy)
+    ) {
       bestShanten = value;
+      bestSynergy = synergy;
       best = tile;
     }
   }


### PR DESCRIPTION
## Summary
- adjust AI discard logic to consider tile synergy
- add a test ensuring isolated tiles are preferred

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_6863dd7b93cc832aa28559486a1b23bf