### PR TITLE
Fix river called-tile rotation

### DIFF
--- a/src/components/MeldView.test.tsx
+++ b/src/components/MeldView.test.tsx
@@ -38,8 +38,8 @@ describe('MeldView', () => {
       <MeldView meld={{ ...base, fromPlayer: 3 }} seat={0} />,
     );
 
-    expect(htmlRight).toContain('rotate(90deg)');
-    expect(htmlLeft).toContain('rotate(-90deg)');
+    expect(htmlRight).toContain('rotate(-90deg)');
+    expect(htmlLeft).toContain('rotate(90deg)');
   });
 
   it('rotates called tile horizontally when from opposite seat', () => {

--- a/src/components/RiverView.test.tsx
+++ b/src/components/RiverView.test.tsx
@@ -75,7 +75,7 @@ describe('RiverView', () => {
     const tile = screen.getByTestId('rv-called').querySelector('[style]');
     const style = tile?.getAttribute('style') || '';
     expect(style).toContain(`translateX(-${CALLED_OFFSET})`);
-    expect(style).toContain('rotate(-90deg)');
+    expect(style).toContain('rotate(90deg)');
   });
 
   it('rotates called tile horizontally when from opposite seat', () => {
@@ -87,6 +87,16 @@ describe('RiverView', () => {
     const style = tile?.getAttribute('style') || '';
     expect(style).toContain('rotate(90deg)');
     expect(style).not.toContain('rotate(180deg)');
+  });
+
+  it('rotates called tile based on caller to the right', () => {
+    const tiles = [{ ...t('pin', 5, 'e'), called: true, calledFrom: 0 }];
+    render(
+      <RiverView tiles={tiles} seat={3} lastDiscard={null} dataTestId="rv-right" />,
+    );
+    const tile = screen.getByTestId('rv-right').querySelector('[style]');
+    const style = tile?.getAttribute('style') || '';
+    expect(style).toContain('rotate(-90deg)');
   });
 
   it('moves called tiles to the end of the river', () => {

--- a/src/utils/calledRotation.ts
+++ b/src/utils/calledRotation.ts
@@ -10,11 +10,11 @@ export const calledRotation = (seat: number, from: number): number => {
   const diff = (from - seat + 4) % 4;
   switch (diff) {
     case 1:
-      return 90; // from right
+      return -90; // from right
     case 2:
       return 90; // from opposite
     case 3:
-      return -90; // from left
+      return 90; // from left
     default:
       return 0;
   }


### PR DESCRIPTION
## Summary
- correct `calledRotation` angles for discarder view
- update tests to match fixed orientation

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6873567fee1c832a9c231d896b219085