### PR TITLE
Fix spectator toggle cancels AI timers

### DIFF
--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -329,6 +329,7 @@ export const useGame = (gameLength: GameLength) => {
   }, [preset]);
 
   const togglePlayerAI = () => {
+    clearActionTimer();
     setPlayerIsAI(prev => {
       const next = !prev;
       setPlayers(ps =>


### PR DESCRIPTION
## Summary
- ensure `togglePlayerAI` clears any pending AI action timers

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6865237c9968832a86eb26dd6d94678b