### PR TITLE
Implement missing yaku

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ npm run lint
 | San Doukou | ✓ |
 | Ittsu | ✓ |
 | Chanta | ✓ |
-| Junchan | ✗ |
+| Junchan | ✓ |
 | Honitsu | ✓ |
 | Chinitsu | ✓ |
 | Riichi | ✓ |
@@ -179,8 +179,19 @@ npm run lint
 | Houtei | ✓ |
 | Ura Dora | ✓ |
 | Kokushi Musou | ✓ |
-| San Kantsu | ✗ |
-| Su Kantsu | ✗ |
+| San Kantsu | ✓ |
+| Su Kantsu | ✓ |
+| Daisangen | ✗ |
+| Shousangen | ✗ |
+| Suu Ankou | ✗ |
+| Daisuushii | ✗ |
+| Shousuushii | ✗ |
+| Tsuuiisou | ✗ |
+| Chinroutou | ✗ |
+| Ryuuiisou | ✗ |
+| Chuuren Poutou | ✗ |
+| Tenhou / Chiihou | ✗ |
+| Renhou | ✗ |
 
 ## 牌譜エクスポート
 

--- a/src/score/yaku.test.ts
+++ b/src/score/yaku.test.ts
@@ -476,6 +476,44 @@ describe('Scoring', () => {
     expect(fu).toBe(40);
   });
 
+  it('detects Junchan', () => {
+    const hand: Tile[] = [
+      t('man',1,'j1'),t('man',2,'j2'),t('man',3,'j3'),
+      t('man',7,'j4'),t('man',8,'j5'),t('man',9,'j6'),
+      t('pin',1,'j7'),t('pin',1,'j8'),t('pin',1,'j9'),
+      t('sou',9,'j10'),t('sou',9,'j11'),t('sou',9,'j12'),
+      t('sou',1,'j13'),t('sou',1,'j14'),
+    ];
+    const yaku = detectYaku(hand, [], { isTsumo: true });
+    expect(yaku.some(y => y.name === 'Junchan')).toBe(true);
+  });
+
+  it('detects San Kantsu', () => {
+    const concealed: Tile[] = [
+      t('man',1,'sk1'),t('man',1,'sk2'),t('man',1,'sk3'),
+      t('sou',1,'skp1'),t('sou',1,'skp2'),
+    ];
+    const melds: Meld[] = [
+      { type: 'kan', tiles: [t('dragon',1,'kd1'),t('dragon',1,'kd2'),t('dragon',1,'kd3')], fromPlayer: 0, calledTileId: 'kd1', kanType: 'daiminkan' },
+      { type: 'kan', tiles: [t('dragon',2,'kd4'),t('dragon',2,'kd5'),t('dragon',2,'kd6')], fromPlayer: 0, calledTileId: 'kd4', kanType: 'daiminkan' },
+      { type: 'kan', tiles: [t('dragon',3,'kd7'),t('dragon',3,'kd8'),t('dragon',3,'kd9')], fromPlayer: 0, calledTileId: 'kd7', kanType: 'daiminkan' },
+    ];
+    const yaku = detectYaku(concealed, melds, { isTsumo: true });
+    expect(yaku.some(y => y.name === 'San Kantsu')).toBe(true);
+  });
+
+  it('detects Su Kantsu', () => {
+    const concealed: Tile[] = [t('sou',1,'sks1'),t('sou',1,'sks2')];
+    const melds: Meld[] = [
+      { type: 'kan', tiles: [t('dragon',1,'k1a'),t('dragon',1,'k1b'),t('dragon',1,'k1c')], fromPlayer: 0, calledTileId: 'k1a', kanType: 'daiminkan' },
+      { type: 'kan', tiles: [t('dragon',2,'k2a'),t('dragon',2,'k2b'),t('dragon',2,'k2c')], fromPlayer: 0, calledTileId: 'k2a', kanType: 'daiminkan' },
+      { type: 'kan', tiles: [t('dragon',3,'k3a'),t('dragon',3,'k3b'),t('dragon',3,'k3c')], fromPlayer: 0, calledTileId: 'k3a', kanType: 'daiminkan' },
+      { type: 'kan', tiles: [t('man',1,'k4a'),t('man',1,'k4b'),t('man',1,'k4c')], fromPlayer: 0, calledTileId: 'k4a', kanType: 'daiminkan' },
+    ];
+    const yaku = detectYaku(concealed, melds, { isTsumo: true });
+    expect(yaku.some(y => y.name === 'Su Kantsu')).toBe(true);
+  });
+
   it('adds riichi han when declared', () => {
     const hand: Tile[] = [
       t('man',2,'m2a'),t('man',3,'m3a'),t('man',4,'m4a'),

--- a/src/score/yaku.ts
+++ b/src/score/yaku.ts
@@ -301,6 +301,24 @@ function isChanta(parsed: { pair: Tile[]; melds: ParsedMeld[] }): boolean {
   return parsed.melds.every(m => m.tiles.some(isTerminalOrHonor));
 }
 
+function isJunchan(parsed: { pair: Tile[]; melds: ParsedMeld[] }): boolean {
+  if (!isChanta(parsed)) return false;
+  const tiles = [...parsed.pair, ...parsed.melds.flatMap(m => m.tiles)];
+  return tiles.every(t => t.suit !== 'wind' && t.suit !== 'dragon');
+}
+
+function countKans(melds: Meld[]): number {
+  return melds.filter(m => m.type === 'kan').length;
+}
+
+function isSanKantsu(melds: Meld[]): boolean {
+  return countKans(melds) >= 3;
+}
+
+function isSuKantsu(melds: Meld[]): boolean {
+  return countKans(melds) >= 4;
+}
+
 function isHonitsu(tiles: Tile[]): boolean {
   const suits = new Set(tiles.filter(t => t.suit === 'man' || t.suit === 'pin' || t.suit === 'sou').map(t => t.suit));
   const hasHonor = tiles.some(t => t.suit === 'wind' || t.suit === 'dragon');
@@ -378,7 +396,9 @@ export function detectYaku(
   if (parsed && isIttsu(parsed)) {
     result.push({ name: 'Ittsu', han: isClosed ? 2 : 1 });
   }
-  if (parsed && isChanta(parsed)) {
+  if (parsed && isJunchan(parsed)) {
+    result.push({ name: 'Junchan', han: isClosed ? 3 : 2 });
+  } else if (parsed && isChanta(parsed)) {
     result.push({ name: 'Chanta', han: isClosed ? 2 : 1 });
   }
   if (isClosed && isPinfuHand(allTiles)) {
@@ -415,6 +435,11 @@ export function detectYaku(
     result.push({ name: 'Chinitsu', han: isClosed ? 6 : 5 });
   } else if (isHonitsu(allTiles)) {
     result.push({ name: 'Honitsu', han: isClosed ? 3 : 2 });
+  }
+  if (isSuKantsu(melds)) {
+    result.push({ name: 'Su Kantsu', han: 13 });
+  } else if (isSanKantsu(melds)) {
+    result.push({ name: 'San Kantsu', han: 2 });
   }
   const yakuhai = countValueTriplets(
     counts,

--- a/src/yaku.ts
+++ b/src/yaku.ts
@@ -79,6 +79,12 @@ export const YAKU_LIST: Yaku[] = [
     hanOpen: 1,
   },
   {
+    name: 'Junchan',
+    description: '么九牌のみを含み字牌を含まない',
+    hanClosed: 3,
+    hanOpen: 2,
+  },
+  {
     name: 'Honitsu',
     description: '1種類の数牌と字牌のみで構成する',
     hanClosed: 3,
@@ -131,5 +137,17 @@ export const YAKU_LIST: Yaku[] = [
     description: '裏ドラによる加算',
     hanClosed: 1,
     hanOpen: 0,
+  },
+  {
+    name: 'San Kantsu',
+    description: '槓子を3組作る',
+    hanClosed: 2,
+    hanOpen: 2,
+  },
+  {
+    name: 'Su Kantsu',
+    description: '槓子を4組作る',
+    hanClosed: 13,
+    hanOpen: 13,
   },
 ];


### PR DESCRIPTION
## Summary
- add missing yaku detection (Junchan, San Kantsu, Su Kantsu)
- record new yaku names for the help modal
- extend README yaku table with more yakuman
- test newly supported yaku

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b38da9d8c832a8a712d6e59b989e6