### PR TITLE
Fix riichi discard duplication

### DIFF
--- a/src/utils/tenhouExport.test.ts
+++ b/src/utils/tenhouExport.test.ts
@@ -82,7 +82,7 @@ describe('exportTenhouLog', () => {
     const scores = [25000, 25000, 25000, 25000];
     const json = exportTenhouLog(start, log, scores, end);
     const dahai = json.log[0][6];
-    expect(dahai[0]).toBe('r' + tileToTenhouNumber(discardTile));
+    expect(dahai).toEqual(['r' + tileToTenhouNumber(discardTile)]);
     writeFileSync('tmp.tenhou.json', JSON.stringify(json));
     execSync('python devutils/tenhou-validator.py tmp.tenhou.json');
   });

--- a/src/utils/tenhouExport.ts
+++ b/src/utils/tenhouExport.ts
@@ -41,7 +41,8 @@ export function exportTenhouLog(
   const take: (Array<number | string>)[] = [[], [], [], []];
   const dahai: (Array<number | string>)[] = [[], [], [], []];
 
-  for (const entry of log) {
+  for (let i = 0; i < log.length; i++) {
+    const entry = log[i];
     switch (entry.type) {
       case 'draw':
         take[entry.player].push(tileToTenhouNumber(entry.tile));
@@ -49,9 +50,19 @@ export function exportTenhouLog(
       case 'discard':
         dahai[entry.player].push(tileToTenhouNumber(entry.tile));
         break;
-      case 'riichi':
+      case 'riichi': {
         dahai[entry.player].push('r' + tileToTenhouNumber(entry.tile));
+        const next = log[i + 1];
+        if (
+          next &&
+          next.type === 'discard' &&
+          next.player === entry.player &&
+          next.tile.id === entry.tile.id
+        ) {
+          i++;
+        }
         break;
+      }
       case 'meld':
         take[entry.player].push(encodeMeld(entry));
         dahai[entry.from].push(0);


### PR DESCRIPTION
## Summary
- deduplicate discard entries following a riichi declaration
- update test to ensure tenhou export doesn't output the same tile twice

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_687436695144832a8c676758b08d520c