### PR TITLE
Fix AI dealer discard when starting new round

### DIFF
--- a/src/game/startRoundAI.test.ts
+++ b/src/game/startRoundAI.test.ts
@@ -17,4 +17,32 @@ describe('startRound with AI dealer', () => {
     expect(result.current.players[1].discard.length).toBeGreaterThan(0);
     vi.useRealTimers();
   });
+
+  it('clears stale winResult before starting next round', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useGame('tonpu'));
+    act(() => {
+      result.current.setWinResult({
+        players: result.current.players,
+        winner: 0,
+        winType: 'tsumo',
+        hand: [],
+        melds: [],
+        winTile: result.current.players[0].hand[0],
+        yaku: [],
+        han: 0,
+        fu: 0,
+        points: 0,
+        dora: [],
+        uraDora: [],
+      });
+      result.current.setWinResult(null);
+      result.current.nextKyoku(false);
+    });
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(result.current.players[1].discard.length).toBeGreaterThan(0);
+    vi.useRealTimers();
+  });
 });

--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -494,6 +494,7 @@ export const useGame = (gameLength: GameLength) => {
     setRonCandidate(null);
     setRoundResult(null);
     setWinResult(null);
+    winResultRef.current = null;
     if (resetKyoku) {
       setRiichiPool(0);
       setHonba(0);


### PR DESCRIPTION
## Summary
- clear `winResultRef` when starting a new round
- test AI discard after clearing win result

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c5a472f4c832a860c7fa1e5726265