### PR TITLE
Adjust noten split for two-player tenpai

### DIFF
--- a/src/components/WallLogic.test.ts
+++ b/src/components/WallLogic.test.ts
@@ -55,9 +55,9 @@ describe('exhausted wall ends the round in a draw', () => {
     wall = [];
 
     const tenpai = [true, false, false, true];
-    // 2人テンパイの場合、ノーテン者はそれぞれテンパイ者2人に1000点ずつ支払う
-    // よってテンパイ者は2000点受け取り、ノーテン者は2000点支払いとなるはず
+    // 2人テンパイの場合、ノーテン合計3000点を2人のテンパイ者で分け合う
+    // よってテンパイ者は1500点受け取り、ノーテン者は1500点支払いとなるはず
     const { players: updated } = payoutNoten(players, tenpai);
-    expect(updated.map(p => p.score)).toEqual([27000, 23000, 23000, 27000]);
+    expect(updated.map(p => p.score)).toEqual([26500, 23500, 23500, 26500]);
   });
 });

--- a/src/utils/payout.test.ts
+++ b/src/utils/payout.test.ts
@@ -68,12 +68,12 @@ describe('payoutNoten', () => {
     const players = setupPlayers();
     const tenpai = [true, true, false, false];
     const { players: updated } = payoutNoten(players, tenpai);
-    // 2人テンパイ・2人ノーテンの場合、ノーテン者はテンパイ者それぞれに1000点支払う
-    // よってテンパイ者は1000点×2=2000点受け取り、ノーテン者は2000点支払いとなるはず
-    expect(updated[0].score).toBe(players[0].score + 2000);
-    expect(updated[1].score).toBe(players[1].score + 2000);
+    // 2人テンパイ・2人ノーテンの場合、ノーテン合計3000点をテンパイ同士で分け合う
+    // よってテンパイ者は1500点受け取り、ノーテン者は1500点支払いとなるはず
+    expect(updated[0].score).toBe(players[0].score + 1500);
+    expect(updated[1].score).toBe(players[1].score + 1500);
     for (let i = 2; i < 4; i++) {
-      expect(updated[i].score).toBe(players[i].score - 2000);
+      expect(updated[i].score).toBe(players[i].score - 1500);
     }
   });
 

--- a/src/utils/payout.ts
+++ b/src/utils/payout.ts
@@ -42,12 +42,14 @@ export function payoutNoten(
     return { players: [...players], changes: players.map(() => 0) };
   }
   const notenCount = players.length - tenpaiCount;
-  const penalty = 1000;
+  const totalPenalty = 3000;
+  const gain = totalPenalty / tenpaiCount;
+  const loss = totalPenalty / notenCount;
   const updated: PlayerState[] = players.map((p, idx) => {
     if (tenpai[idx]) {
-      return { ...p, score: p.score + penalty * notenCount };
+      return { ...p, score: p.score + gain };
     }
-    return { ...p, score: p.score - penalty * tenpaiCount };
+    return { ...p, score: p.score - loss };
   });
   const changes = updated.map((p, idx) => p.score - players[idx].score);
   return { players: updated, changes };


### PR DESCRIPTION
## Summary
- fix `payoutNoten` to split a fixed 3000-point penalty
- update tests for new +1500/-1500 distribution

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a4e2cc0a0832aa9de2cc79d197bc7