### PR TITLE
Fix Tenhou log honba/kyotaku

### DIFF
--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -336,6 +336,8 @@ export const useGame = (gameLength: GameLength, red = 1) => {
       endInfoRef.current,
       dora,
       red,
+      honbaRef.current,
+      riichiPoolRef.current,
     );
     return tenhouJsonToUrl(data);
   };
@@ -1329,6 +1331,8 @@ const handleCallAction = (action: MeldType | 'pass') => {
       endInfoRef.current,
       dora,
       red,
+      honbaRef.current,
+      riichiPoolRef.current,
     );
     const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
@@ -1348,6 +1352,8 @@ const handleCallAction = (action: MeldType | 'pass') => {
       endInfoRef.current,
       dora,
       red,
+      honbaRef.current,
+      riichiPoolRef.current,
     );
     await navigator.clipboard.writeText(JSON.stringify(data, null, 2));
     setMessage('Tenhouログをコピーしました');

--- a/src/utils/tenhouExport.test.ts
+++ b/src/utils/tenhouExport.test.ts
@@ -452,6 +452,25 @@ describe('exportTenhouLog', () => {
       tileToTenhouNumber(kanDora),
     ]);
     writeFileSync('tmp.tenhou.json', JSON.stringify(json));
+  execSync('python devutils/tenhou-validator.py tmp.tenhou.json');
+  });
+
+  it('records honba and kyotaku counts', () => {
+    const t = makeTile(1);
+    const start: RoundStartInfo = {
+      hands: Array(4)
+        .fill(0)
+        .map(() => Array(13).fill(t)),
+      dealer: 0,
+      doraIndicator: t,
+      kyoku: 1,
+    };
+    const log: LogEntry[] = [{ type: 'startRound', kyoku: 1 }];
+    const end: RoundEndInfo = { result: '流局', diffs: [0, 0, 0, 0] };
+    const scores = [25000, 25000, 25000, 25000];
+    const json = exportTenhouLog(start, log, scores, end, [t], 0, 2, 1);
+    expect(json.log[0][0]).toEqual([0, 2, 1]);
+    writeFileSync('tmp.tenhou.json', JSON.stringify(json));
     execSync('python devutils/tenhou-validator.py tmp.tenhou.json');
   });
 

--- a/src/utils/tenhouExport.ts
+++ b/src/utils/tenhouExport.ts
@@ -104,6 +104,8 @@ export function exportTenhouLog(
   end: RoundEndInfo,
   doraIndicators: Tile[] = [round.doraIndicator],
   aka: number = 0,
+  honba: number = 0,
+  kyotaku: number = 0,
 ) {
   const hai = round.hands.map(h => h.map(tileToTenhouNumber));
   // Dealer has 14 tiles in RoundStartInfo; Tenhou format expects 13.
@@ -205,7 +207,7 @@ export function exportTenhouLog(
   const kyokuNum = round.kyoku - 1;
 
   const hand: any[] = [
-    [kyokuNum, 0, 0],
+    [kyokuNum, honba, kyotaku],
     startScores,
     dora,
     ura,


### PR DESCRIPTION
## Summary
- include honba and kyotaku counts in Tenhou JSON export
- pass values from store when generating logs
- test honba and kyotaku output

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_687dd17044dc832a8e3ba0290279eee2