### PR TITLE
Fix autoplay continuing after tsumo

### DIFF
--- a/src/game/handleAITurn.test.ts
+++ b/src/game/handleAITurn.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useGame } from './store';
+
+// Ensure AI does not continue acting after a tsumo win
+
+describe('handleAITurn after tsumo', () => {
+  it('stops without scheduling further actions', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useGame('tonpu'));
+    act(() => {
+      result.current.togglePlayerAI();
+      result.current.handleTsumo();
+    });
+    const wallBefore = result.current.wall.length;
+    act(() => {
+      // attempt to run AI turn even though win already occurred
+      result.current.handleAITurn(0);
+    });
+    vi.advanceTimersByTime(600);
+    expect(result.current.wall.length).toBe(wallBefore);
+    expect(result.current.winResult?.winType).toBe('tsumo');
+    vi.useRealTimers();
+  });
+});

--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -298,6 +298,7 @@ export const useGame = (gameLength: GameLength) => {
   const honbaRef = useRef(honba);
   const logRef = useRef<LogEntry[]>(log);
   const tsumoOptionRef = useRef(tsumoOption);
+  const winResultRef = useRef<WinResult | null>(winResult);
   const actionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const kanDrawRef = useRef<number | null>(null);
   const drawInfoRef = useRef<Record<number, { rinshan: boolean; last: boolean }>>({});
@@ -387,6 +388,10 @@ export const useGame = (gameLength: GameLength) => {
   useEffect(() => {
     tsumoOptionRef.current = tsumoOption;
   }, [tsumoOption]);
+
+  useEffect(() => {
+    winResultRef.current = winResult;
+  }, [winResult]);
 
   useEffect(() => {
     pendingRiichiIndicatorRef.current = pendingRiichiIndicator;
@@ -1113,6 +1118,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
 
   // ターン進行
   const handleAITurn = (ai: number) => {
+    if (winResultRef.current) return;
     if (lastDiscard && lastDiscard.player !== ai) {
       const action = chooseAICallOption(playersRef.current[ai], lastDiscard.tile);
       if (action !== 'pass') {
@@ -1122,6 +1128,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
       setLastDiscard(null);
     }
     drawForCurrentPlayer();
+    if (winResultRef.current) return;
     if (wallRef.current.length === 0) return;
     if (canDeclareRiichi(playersRef.current[ai])) {
       performRiichi(ai);
@@ -1249,6 +1256,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
     handleTsumoPass,
     handleRon,
     handleRonPass,
+    handleAITurn,
     nextTurn,
     nextKyoku,
     handleRestart,


### PR DESCRIPTION
## Summary
- stop `handleAITurn` when a win result already exists
- keep track of winResult in ref
- expose `handleAITurn` for tests
- test that AI turn stops after a tsumo

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_6863e57a6a14832a970bc94ce742e602