### PR TITLE
Fix illegal AI chi calls

### DIFF
--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -358,6 +358,7 @@ export const useGame = (gameLength: GameLength) => {
             const action = chooseAICallOption(
               playersRef.current[0],
               lastDiscard.tile,
+              playersRef.current[lastDiscard.player].seat,
             );
             handleCallAction(action);
           }, 500);
@@ -1212,7 +1213,11 @@ const handleCallAction = (action: MeldType | 'pass') => {
   const handleAITurn = (ai: number) => {
     if (winResultRef.current) return;
     if (lastDiscard && lastDiscard.player !== ai) {
-      const action = chooseAICallOption(playersRef.current[ai], lastDiscard.tile);
+      const action = chooseAICallOption(
+        playersRef.current[ai],
+        lastDiscard.tile,
+        playersRef.current[lastDiscard.player].seat,
+      );
       if (action !== 'pass') {
         performAICall(ai, action);
         return;

--- a/src/utils/ai.test.ts
+++ b/src/utils/ai.test.ts
@@ -7,8 +7,8 @@ import {
   isTenpaiAfterDiscard,
 } from '../components/Player';
 
-function makePlayer(hand: Tile[]): PlayerState {
-  return { ...createInitialPlayerState('ai', true), hand };
+function makePlayer(hand: Tile[], seat = 0): PlayerState {
+  return { ...createInitialPlayerState('ai', true, seat), hand };
 }
 
 describe('chooseAICallOption', () => {
@@ -19,7 +19,7 @@ describe('chooseAICallOption', () => {
       { suit: 'man', rank: 3, id: 'b' },
       { suit: 'man', rank: 3, id: 'c' },
     ];
-    expect(chooseAICallOption(makePlayer(hand), discard)).toBe('kan');
+    expect(chooseAICallOption(makePlayer(hand), discard, 3)).toBe('kan');
   });
 
   it('calls pon when it improves shanten', () => {
@@ -39,7 +39,7 @@ describe('chooseAICallOption', () => {
       { suit: 'man', rank: 9, id: 'l' },
       { suit: 'man', rank: 1, id: 'm' },
     ];
-    expect(chooseAICallOption(makePlayer(hand), discard)).toBe('pon');
+    expect(chooseAICallOption(makePlayer(hand), discard, 3)).toBe('pon');
   });
 
   it('calls chi when it improves shanten', () => {
@@ -59,7 +59,16 @@ describe('chooseAICallOption', () => {
       { suit: 'pin', rank: 9, id: 'l' },
       { suit: 'pin', rank: 9, id: 'm' },
     ];
-    expect(chooseAICallOption(makePlayer(hand), discard)).toBe('chi');
+    expect(chooseAICallOption(makePlayer(hand), discard, 3)).toBe('chi');
+  });
+
+  it('does not chi when caller is not left of discarder', () => {
+    const discard: Tile = { suit: 'pin', rank: 2, id: 'x' };
+    const hand: Tile[] = [
+      { suit: 'pin', rank: 1, id: 'f' },
+      { suit: 'pin', rank: 3, id: 'i' },
+    ];
+    expect(chooseAICallOption(makePlayer(hand, 1), discard, 3)).toBe('pass');
   });
 
   it('passes when call does not improve shanten', () => {
@@ -79,7 +88,7 @@ describe('chooseAICallOption', () => {
       { suit: 'sou', rank: 5, id: 'm' },
       { suit: 'sou', rank: 7, id: 'n' },
     ];
-    expect(chooseAICallOption(makePlayer(hand), discard)).toBe('pass');
+    expect(chooseAICallOption(makePlayer(hand), discard, 3)).toBe('pass');
   });
 
   it('passes when no meld available', () => {
@@ -88,7 +97,7 @@ describe('chooseAICallOption', () => {
       { suit: 'man', rank: 1, id: 'a' },
       { suit: 'pin', rank: 2, id: 'b' },
     ];
-    expect(chooseAICallOption(makePlayer(hand), discard)).toBe('pass');
+    expect(chooseAICallOption(makePlayer(hand), discard, 3)).toBe('pass');
   });
 });
 

--- a/src/utils/ai.ts
+++ b/src/utils/ai.ts
@@ -1,5 +1,6 @@
 import { PlayerState, Tile, MeldType } from '../types/mahjong';
 import { getValidCallOptions, selectMeldTiles } from './meld';
+import { isLeftOf } from './table';
 import { calcShanten } from './shanten';
 import { canDiscardTile } from '../components/Player';
 
@@ -11,11 +12,15 @@ import { canDiscardTile } from '../components/Player';
 export function chooseAICallOption(
   player: PlayerState,
   tile: Tile,
+  discarderSeat: number,
 ): MeldType | 'pass' {
   const options = getValidCallOptions(player, tile).filter(
     o => o !== 'pass',
   ) as MeldType[];
-  if (options.includes('kan')) return 'kan';
+  const filtered = isLeftOf(player.seat, discarderSeat)
+    ? options
+    : options.filter(o => o !== 'chi');
+  if (filtered.includes('kan')) return 'kan';
 
   const base = calcShanten(player.hand, player.melds.length);
   const baseValue = Math.min(base.standard, base.chiitoi, base.kokushi);
@@ -23,7 +28,7 @@ export function chooseAICallOption(
   let best: MeldType | null = null;
   let bestValue = baseValue;
 
-  for (const action of options) {
+  for (const action of filtered) {
     if (action === 'kan') continue;
     const tiles = selectMeldTiles(player, tile, action);
     if (!tiles) continue;


### PR DESCRIPTION
## Summary
- prevent AI from calling chi on a discard from the wrong seat
- update AI tests to cover seat restrictions

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b45103ea8832aa1a87f3286672685