### PR TITLE
Improve tsumo result formatting

### DIFF
--- a/src/components/WinResultModal.test.tsx
+++ b/src/components/WinResultModal.test.tsx
@@ -101,4 +101,45 @@ describe('WinResultModal', () => {
     );
     expect(screen.getByText(/ドラ1/)).toBeTruthy();
   });
+
+  it('shows dealer tsumo points with all text', () => {
+    render(
+      <WinResultModal
+        players={players}
+        winner={0}
+        winType="tsumo"
+        hand={hand}
+        melds={[]}
+        winTile={winTile}
+        yaku={['立直']}
+        han={1}
+        fu={30}
+        points={1000}
+        dora={[]}
+        onNext={() => {}}
+      />,
+    );
+    expect(screen.getByText('1000点オール')).toBeTruthy();
+    expect(screen.getByText(/立直 1翻 30符/)).toBeTruthy();
+  });
+
+  it('shows non-dealer tsumo split payments', () => {
+    render(
+      <WinResultModal
+        players={players}
+        winner={1}
+        winType="tsumo"
+        hand={hand}
+        melds={[]}
+        winTile={winTile}
+        yaku={['立直']}
+        han={1}
+        fu={30}
+        points={500}
+        dora={[]}
+        onNext={() => {}}
+      />,
+    );
+    expect(screen.getByText('500点-1000点')).toBeTruthy();
+  });
 });

--- a/src/components/WinResultModal.tsx
+++ b/src/components/WinResultModal.tsx
@@ -55,12 +55,20 @@ export const WinResultModal: React.FC<Props> = ({
   ]
     .filter(Boolean)
     .join('、');
+  const isDealer = players[winner].seat === 0;
+  let pointsText = `${points}点`;
+  if (winType === 'tsumo') {
+    pointsText = isDealer
+      ? `${points}点オール`
+      : `${points}点-${points * 2}点`;
+  }
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
       <div className="bg-white rounded-lg p-4 shadow-lg">
         <h2 className="text-lg font-bold mb-2">{title}</h2>
+        <div className="mb-2 text-sm">{pointsText}</div>
         <div className="mb-2 text-sm">
-          {yakuText} {han}翻 {fu}符 {points}点
+          {yakuText} {han}翻 {fu}符
         </div>
         {dora.length > 0 && (
           <div className="mb-2 text-sm flex items-center gap-1">


### PR DESCRIPTION
## Summary
- show tsumo scores as `n点オール` or `n点-2n点`
- split points and yaku information into separate lines
- add tests for the new layout

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687363589528832abf02f43056ff5c92