### PR TITLE
fix shanten pair handling

### DIFF
--- a/src/components/ShantenQuiz.test.tsx
+++ b/src/components/ShantenQuiz.test.tsx
@@ -5,9 +5,9 @@ import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { ShantenQuiz } from './ShantenQuiz';
 import { Tile } from '../types/mahjong';
 
-// The hand below is 1-shanten.
-// Standard calculation finds 3 melds, 1 pair and no taatsu:
-// 8 - 3*2 - 0 - 1 = 1. Chiitoi = 4, Kokushi = 9.
+// The hand below is tenpai.
+// Standard calculation finds 3 melds, 2 pairs and 1 taatsu:
+// 8 - 3*2 - 1 - 1 = 0. Chiitoi = 4, Kokushi = 9.
 const t = (suit: Tile['suit'], rank: number, id: string): Tile => ({ suit, rank, id });
 const hand: Tile[] = [
   t('man',1,'a'), t('man',2,'b'), t('man',3,'c'),
@@ -23,10 +23,10 @@ describe('ShantenQuiz', () => {
   it('shows "正解！" when the guess is correct', () => {
     render(<ShantenQuiz initialHand={hand} />);
     const input = screen.getByPlaceholderText('向聴数を入力');
-    fireEvent.change(input, { target: { value: '1' } });
+    fireEvent.change(input, { target: { value: '0' } });
     fireEvent.click(screen.getByText('答える'));
     expect(screen.getByText('正解！')).toBeTruthy();
-    expect(screen.getByText('向聴数: 1 - 標準形: 面子3組、対子2組、ターツ0組 -> 8 - 3*2 - 0 - 1 = 1')).toBeTruthy();
+    expect(screen.getByText('聴牌。標準形: 面子3組、対子2組、ターツ1組 -> 8 - 3*2 - 1 - 1 = 0')).toBeTruthy();
   });
 
   it('shows the correct answer when wrong', () => {
@@ -34,7 +34,7 @@ describe('ShantenQuiz', () => {
     const input = screen.getByPlaceholderText('向聴数を入力');
     fireEvent.change(input, { target: { value: '2' } });
     fireEvent.click(screen.getByText('答える'));
-    expect(screen.getByText('不正解。正解: 1')).toBeTruthy();
-    expect(screen.getByText('向聴数: 1 - 標準形: 面子3組、対子2組、ターツ0組 -> 8 - 3*2 - 0 - 1 = 1')).toBeTruthy();
+    expect(screen.getByText('不正解。正解: 0')).toBeTruthy();
+    expect(screen.getByText('聴牌。標準形: 面子3組、対子2組、ターツ1組 -> 8 - 3*2 - 1 - 1 = 0')).toBeTruthy();
   });
 });

--- a/src/utils/shanten.test.ts
+++ b/src/utils/shanten.test.ts
@@ -36,9 +36,9 @@ describe('shanten calculations', () => {
       t('sou', 2, 'm'), t('sou', 3, 'n'),
     ];
     expect(calcChiitoiShanten(hand)).toBe(0);
-    expect(calcStandardShanten(hand)).toBe(1);
+    expect(calcStandardShanten(hand)).toBe(0);
     expect(calcKokushiShanten(hand)).toBe(9);
-    expect(calcShanten(hand)).toEqual({ standard: 1, chiitoi: 0, kokushi: 9 });
+    expect(calcShanten(hand)).toEqual({ standard: 0, chiitoi: 0, kokushi: 9 });
   });
 
   it('calculates chiitoitsu 2-shanten', () => {
@@ -102,7 +102,7 @@ describe('shanten calculations', () => {
       t('wind', 3, 'l'), t('wind', 3, 'm'),
     ];
     // この手牌は44m 2p 99p 123456s 西西で、2pを引けば聴牌になる
-    expect(calcStandardShanten(hand)).toBe(3);
+    expect(calcStandardShanten(hand)).toBe(1);
   });
 
   it('calculates tenpai for 2345677p 8p 22345s', () => {
@@ -121,5 +121,11 @@ describe('shanten calculations', () => {
     const hand = tilesFromString('678p1234466s5s');
     // 555m is already opened, so openMelds = 1
     expect(calcStandardShanten(hand, 1)).toBe(0);
+  });
+
+  it('uses extra pair as taatsu when beneficial', () => {
+    const hand = tilesFromString('11m22m345p678p789s5m');
+    // One pair is used as the head, the other as a taatsu
+    expect(calcStandardShanten(hand)).toBe(0);
   });
 });

--- a/src/utils/shanten.ts
+++ b/src/utils/shanten.ts
@@ -45,6 +45,7 @@ export function calcStandardShanten(hand: Tile[], openMelds = 0): number {
     if (counts[idx] >= 2) {
       counts[idx] -= 2;
       dfs(idx, melds, pairs + 1, taatsu);
+      dfs(idx, melds, pairs, taatsu + 1);
       counts[idx] += 2;
     }
 

--- a/src/utils/shantenExplain.test.ts
+++ b/src/utils/shantenExplain.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { explainShanten } from './shantenExplain';
+import { tilesFromString } from './tileString';
 import { Tile } from '../types/mahjong';
 
 describe('explainShanten', () => {
@@ -15,7 +16,13 @@ describe('explainShanten', () => {
       t('dragon', 3, 'n'),
     ];
     const { shanten, explanation } = explainShanten(hand);
-    expect(shanten).toBe(4);
-    expect(explanation).toBe('標準形: 面子0組、対子2組、ターツ3組 -> 8 - 0*2 - 3 - 1 = 4');
+    expect(shanten).toBe(3);
+    expect(explanation).toBe('標準形: 面子0組、対子2組、ターツ4組 -> 8 - 0*2 - 4 - 1 = 3');
+  });
+
+  it('counts extra pair as taatsu', () => {
+    const { shanten, explanation } = explainShanten(tilesFromString('11m22m345p678p789s5m'));
+    expect(shanten).toBe(0);
+    expect(explanation).toBe('聴牌。標準形: 面子3組、対子2組、ターツ1組 -> 8 - 3*2 - 1 - 1 = 0');
   });
 });

--- a/src/utils/shantenExplain.ts
+++ b/src/utils/shantenExplain.ts
@@ -36,10 +36,16 @@ export function calcStandardDetail(hand: Tile[], openMelds = 0) {
       melds++;
     }
   }
+  let pairUsed = false;
   for (let i = 0; i < 34; i++) {
     while (counts[i] >= 2) {
       counts[i] -= 2;
       pairs++;
+      if (!pairUsed) {
+        pairUsed = true;
+      } else {
+        taatsu++;
+      }
     }
   }
   for (let i = 0; i < 27; i++) {
@@ -56,13 +62,7 @@ export function calcStandardDetail(hand: Tile[], openMelds = 0) {
       taatsu++;
     }
   }
-  for (let i = 0; i < 34; i++) {
-    while (counts[i] >= 2) {
-      counts[i] -= 2;
-      taatsu++;
-    }
-  }
-  pairForShanten = Math.min(pairs, 1);
+  pairForShanten = pairUsed ? 1 : 0;
   melds += openMelds;
   if (taatsu > 4 - melds) taatsu = 4 - melds;
   const shanten = 8 - melds * 2 - taatsu - pairForShanten;


### PR DESCRIPTION
## Summary
- treat duplicate tile pairs as taatsu in shanten search
- apply same logic to detailed shanten explanation
- update shanten quiz and shanten tests

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_687902335fd4832ab4703132d88dd48f