### PR TITLE
Fix riichi-only ron detection

### DIFF
--- a/src/components/DiscardUtil.test.ts
+++ b/src/components/DiscardUtil.test.ts
@@ -47,4 +47,28 @@ describe('findRonWinner', () => {
     const idx = findRonWinner(players, 0, win, 1);
     expect(idx).toBeNull();
   });
+
+  it('counts riichi as valid yaku', () => {
+    const base: Tile[] = [
+      t('man', 1, 'm1'),
+      t('man', 2, 'm2'),
+      t('man', 3, 'm3'),
+      t('pin', 2, 'p2'),
+      t('pin', 3, 'p3'),
+      t('pin', 4, 'p4'),
+      t('sou', 2, 's2'),
+      t('sou', 3, 's3'),
+      t('sou', 4, 's4'),
+      t('man', 5, 'm5'),
+      t('man', 6, 'm6'),
+      t('wind', 3, 'w1'),
+      t('wind', 3, 'w2'),
+    ];
+    const winTile = t('man', 7, 'm7');
+    const p1 = { ...createInitialPlayerState('p1', false), hand: base, isRiichi: true };
+    const p2 = createInitialPlayerState('p2', false);
+    const players = [p1, p2];
+    const idx = findRonWinner(players, 1, winTile, 1);
+    expect(idx).toBe(0);
+  });
 });

--- a/src/components/DiscardUtil.ts
+++ b/src/components/DiscardUtil.ts
@@ -1,4 +1,4 @@
-import { Tile } from '../types/mahjong';
+import { Tile, PlayerState } from '../types/mahjong';
 import { isWinningHand, detectYaku } from '../score/yaku';
 
 export function incrementDiscardCount(
@@ -12,7 +12,10 @@ export function incrementDiscardCount(
 }
 
 export function findRonWinner(
-  players: { hand: Tile[]; melds: { tiles: Tile[] }[]; seat: number }[],
+  players: Pick<
+    PlayerState,
+    'hand' | 'melds' | 'seat' | 'isRiichi' | 'doubleRiichi' | 'ippatsu'
+  >[],
   discarderIndex: number,
   tile: Tile,
   roundWind: number,
@@ -28,7 +31,14 @@ export function findRonWinner(
       const yaku = detectYaku(
         [...players[i].hand, tile],
         players[i].melds as any,
-        { seatWind: players[i].seat + 1, roundWind, isTsumo: false },
+        {
+          seatWind: players[i].seat + 1,
+          roundWind,
+          isTsumo: false,
+          isRiichi: players[i].isRiichi,
+          doubleRiichi: players[i].doubleRiichi,
+          ippatsu: players[i].ippatsu,
+        },
       );
       const hasBaseYaku = yaku.some(y => y.name !== 'Ura Dora');
       if (hasBaseYaku) return i;


### PR DESCRIPTION
## Summary
- include riichi status when evaluating ron candidates
- test that riichi-only hands trigger a ron win

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a369f46ac832a973d33157302b5c1