### PR TITLE
Include kan dora indicators in Tenhou logs

### DIFF
--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -1286,6 +1286,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
       logRef.current,
       startScoresRef.current,
       endInfoRef.current,
+      dora,
     );
     const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
@@ -1303,6 +1304,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
       logRef.current,
       startScoresRef.current,
       endInfoRef.current,
+      dora,
     );
     await navigator.clipboard.writeText(JSON.stringify(data, null, 2));
     setMessage('Tenhouログをコピーしました');

--- a/src/utils/tenhouExport.test.ts
+++ b/src/utils/tenhouExport.test.ts
@@ -347,9 +347,32 @@ describe('exportTenhouLog', () => {
     const scores = [25000, 25000, 25000, 25000];
     const json = exportTenhouLog(start, log, scores, end);
     const code = tileToTenhouNumber(base);
-    const expected = `${code}${code}k${code}${code}`;
-    expect(json.log[0][6]).toEqual([expected]);
-    expect(json.log[0][5]).toEqual([code, tileToTenhouNumber(rinshan)]);
+  const expected = `${code}${code}k${code}${code}`;
+  expect(json.log[0][6]).toEqual([expected]);
+  expect(json.log[0][5]).toEqual([code, tileToTenhouNumber(rinshan)]);
+  writeFileSync('tmp.tenhou.json', JSON.stringify(json));
+  execSync('python devutils/tenhou-validator.py tmp.tenhou.json');
+  });
+
+  it('includes kan dora indicators', () => {
+    const base = makeTile(1);
+    const kanDora = makeTile(2);
+    const start: RoundStartInfo = {
+      hands: Array(4)
+        .fill(0)
+        .map(() => Array(13).fill(base)),
+      dealer: 0,
+      doraIndicator: base,
+      kyoku: 1,
+    };
+    const log: LogEntry[] = [{ type: 'startRound', kyoku: 1 }];
+    const end: RoundEndInfo = { result: '流局', diffs: [0, 0, 0, 0] };
+    const scores = [25000, 25000, 25000, 25000];
+    const json = exportTenhouLog(start, log, scores, end, [base, kanDora]);
+    expect(json.log[0][2]).toEqual([
+      tileToTenhouNumber(base),
+      tileToTenhouNumber(kanDora),
+    ]);
     writeFileSync('tmp.tenhou.json', JSON.stringify(json));
     execSync('python devutils/tenhou-validator.py tmp.tenhou.json');
   });

--- a/src/utils/tenhouExport.ts
+++ b/src/utils/tenhouExport.ts
@@ -96,6 +96,7 @@ export function exportTenhouLog(
   log: LogEntry[],
   startScores: number[],
   end: RoundEndInfo,
+  doraIndicators: Tile[] = [round.doraIndicator],
 ) {
   const hai = round.hands.map(h => h.map(tileToTenhouNumber));
   // Dealer has 14 tiles in RoundStartInfo; Tenhou format expects 13.
@@ -191,7 +192,7 @@ export function exportTenhouLog(
     }
   }
 
-  const dora = [tileToTenhouNumber(round.doraIndicator)];
+  const dora = doraIndicators.map(tileToTenhouNumber);
   const ura = end.uraDora ? end.uraDora.map(tileToTenhouNumber) : [];
 
   const kyokuNum = round.kyoku - 1;


### PR DESCRIPTION
## Summary
- support passing multiple dora indicators to `exportTenhouLog`
- propagate current dora list when exporting logs from the game store
- test that kan dora indicators are included

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ade5cb118832a8be0f986b47ea8f7