### PR TITLE
Add shanten open meld test

### DIFF
--- a/src/utils/shanten.test.ts
+++ b/src/utils/shanten.test.ts
@@ -6,6 +6,7 @@ import {
   calcShanten,
 } from './shanten';
 import { Tile } from '../types/mahjong';
+import { tilesFromString } from './tileString';
 
 describe('shanten calculations', () => {
   const t = (suit: Tile['suit'], rank: number, id: string): Tile => ({ suit, rank, id });
@@ -114,5 +115,11 @@ describe('shanten calculations', () => {
     ];
     // 234p 567p 77p 22345s -> waiting on 6p or 9p
     expect(calcStandardShanten(hand)).toBe(0);
+  });
+
+  it('computes 0 shanten for 678p1234466s5s with open 555m', () => {
+    const hand = tilesFromString('678p1234466s5s');
+    // 555m is already opened, so openMelds = 1
+    expect(calcStandardShanten(hand, 1)).toBe(0);
   });
 });

--- a/src/utils/tileString.ts
+++ b/src/utils/tileString.ts
@@ -13,3 +13,21 @@ export function tileToKanji(tile: Tile): string {
   return honorMap[tile.suit]?.[tile.rank] ?? '';
 }
 
+let idCounter = 0;
+
+/** Parse compact tile notation like `123m456p` into Tile objects. */
+export function tilesFromString(notation: string): Tile[] {
+  const tiles: Tile[] = [];
+  const regex = /(\d+)([mpsz])/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(notation)) !== null) {
+    const digits = match[1];
+    const suitCode = match[2];
+    const suit = suitCode === 'm' ? 'man' : suitCode === 'p' ? 'pin' : suitCode === 's' ? 'sou' : 'wind';
+    for (const d of digits) {
+      tiles.push({ suit, rank: parseInt(d, 10), id: `t${idCounter++}` });
+    }
+  }
+  return tiles;
+}
+


### PR DESCRIPTION
## Summary
- add `tilesFromString` helper for parsing compact tile notation
- test shanten computation for a hand with an open meld

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878fa95a030832a9269a39142bc4943