### PR TITLE
Fix overlapping meld area

### DIFF
--- a/src/components/UIBoard.test.tsx
+++ b/src/components/UIBoard.test.tsx
@@ -812,6 +812,6 @@ describe('UIBoard meld area placement', () => {
     );
     const meld = screen.getByTestId('meld-seat-3');
     const wrapper = meld.parentElement as HTMLElement;
-    expect(wrapper.className).toContain('bottom-[10px]');
+    expect(wrapper.className).toContain('bottom-[calc(var(--tile-font-size)*4)]');
   });
 });

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -358,7 +358,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
           dataTestId="meld-seat-1"
         />
       </div>
-      <div className="absolute left-0 bottom-[10px]">
+      <div className="absolute left-0 bottom-[calc(var(--tile-font-size)*4)]">
         <MeldArea
           melds={left.melds}
           seat={left.seat}


### PR DESCRIPTION
## Summary
- move kamicha meld area higher to avoid covering player's hand
- update corresponding test

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687caef62e0c832a8c6996e49fb7166f