### PR TITLE
Update red five defaults and reload behavior

### DIFF
--- a/src/App.redAka.test.tsx
+++ b/src/App.redAka.test.tsx
@@ -1,0 +1,20 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import App from './App';
+
+describe('red five count setting', () => {
+  it('defaults to 1 and reloads when changed', async () => {
+    render(<App />);
+    await screen.findAllByText('手牌');
+    const select = screen.getByLabelText('赤5枚数') as HTMLSelectElement;
+    expect(select.value).toBe('1');
+    const watch = screen.getByLabelText('観戦モード') as HTMLInputElement;
+    fireEvent.click(watch);
+    expect(watch.checked).toBe(true);
+    fireEvent.change(select, { target: { value: '2' } });
+    const newWatch = screen.getByLabelText('観戦モード') as HTMLInputElement;
+    expect(newWatch.checked).toBe(false);
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ function App() {
   const [gameLength, setGameLength] = useState<'east1' | 'tonpu' | 'tonnan'>(
     'east1',
   );
-  const [redAka, setRedAka] = useState(0);
+  const [redAka, setRedAka] = useState(1);
   const [helpOpen, setHelpOpen] = useState(false);
   const [toolsOpen, setToolsOpen] = useState(false);
   const [dark, setDark] = useState(false);
@@ -134,7 +134,7 @@ function App() {
       </div>
       {mode === 'game' ? (
         <GameController
-          key={gameLength}
+          key={`${gameLength}-${redAka}`}
           gameLength={gameLength}
           red={redAka}
           showBorders={showBorders}

--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -273,7 +273,7 @@ const boardPresets: Record<string, BoardData> = (() => {
   return { basic, multiCalls, kanVariants, longRiver, allFuro };
 })();
 
-export const useGame = (gameLength: GameLength, red = 0) => {
+export const useGame = (gameLength: GameLength, red = 1) => {
   // ゲーム状態
   const [wall, setWall] = useState<Tile[]>([]);
   const [players, setPlayers] = useState<PlayerState[]>([]);


### PR DESCRIPTION
## Summary
- default red fives to one
- reload `GameController` when red count changes
- expose test verifying new behavior

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_687db25b0ae8832a93bb12426ad37133