### PR TITLE
Fix kan tile counting in win check

### DIFF
--- a/src/game/store.test.ts
+++ b/src/game/store.test.ts
@@ -2,6 +2,8 @@
 import { describe, it, expect } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useGame } from './store';
+import type { Tile, MeldType } from '../types/mahjong';
+import { isWinningHand } from '../score/yaku';
 
 describe('game store', () => {
   it('advances kyoku with nextKyoku', () => {
@@ -59,5 +61,28 @@ describe('game store', () => {
       result.current.nextKyoku(true);
     });
     expect(result.current.players.map(p => p.name)).toEqual(before);
+  });
+
+  it('isWinningHand succeeds when kan melds are counted as three tiles', () => {
+    const t = (suit: Tile['suit'], rank: number, id: string): Tile => ({ suit, rank, id });
+    const kan = {
+      type: 'kan' as MeldType,
+      tiles: [t('man', 1, 'k1'), t('man', 1, 'k2'), t('man', 1, 'k3'), t('man', 1, 'k4')],
+      fromPlayer: 0,
+      calledTileId: 'k1',
+      kanType: 'ankan',
+    };
+    const hand = [
+      t('man', 2, 'm2a'), t('man', 2, 'm2b'), t('man', 2, 'm2c'),
+      t('man', 3, 'm3a'), t('man', 3, 'm3b'), t('man', 3, 'm3c'),
+      t('man', 4, 'm4a'), t('man', 4, 'm4b'), t('man', 4, 'm4c'),
+      t('man', 5, 'm5a'), t('man', 5, 'm5b'),
+    ];
+    const fullHand = [
+      ...hand,
+      ...kan.tiles.slice(0, 3),
+    ];
+    expect(fullHand).toHaveLength(14);
+    expect(isWinningHand(fullHand)).toBe(true);
   });
 });

--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -642,7 +642,12 @@ export const useGame = (gameLength: GameLength, red = 1) => {
       performSelfKan(currentIndex, kanOpts[0]);
       return;
     }
-    const fullHand = [...p[currentIndex].hand, ...p[currentIndex].melds.flatMap(m => m.tiles)];
+    const fullHand = [
+      ...p[currentIndex].hand,
+      ...p[currentIndex].melds.flatMap(m =>
+        m.type === 'kan' ? m.tiles.slice(0, 3) : m.tiles,
+      ),
+    ];
     if (isWinningHand(fullHand)) {
       const seatWind = p[currentIndex].seat + 1;
       const roundWind = kyokuRef.current <= 4 ? 1 : 2;


### PR DESCRIPTION
## Summary
- ignore the fourth tile of a kan when assembling a hand in `drawForCurrentPlayer`
- test winning hand calculation with a kan meld

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687de2afa9c0832abaf91511bf35ca44