### PR TITLE
Fix dealer starting hand in Tenhou log

### DIFF
--- a/src/utils/tenhouExport.test.ts
+++ b/src/utils/tenhouExport.test.ts
@@ -211,4 +211,37 @@ describe('exportTenhouLog', () => {
     writeFileSync('tmp.tenhou.json', JSON.stringify(json));
     execSync('python devutils/tenhou-validator.py tmp.tenhou.json');
   });
+
+  it('outputs 13-tile starting hand for dealer', () => {
+    const extra = makeTile(99);
+    const base = makeTile(1);
+    const hands = Array(4)
+      .fill(0)
+      .map(() => Array(13).fill(base));
+    hands[0].push(extra); // dealer has 14 tiles
+    const start: RoundStartInfo = {
+      hands,
+      dealer: 0,
+      doraIndicator: base,
+      kyoku: 1,
+    };
+    const log: LogEntry[] = [
+      { type: 'startRound', kyoku: 1 },
+      { type: 'draw', player: 0, tile: extra },
+      { type: 'tsumo', player: 0, tile: base },
+    ];
+    const end: RoundEndInfo = {
+      result: '和了',
+      diffs: [0, 0, 0, 0],
+      winner: 0,
+      loser: 0,
+      uraDora: [],
+    };
+    const scores = [25000, 25000, 25000, 25000];
+    const json = exportTenhouLog(start, log, scores, end);
+    expect(json.log[0][4]).toHaveLength(13);
+    expect(json.log[0][5][0]).toBe(tileToTenhouNumber(extra));
+    writeFileSync('tmp.tenhou.json', JSON.stringify(json));
+    execSync('python devutils/tenhou-validator.py tmp.tenhou.json');
+  });
 });

--- a/src/utils/tenhouExport.ts
+++ b/src/utils/tenhouExport.ts
@@ -38,6 +38,23 @@ export function exportTenhouLog(
   end: RoundEndInfo,
 ) {
   const hai = round.hands.map(h => h.map(tileToTenhouNumber));
+  // Dealer has 14 tiles in RoundStartInfo; Tenhou format expects 13.
+  // Remove the tile that was drawn before the round began so it only
+  // appears in the take list.
+  if (hai[round.dealer].length === 14) {
+    let drawTile: Tile | null = null;
+    for (const e of log) {
+      if (e.type === 'draw' && e.player === round.dealer) {
+        drawTile = e.tile;
+        break;
+      }
+    }
+    if (drawTile) {
+      const n = tileToTenhouNumber(drawTile);
+      const idx = hai[round.dealer].indexOf(n);
+      if (idx !== -1) hai[round.dealer].splice(idx, 1);
+    }
+  }
   const take: (Array<number | string>)[] = [[], [], [], []];
   const dahai: (Array<number | string>)[] = [[], [], [], []];
   const lastDraw: (Tile | null)[] = [null, null, null, null];


### PR DESCRIPTION
## Summary
- ensure dealer hand shows 13 tiles in Tenhou export
- test dealer hand trimming

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_6874eabc1304832ab699aed6a18d2924