### PR TITLE
Fix kakan handling in Tenhou log export

### DIFF
--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -826,17 +826,23 @@ const handleCallAction = (action: MeldType | 'pass') => {
       kanType = 'kakan';
     }
 
-    p[caller] = claimMeld(p[caller], tiles, 'kan', from, calledId, kanType);
+    const ordered = [...tiles];
+    const idx = ordered.findIndex(t => t.id === calledId);
+    if (idx >= 0) {
+      const calledTile = ordered.splice(idx, 1)[0];
+      ordered.push(calledTile);
+    }
+    p[caller] = claimMeld(p[caller], ordered, 'kan', from, calledId, kanType);
 
     setPlayers(p);
     playersRef.current = p;
     setLog(prev => [
       ...prev,
-      { type: 'meld', player: caller, tiles, meldType: 'kan', from, kanType },
+      { type: 'meld', player: caller, tiles: ordered, meldType: 'kan', from, kanType },
     ]);
     logRef.current = [
       ...logRef.current,
-      { type: 'meld', player: caller, tiles, meldType: 'kan', from, kanType },
+      { type: 'meld', player: caller, tiles: ordered, meldType: 'kan', from, kanType },
     ];
 
     kanDrawRef.current = caller;


### PR DESCRIPTION
## Summary
- ensure kakan tile ordering places called tile last
- encode kakan/ankan discards using `k` or `a` in Tenhou logs
- output kakan melds into discard list and rinshan draw into take list
- add regression test for kakan export

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_6877bb7b24a8832a96161e67c50e7576