### PR TITLE
Fix kamicha meld area overlap

### DIFF
--- a/src/components/UIBoard.test.tsx
+++ b/src/components/UIBoard.test.tsx
@@ -778,4 +778,40 @@ describe('UIBoard meld area placement', () => {
     const label = container.children[1].querySelector('span[aria-hidden="true"]');
     expect(label?.textContent).toBe('鳴き牌');
   });
+
+  it('offsets kamicha meld area from the bottom edge', () => {
+    const sampleMeld: Meld = {
+      type: 'chi',
+      tiles: [
+        { suit: 'man', rank: 1, id: 'a' },
+        { suit: 'man', rank: 2, id: 'b' },
+        { suit: 'man', rank: 3, id: 'c' },
+      ],
+      fromPlayer: 0,
+      calledTileId: 'b',
+    };
+    const players: PlayerState[] = [
+      createInitialPlayerState('me', false, 0),
+      createInitialPlayerState('ai1', true, 1),
+      createInitialPlayerState('ai2', true, 2),
+      { ...createInitialPlayerState('ai3', true, 3), melds: [sampleMeld] },
+    ];
+    render(
+      <UIBoard
+        players={players}
+        dora={[]}
+        kyoku={1}
+        wallCount={70}
+        kyotaku={0}
+        honba={0}
+        onDiscard={() => {}}
+        isMyTurn={true}
+        shanten={{ standard: 0, chiitoi: 0, kokushi: 0 }}
+        lastDiscard={null}
+      />,
+    );
+    const meld = screen.getByTestId('meld-seat-3');
+    const wrapper = meld.parentElement as HTMLElement;
+    expect(wrapper.className).toContain('bottom-[10px]');
+  });
 });

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -347,6 +347,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
           melds={top.melds}
           seat={top.seat}
           showBorder={showBorders && top.melds.length > 0}
+          dataTestId="meld-seat-2"
         />
       </div>
       <div className="absolute right-0 top-0">
@@ -354,13 +355,15 @@ export const UIBoard: React.FC<UIBoardProps> = ({
           melds={right.melds}
           seat={right.seat}
           showBorder={showBorders && right.melds.length > 0}
+          dataTestId="meld-seat-1"
         />
       </div>
-      <div className="absolute left-0 bottom-0">
+      <div className="absolute left-0 bottom-[10px]">
         <MeldArea
           melds={left.melds}
           seat={left.seat}
           showBorder={showBorders && left.melds.length > 0}
+          dataTestId="meld-seat-3"
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add dataTestId hooks for corner meld areas
- shift kamicha meld area 10px away from bottom edge
- test that the meld area offset works

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b42e90fe4832a92503dffc967c463