### PR TITLE
Move Tenhou log button to win modal

### DIFF
--- a/src/components/GameController.tsx
+++ b/src/components/GameController.tsx
@@ -55,9 +55,6 @@ export const GameController: React.FC<Props> = ({ gameLength, showBorders = true
       <button className="ml-2 px-2 py-1 bg-gray-200 rounded" onClick={game.handleDownloadMjaiLog}>
         MJAIログダウンロード
       </button>
-      <button className="ml-2 px-2 py-1 bg-gray-200 rounded" onClick={game.handleDownloadTenhouLog}>
-        Tenhouログダウンロード
-      </button>
       <div className="my-2 flex items-center gap-2">
         <label htmlFor="preset" className="whitespace-nowrap">プリセット</label>
         <select
@@ -87,6 +84,7 @@ export const GameController: React.FC<Props> = ({ gameLength, showBorders = true
         <WinResultModal
           {...game.winResult}
           nextLabel={game.kyoku >= maxKyoku ? '結果発表へ' : undefined}
+          onDownloadTenhou={game.handleDownloadTenhouLog}
           onNext={() => {
             const dealerWon = game.winResult!.winner === 0;
             game.setWinResult(null);

--- a/src/components/WinResultModal.test.tsx
+++ b/src/components/WinResultModal.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import React from 'react';
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
 import { WinResultModal } from './WinResultModal';
 import { PlayerState, Tile } from '../types/mahjong';
@@ -100,5 +100,28 @@ describe('WinResultModal', () => {
       />,
     );
     expect(screen.getByText(/ドラ1/)).toBeTruthy();
+  });
+
+  it('calls download callback', () => {
+    const fn = vi.fn();
+    render(
+      <WinResultModal
+        players={players}
+        winner={0}
+        winType="tsumo"
+        hand={hand}
+        melds={[]}
+        winTile={winTile}
+        yaku={['立直']}
+        han={1}
+        fu={30}
+        points={1000}
+        dora={[]}
+        onNext={() => {}}
+        onDownloadTenhou={fn}
+      />,
+    );
+    screen.getByText('Tenhouログダウンロード').click();
+    expect(fn).toHaveBeenCalled();
   });
 });

--- a/src/components/WinResultModal.tsx
+++ b/src/components/WinResultModal.tsx
@@ -27,6 +27,7 @@ export interface WinResult {
 interface Props extends WinResult {
   onNext: () => void;
   nextLabel?: string;
+  onDownloadTenhou?: () => void;
 }
 
 export const WinResultModal: React.FC<Props> = ({
@@ -44,6 +45,7 @@ export const WinResultModal: React.FC<Props> = ({
   uraDora,
   onNext,
   nextLabel = '次局へ',
+  onDownloadTenhou,
 }) => {
   if (players.length === 0) return null;
   const title = winType === 'ron' ? 'ロン和了' : 'ツモ和了';
@@ -110,6 +112,14 @@ export const WinResultModal: React.FC<Props> = ({
             ))}
           </tbody>
         </table>
+        {onDownloadTenhou && (
+          <button
+            className="mt-2 mr-2 px-2 py-1 bg-gray-200 rounded"
+            onClick={onDownloadTenhou}
+          >
+            Tenhouログダウンロード
+          </button>
+        )}
         <button className="mt-2 px-4 py-1 bg-blue-500 text-white rounded" onClick={onNext}>
           {nextLabel}
         </button>


### PR DESCRIPTION
## Summary
- allow WinResultModal to show a Tenhou log download button
- remove always-visible Tenhou log download button
- test WinResultModal log download callback

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687363a52a98832a858efca8a4fcf901