### PR TITLE
Update favicon to 發

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAA4UlEQVR4nO2WMQ6CQBBFP8TE0CCh4hQW2BIrCZ7Aypt4LSz2DDYQKwoq6y1sTci3mIqgyW4woXB+NfNnd+ZlttmAJLGgwiWHK4ACKIACKIAC+AFEEXA6jb3zWfxPSpIfA6zXQNcBwyA5CfS9+DPk9wR5DtxuEjcNsN3OGu4PUFWAMRIbI/lc0VWbDWktWRSSlyX5fIr/7byD/DaQpkAYAo+H5HE8ru/33gtYed84HoHLBTgcpjVrBe71ArLMrZ/XE5Bk25JBQN7v01XXNZnn5G5HXq9ObQNSf8UKoAAK8OcAb/lpDxRArCMIAAAAAElFTkSuQmCC" />
+    <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAp0lEQVR4nO3WsQkCQRCF4X/kDKxBbOO4yA40sgHLuGjZTgzMRRMtQWxDBFsQhGfgNeAsuIKzMLDJvvkYGFiTRM0zqto9AAEIQAACEIBfADTeh5ZNwB54AmNgqST7NKdkAhfgqKQVcADOnpASwBV4WLYOuA31VQDAFuiVdPIGlALWwMayLWoAZsBESbvhPvWEuLcAaIG7ZZvz3oLOE2LxKw5AAALw94AXsjgiM/IUc7gAAAAASUVORK5CYII=" />
     <link rel="stylesheet" href="/fonts/emoji.css" />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Poppins:wght@600&display=swap"


### PR DESCRIPTION
## Summary
- embed new base64-encoded favicon representing the kanji 発

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687cae93abb4832aa6269417e6107fbe