### PR TITLE
Update docs on tile rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,19 +127,9 @@ npm run lint
 - `public/` … favicon等
 - `tailwind.config.js`, `postcss.config.js` … CSSビルド
 - `vite.config.js` … Pages対応
- - `.github/workflows/ci.yml` … CIワークフロー
+- `.github/workflows/ci.yml` … CIワークフロー
 
-## 牌の回転ユーティリティ
-
-`rotationForSeat`、`calledRotation`、`calledOffset` は牌の向きと位置を制御するヘルパー関数です。
-`rotationForSeat` は各プレイヤーの座席に応じた基本角度を返し、
-`calledRotation` は他家から鳴いた牌をどの方向から取ったかで追加回転を決定します。
-`calledOffset` はその牌を少しずらして配置するための変換値を返し、主に `RiverView` で利用されます。
-
-これらを組み合わせることで、鳴き牌を含む捨て牌の向きを簡潔に表現できます。
-レイアウトを拡張する際は、この3関数を基準に角度やオフセットを調整するだけで対応可能です。
-さらに `RiverView` では、鳴かれた捨て牌を河から除去し、
-副露した面子の右端に移動させて表示します。実卓の四隅に鳴き牌を置く挙動を再現するための仕様です。
+詳細な牌の回転ロジックについては [docs/rotation-utils.md](docs/rotation-utils.md) を参照してください。
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,4 @@
+# Documentation Overview
+
+- [Tenhou JSON format](tenhou-json.md)
+- [Tile rotation utilities](rotation-utils.md)

--- a/docs/rotation-utils.md
+++ b/docs/rotation-utils.md
@@ -1,0 +1,9 @@
+# Tile Rotation Utilities
+
+These helpers control the orientation and placement of tiles based on player seat and calling position.
+
+- `rotationForSeat(seat: number)` returns the base rotation in degrees for the given seat.
+- `calledRotation(seat: number, from: number)` adjusts the rotation when claiming a tile from another player's discard.
+- `calledOffset(seat: number)` is defined in `RiverView.tsx` and offsets the called tile slightly so it appears tucked into the meld.
+
+Combining these allows the discard and meld areas to mimic real table layouts. When extending the layout, adjust these functions to reposition or rotate tiles consistently.


### PR DESCRIPTION
## Summary
- reorganize documentation
- move tile rotation notes to `docs/rotation-utils.md`
- add docs index
- link to rotation docs from README

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6878ca6bfdec832a9a12c8b37c707607