### PR TITLE
Enlarge 發 on favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAp0lEQVR4nO3WsQkCQRCF4X/kDKxBbOO4yA40sgHLuGjZTgzMRRMtQWxDBFsQhGfgNeAsuIKzMLDJvvkYGFiTRM0zqto9AAEIQAACEIBfADTeh5ZNwB54AmNgqST7NKdkAhfgqKQVcADOnpASwBV4WLYOuA31VQDAFuiVdPIGlALWwMayLWoAZsBESbvhPvWEuLcAaIG7ZZvz3oLOE2LxKw5AAALw94AXsjgiM/IUc7gAAAAASUVORK5CYII=" />
+    <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAU0lEQVR4nO3XwQkAIRBDUb9YzHZhA1uuBdjZbAsKyrDwcw7kXUNElMzU1HUBvwEAA5iL3QcI4D0GuBkBAgQIECBAgAAB6YC20e3A8RuF10xANuAD37wKcpUqiuIAAAAASUVORK5CYII=" />
     <link rel="stylesheet" href="/fonts/emoji.css" />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Poppins:wght@600&display=swap"


### PR DESCRIPTION
## Summary
- update favicon Base64 PNG so the kanji 發 fills the icon

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687dad3d8fa4832aa2502fb5945d4cb5