### PR TITLE
Fix tsumo discard encoding in Tenhou export

### DIFF
--- a/src/utils/tenhouExport.test.ts
+++ b/src/utils/tenhouExport.test.ts
@@ -147,4 +147,38 @@ describe('exportTenhouLog', () => {
     writeFileSync('tmp.tenhou.json', JSON.stringify(json));
     execSync('python devutils/tenhou-validator.py tmp.tenhou.json');
   });
+
+  it('handles delayed tsumogiri discard', () => {
+    const t = makeTile(88);
+    const other = makeTile(99);
+    const hands = Array(4)
+      .fill(0)
+      .map(() => Array(13).fill(t));
+    const start: RoundStartInfo = {
+      hands,
+      dealer: 0,
+      doraIndicator: t,
+      kyoku: 1,
+    };
+    const log: LogEntry[] = [
+      { type: 'startRound', kyoku: 1 },
+      { type: 'draw', player: 0, tile: t },
+      { type: 'draw', player: 1, tile: other },
+      { type: 'discard', player: 1, tile: other },
+      { type: 'discard', player: 0, tile: t },
+      { type: 'tsumo', player: 0, tile: t },
+    ];
+    const end: RoundEndInfo = {
+      result: '和了',
+      diffs: [0, 0, 0, 0],
+      winner: 0,
+      loser: 0,
+      uraDora: [],
+    };
+    const scores = [25000, 25000, 25000, 25000];
+    const json = exportTenhouLog(start, log, scores, end);
+    expect(json.log[0][6]).toEqual([60]);
+    writeFileSync('tmp.tenhou.json', JSON.stringify(json));
+    execSync('python devutils/tenhou-validator.py tmp.tenhou.json');
+  });
 });

--- a/src/utils/tenhouExport.ts
+++ b/src/utils/tenhouExport.ts
@@ -50,12 +50,8 @@ export function exportTenhouLog(
         lastDraw[entry.player] = entry.tile;
         break;
       case 'discard': {
-        const prev = log[i - 1];
         if (
           lastDraw[entry.player] &&
-          prev &&
-          prev.type === 'draw' &&
-          prev.player === entry.player &&
           lastDraw[entry.player]!.id === entry.tile.id
         ) {
           dahai[entry.player].push(60);


### PR DESCRIPTION
## Summary
- ensure tsumogiri detection checks the last drawn tile even if other events occurred
- add regression test for delayed tsumogiri case

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_6874c52fc64c832abef08c5c6535b8e9