### PR TITLE
Fix Tenhou log reach tile and missing draw events

### DIFF
--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -504,8 +504,14 @@ export const useGame = (gameLength: GameLength) => {
     setMessage(
       `配牌が完了しました。${playerIsAI ? 'AIのターンです。' : 'あなたのターンです。'}`,
     );
-    setLog([{ type: 'startRound', kyoku: roundNumber }]);
-    logRef.current = [{ type: 'startRound', kyoku: roundNumber }];
+    setLog([
+      { type: 'startRound', kyoku: roundNumber },
+      { type: 'draw', player: 0, tile: extra.player.drawnTile as Tile },
+    ]);
+    logRef.current = [
+      { type: 'startRound', kyoku: roundNumber },
+      { type: 'draw', player: 0, tile: extra.player.drawnTile as Tile },
+    ];
     kanDrawRef.current = null;
     drawInfoRef.current = {};
     setPhase('playing');
@@ -646,6 +652,10 @@ export const useGame = (gameLength: GameLength) => {
       pendingRiichiRef.current,
       pendingRiichiIndicatorRef.current,
     );
+    if (pendingRiichiRef.current === idx) {
+      setLog(prev => [...prev, { type: 'riichi', player: idx, tile }]);
+      logRef.current = [...logRef.current, { type: 'riichi', player: idx, tile }];
+    }
     p[idx] = discardTile(p[idx], tileId, shouldMarkRiichi);
     if (shouldMarkRiichi && pendingRiichiIndicatorRef.current.includes(idx)) {
       setPendingRiichiIndicator(prev => prev.filter(s => s !== idx));
@@ -1053,8 +1063,6 @@ const handleCallAction = (action: MeldType | 'pass') => {
     playersRef.current = p;
     setPendingRiichi(idx);
     pendingRiichiRef.current = idx;
-    setLog(prev => [...prev, { type: 'riichi', player: idx, tile: p[idx].drawnTile as Tile }]);
-    logRef.current = [...logRef.current, { type: 'riichi', player: idx, tile: p[idx].drawnTile as Tile }];
   };
 
   const handleRiichi = () => {

--- a/src/utils/tenhouExport.test.ts
+++ b/src/utils/tenhouExport.test.ts
@@ -52,4 +52,38 @@ describe('exportTenhouLog', () => {
     writeFileSync('tmp.tenhou.json', JSON.stringify(json));
     execSync('python devutils/tenhou-validator.py tmp.tenhou.json');
   });
+
+  it('uses discard tile for riichi event', () => {
+    const drawTile = makeTile(32);
+    const discardTile = makeTile(31);
+    const hands = Array(4)
+      .fill(0)
+      .map(() => Array(13).fill(0).map((_, i) => makeTile(i + 2)));
+    const start: RoundStartInfo = {
+      hands,
+      dealer: 0,
+      doraIndicator: drawTile,
+      kyoku: 1,
+    };
+    const log: LogEntry[] = [
+      { type: 'startRound', kyoku: 1 },
+      { type: 'draw', player: 0, tile: drawTile },
+      { type: 'riichi', player: 0, tile: discardTile },
+      { type: 'discard', player: 0, tile: discardTile },
+      { type: 'tsumo', player: 0, tile: drawTile },
+    ];
+    const end: RoundEndInfo = {
+      result: '和了',
+      diffs: [0, 0, 0, 0],
+      winner: 0,
+      loser: 0,
+      uraDora: [],
+    };
+    const scores = [25000, 25000, 25000, 25000];
+    const json = exportTenhouLog(start, log, scores, end);
+    const dahai = json.log[0][6];
+    expect(dahai[0]).toBe('r' + tileToTenhouNumber(discardTile));
+    writeFileSync('tmp.tenhou.json', JSON.stringify(json));
+    execSync('python devutils/tenhou-validator.py tmp.tenhou.json');
+  });
 });


### PR DESCRIPTION
## Summary
- ensure initial dealer draw is logged
- record `riichi` event using the discarded tile
- update tests for Tenhou export

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6873aa9e5074832a8df8d6a9078c0f78