### PR TITLE
Fix tsumogiri ron detection

### DIFF
--- a/src/components/DiscardUtil.test.ts
+++ b/src/components/DiscardUtil.test.ts
@@ -71,4 +71,28 @@ describe('findRonWinner', () => {
     const idx = findRonWinner(players, 1, winTile, 1);
     expect(idx).toBe(0);
   });
+
+  it('detects ron on tsumogiri 6p for 6p/9p wait', () => {
+    const base: Tile[] = [
+      t('pin', 2, 'a'),
+      t('pin', 3, 'b'),
+      t('pin', 4, 'c'),
+      t('pin', 5, 'd'),
+      t('pin', 6, 'e'),
+      t('pin', 7, 'f'),
+      t('pin', 7, 'g'),
+      t('pin', 8, 'h'),
+      t('sou', 2, 'i'),
+      t('sou', 2, 'j'),
+      t('sou', 3, 'k'),
+      t('sou', 4, 'l'),
+      t('sou', 5, 'm'),
+    ];
+    const winTile = t('pin', 6, 'ron');
+    const p1 = { ...createInitialPlayerState('p1', false), hand: base };
+    const p2 = createInitialPlayerState('p2', false);
+    const players = [p1, p2];
+    const idx = findRonWinner(players, 1, winTile, 1);
+    expect(idx).toBe(0);
+  });
 });

--- a/src/components/Player.ts
+++ b/src/components/Player.ts
@@ -63,7 +63,10 @@ export function discardTile(
     ...player,
     hand: sortHand(newHand),
     discard: [...player.discard, tile],
-    drawnTile: null,
+    drawnTile:
+      player.drawnTile && player.drawnTile.id === tileId
+        ? player.drawnTile
+        : null,
   };
 }
 

--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -688,7 +688,8 @@ export const useGame = (gameLength: GameLength) => {
     setLog(prev => appendDiscardLog(prev, idx, tile));
     logRef.current = appendDiscardLog(logRef.current, idx, tile);
     const roundWind = kyokuRef.current <= 4 ? 1 : 2;
-    const winIdx = findRonWinner(p, idx, tile, roundWind);
+    const ronTile = p[idx].drawnTile ?? tile;
+    const winIdx = findRonWinner(p, idx, ronTile, roundWind);
     if (winIdx !== null) {
       if (p[winIdx].isAI || winIdx !== 0) {
         performRon(winIdx, idx, tile);


### PR DESCRIPTION
## Summary
- preserve drawn tile on tsumogiri discards
- use the drawn tile when checking for ron
- test tsumogiri discard scenario

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ad125ed38832a88e107591f675c6b