### PR TITLE
Fix tsumo tile duplication in Tenhou export

### DIFF
--- a/src/utils/tenhouExport.test.ts
+++ b/src/utils/tenhouExport.test.ts
@@ -181,4 +181,34 @@ describe('exportTenhouLog', () => {
     writeFileSync('tmp.tenhou.json', JSON.stringify(json));
     execSync('python devutils/tenhou-validator.py tmp.tenhou.json');
   });
+
+  it('avoids duplicate take entry for tsumo tile', () => {
+    const t = makeTile(77);
+    const hands = Array(4)
+      .fill(0)
+      .map(() => Array(13).fill(t));
+    const start: RoundStartInfo = {
+      hands,
+      dealer: 0,
+      doraIndicator: t,
+      kyoku: 1,
+    };
+    const log: LogEntry[] = [
+      { type: 'startRound', kyoku: 1 },
+      { type: 'draw', player: 0, tile: t },
+      { type: 'tsumo', player: 0, tile: t },
+    ];
+    const end: RoundEndInfo = {
+      result: '和了',
+      diffs: [0, 0, 0, 0],
+      winner: 0,
+      loser: 0,
+      uraDora: [],
+    };
+    const scores = [25000, 25000, 25000, 25000];
+    const json = exportTenhouLog(start, log, scores, end);
+    expect(json.log[0][5]).toEqual([tileToTenhouNumber(t)]);
+    writeFileSync('tmp.tenhou.json', JSON.stringify(json));
+    execSync('python devutils/tenhou-validator.py tmp.tenhou.json');
+  });
 });

--- a/src/utils/tenhouExport.ts
+++ b/src/utils/tenhouExport.ts
@@ -81,8 +81,21 @@ export function exportTenhouLog(
         lastDraw[entry.player] = null;
         break;
       case 'tsumo':
-        take[entry.player].push(tileToTenhouNumber(entry.tile));
-        lastDraw[entry.player] = null;
+        // If the previous event was the draw of this tile, we already
+        // recorded it. Avoid duplicating the winning tile in the take list.
+        const prev = log[i - 1];
+        if (
+          i > 0 &&
+          prev &&
+          prev.type === 'draw' &&
+          prev.player === entry.player &&
+          prev.tile.id === entry.tile.id
+        ) {
+          lastDraw[entry.player] = null;
+        } else {
+          take[entry.player].push(tileToTenhouNumber(entry.tile));
+          lastDraw[entry.player] = null;
+        }
         break;
       case 'ron':
         take[entry.player].push(tileToTenhouNumber(entry.tile));

--- a/src/utils/tenhouExport.ts
+++ b/src/utils/tenhouExport.ts
@@ -80,7 +80,7 @@ export function exportTenhouLog(
         dahai[entry.from].push(0);
         lastDraw[entry.player] = null;
         break;
-      case 'tsumo':
+      case 'tsumo': {
         // If the previous event was the draw of this tile, we already
         // recorded it. Avoid duplicating the winning tile in the take list.
         const prev = log[i - 1];
@@ -97,6 +97,7 @@ export function exportTenhouLog(
           lastDraw[entry.player] = null;
         }
         break;
+      }
       case 'ron':
         take[entry.player].push(tileToTenhouNumber(entry.tile));
         lastDraw[entry.player] = null;


### PR DESCRIPTION
## Summary
- prevent duplicate tsumo tiles when exporting Tenhou logs
- test for tsumo tile duplication

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6874c9bdefe8832a9397877f33baea49