### PR TITLE
Fix child tsumo double payment

### DIFF
--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -23,7 +23,7 @@ import {
 } from '../utils/meld';
 import { filterChiOptions } from '../utils/table';
 import { isWinningHand, detectYaku } from '../score/yaku';
-import { calculateScore } from '../score/score';
+import { calculateScore, calcRoundedScore } from '../score/score';
 import { calcShanten } from '../utils/shanten';
 import { incrementDiscardCount, findRonWinner } from '../components/DiscardUtil';
 import { chooseAICallOption, chooseAIDiscardTile } from '../utils/ai';
@@ -997,14 +997,25 @@ const handleCallAction = (action: MeldType | 'pass') => {
       if (idx === 0) setMessage('役なし');
       return;
     }
-    const { han, fu, points } = calculateScore(
+    const { han, fu } = calculateScore(
       p[idx].hand,
       p[idx].melds,
       yaku,
       dora,
       { seatWind, roundWind, winType: 'tsumo' },
     );
-    let newPlayers = payoutTsumo(p, idx, points, honbaRef.current).map((pl, i) =>
+    const points = calcRoundedScore(han, fu, seatWind === 1, 'tsumo');
+    const childPts = calcRoundedScore(han, fu, false, 'tsumo');
+    const dealerPts = calcRoundedScore(han, fu, true, 'tsumo');
+    const dealerIdx = p.findIndex(pl => pl.seat === 0);
+    let newPlayers = payoutTsumo(
+      p,
+      idx,
+      childPts,
+      dealerPts,
+      dealerIdx,
+      honbaRef.current,
+    ).map((pl, i) =>
       i === idx ? { ...pl, ippatsu: false } : pl,
     );
     if (riichiPoolRef.current > 0) {

--- a/src/utils/payout.test.ts
+++ b/src/utils/payout.test.ts
@@ -4,30 +4,32 @@ import { createInitialPlayerState } from '../components/Player';
 
 function setupPlayers() {
   return [
-    createInitialPlayerState('p1', false),
-    createInitialPlayerState('p2', false),
-    createInitialPlayerState('p3', false),
-    createInitialPlayerState('p4', false),
+    createInitialPlayerState('p1', false, 0),
+    createInitialPlayerState('p2', false, 1),
+    createInitialPlayerState('p3', false, 2),
+    createInitialPlayerState('p4', false, 3),
   ];
 }
 
 describe('payoutTsumo', () => {
   it('adjusts scores for a tsumo win', () => {
     const players = setupPlayers();
-    const updated = payoutTsumo(players, 0, 1000);
-    expect(updated[0].score).toBe(players[0].score + 3000);
-    for (let i = 1; i < 4; i++) {
+    const updated = payoutTsumo(players, 0, 1000, 2000, 1);
+    // 子ツモ時は親が2倍支払いになるため合計4000点受け取るはず
+    expect(updated[0].score).toBe(players[0].score + 4000);
+    expect(updated[1].score).toBe(players[1].score - 2000);
+    for (let i = 2; i < 4; i++) {
       expect(updated[i].score).toBe(players[i].score - 1000);
     }
   });
 
   it('includes honba bonus for tsumo', () => {
     const players = setupPlayers();
-    const updated = payoutTsumo(players, 0, 1000, 2);
-    // 今の実装だと2本場でツモした場合、各家が1000点+200点支払いとなるため
-    // 合計3600点受け取りになるはず
-    expect(updated[0].score).toBe(players[0].score + 3600);
-    for (let i = 1; i < 4; i++) {
+    const updated = payoutTsumo(players, 0, 1000, 2000, 1, 2);
+    // 2本場なら親は2200点、子は1200点支払いで計4600点受け取り
+    expect(updated[0].score).toBe(players[0].score + 4600);
+    expect(updated[1].score).toBe(players[1].score - 2200);
+    for (let i = 2; i < 4; i++) {
       expect(updated[i].score).toBe(players[i].score - 1200);
     }
   });

--- a/src/utils/payout.ts
+++ b/src/utils/payout.ts
@@ -3,18 +3,21 @@ import { PlayerState } from '../types/mahjong';
 export function payoutTsumo(
   players: PlayerState[],
   winner: number,
-  points: number,
+  childPoints: number,
+  dealerPoints: number,
+  dealer: number,
   honba = 0,
 ): PlayerState[] {
   const bonusEach = honba * 100;
+  const payments = players.map((_, idx) => {
+    if (idx === winner) return 0;
+    const base = idx === dealer ? dealerPoints : childPoints;
+    return base + bonusEach;
+  });
+  const gain = payments.reduce((sum, p) => sum + p, 0);
   return players.map((p, idx) => {
-    if (idx === winner) {
-      return {
-        ...p,
-        score: p.score + points * (players.length - 1) + honba * 300,
-      };
-    }
-    return { ...p, score: p.score - (points + bonusEach) };
+    if (idx === winner) return { ...p, score: p.score + gain };
+    return { ...p, score: p.score - payments[idx] };
   });
 }
 


### PR DESCRIPTION
## Summary
- adjust payoutTsumo to handle dealer paying double
- update Game store to use new payout logic
- revise tests to cover dealer double payment

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_687dca0c5718832a84e9845997f657ea