### PR TITLE
Fix seat rotation to keep control with human player

### DIFF
--- a/src/game/store.test.ts
+++ b/src/game/store.test.ts
@@ -12,25 +12,14 @@ describe('game store', () => {
     expect(result.current.kyoku).toBe(2);
   });
 
-  it('rotates seats when dealer changes', () => {
+  it('rotates seat numbers when dealer changes', () => {
     const { result } = renderHook(() => useGame('tonpu'));
-    expect(result.current.players.map(p => p.name)).toEqual([
-      'あなた',
-      'AI下家',
-      'AI対面',
-      'AI上家',
-    ]);
+    expect(result.current.players.map(p => p.seat)).toEqual([0, 1, 2, 3]);
     act(() => {
       result.current.nextKyoku(false);
     });
-    expect(result.current.players.map(p => p.name)).toEqual([
-      'AI下家',
-      'AI対面',
-      'AI上家',
-      'あなた',
-    ]);
-    expect(result.current.players[0].seat).toBe(0);
-    expect(result.current.players[3].seat).toBe(3);
+    expect(result.current.players.map(p => p.seat)).toEqual([3, 0, 1, 2]);
+    expect(result.current.players[0].name).toBe('あなた');
   });
 
   it('ends game after final round draw', () => {


### PR DESCRIPTION
## Summary
- keep the human player in control when round advances
- adjust seat rotation logic and round initialization
- update tests for new seat rotation behavior

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_687ad688d79c832aa69178f4e2713f63