### PR TITLE
Fix dealer start hand count in Tenhou log

### DIFF
--- a/src/utils/tenhouExport.test.ts
+++ b/src/utils/tenhouExport.test.ts
@@ -148,6 +148,38 @@ describe('exportTenhouLog', () => {
     execSync('python devutils/tenhou-validator.py tmp.tenhou.json');
   });
 
+  it('trims extra dealer tile from starting hand', () => {
+    const tiles = Array.from({ length: 14 }, (_, i) => makeTile(i + 1));
+    const otherHands = Array(13)
+      .fill(0)
+      .map((_, i) => makeTile(i + 20));
+    const hands = [tiles, otherHands, otherHands, otherHands];
+    const start: RoundStartInfo = {
+      hands,
+      dealer: 0,
+      doraIndicator: tiles[0],
+      kyoku: 1,
+    };
+    const log: LogEntry[] = [
+      { type: 'startRound', kyoku: 1 },
+      { type: 'draw', player: 0, tile: tiles[13] },
+      { type: 'tsumo', player: 0, tile: tiles[13] },
+    ];
+    const end: RoundEndInfo = {
+      result: '和了',
+      diffs: [0, 0, 0, 0],
+      winner: 0,
+      loser: 0,
+      uraDora: [],
+    };
+    const scores = [25000, 25000, 25000, 25000];
+    const json = exportTenhouLog(start, log, scores, end);
+    expect(json.log[0][4]).toHaveLength(13);
+    expect(json.log[0][5][0]).toBe(tileToTenhouNumber(tiles[13]));
+    writeFileSync('tmp.tenhou.json', JSON.stringify(json));
+    execSync('python devutils/tenhou-validator.py tmp.tenhou.json');
+  });
+
   it('handles delayed tsumogiri discard', () => {
     const t = makeTile(88);
     const other = makeTile(99);

--- a/src/utils/tenhouExport.ts
+++ b/src/utils/tenhouExport.ts
@@ -37,7 +37,17 @@ export function exportTenhouLog(
   startScores: number[],
   end: RoundEndInfo,
 ) {
-  const hai = round.hands.map(h => h.map(tileToTenhouNumber));
+  const hai = round.hands.map((h, idx) => {
+    const nums = h.map(tileToTenhouNumber);
+    if (idx === round.dealer && nums.length === 14) {
+      let maxIdx = 0;
+      for (let i = 1; i < nums.length; i++) {
+        if (nums[i] > nums[maxIdx]) maxIdx = i;
+      }
+      nums.splice(maxIdx, 1);
+    }
+    return nums;
+  });
   const take: (Array<number | string>)[] = [[], [], [], []];
   const dahai: (Array<number | string>)[] = [[], [], [], []];
   const lastDraw: (Tile | null)[] = [null, null, null, null];


### PR DESCRIPTION
## Summary
- trim extra tile from dealer's initial hand when exporting Tenhou logs
- test that dealer hand of 14 tiles becomes 13 in output

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_6874eabc1304832ab699aed6a18d2924