### PR TITLE
Fix caller turn after chi/pon

### DIFF
--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -771,6 +771,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
   setSelfKanOptions(null);
   setChiTileOptions(null);
   setTurn(caller);
+  turnRef.current = caller;
 };
 
   const performSelfKan = (caller: number, tiles: Tile[]) => {
@@ -882,6 +883,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
 
     setLastDiscard(null);
     setTurn(caller);
+    turnRef.current = caller;
     setActionTimeout(() => {
       const tile = playersRef.current[caller].hand[0];
       handleDiscard(tile.id);
@@ -1074,6 +1076,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
     setChiTileOptions(null);
     setSelfKanOptions(null);
     setTurn(caller);
+    turnRef.current = caller;
   };
 
   const handleTsumo = () => {


### PR DESCRIPTION
## Summary
- ensure internal turnRef updates after chi or pon calls

## Testing
- `npx -y -p node@20 -p npm@10 npm ci`
- `npx -y -p node@20 -p npm@10 npm run lint --if-present`
- `npx -y -p node@20 -p npm@10 npm run type-check --if-present`
- `npx -y -p node@20 -p npm@10 npm run build`
- `npx -y -p node@20 -p npm@10 npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_686523f519ec832a88ae4d1fd63fbb6b