### PR TITLE
Fix drawn tile lingering after tsumogiri

### DIFF
--- a/src/components/Player.test.ts
+++ b/src/components/Player.test.ts
@@ -133,6 +133,15 @@ describe('discardTile', () => {
     const updated = discardTile(player, 'b', true);
     expect(updated.discard[updated.discard.length - 1].riichiDiscard).toBe(true);
   });
+
+  it('clears drawnTile when discarding the drawn tile', () => {
+    const wall = generateTileWall();
+    const base = createInitialPlayerState('Bob', false);
+    const { player } = drawTiles(base, wall, 1);
+    const tileId = player.hand[0].id;
+    const updated = discardTile(player, tileId);
+    expect(updated.drawnTile).toBeNull();
+  });
 });
 
 describe('claimMeld', () => {

--- a/src/components/Player.ts
+++ b/src/components/Player.ts
@@ -63,10 +63,7 @@ export function discardTile(
     ...player,
     hand: sortHand(newHand),
     discard: [...player.discard, tile],
-    drawnTile:
-      player.drawnTile && player.drawnTile.id === tileId
-        ? player.drawnTile
-        : null,
+    drawnTile: null,
   };
 }
 


### PR DESCRIPTION
## Summary
- fix drawnTile not cleared when discarding drawn tile
- add regression test for discardTile

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_687af0138a6c832a923ed9c5e3e1bf93