### PR TITLE
Fix dealer tsumo payout

### DIFF
--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -1012,7 +1012,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
       { seatWind, roundWind, winType: 'tsumo' },
     );
     const points = calcRoundedScore(han, fu, seatWind === 1, 'tsumo');
-    const childPts = calcRoundedScore(han, fu, false, 'tsumo');
+    const childPts = calcRoundedScore(han, fu, seatWind === 1, 'tsumo');
     const dealerPts = calcRoundedScore(han, fu, true, 'tsumo');
     const dealerIdx = p.findIndex(pl => pl.seat === 0);
     let newPlayers = payoutTsumo(

--- a/src/utils/payout.test.ts
+++ b/src/utils/payout.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { payoutTsumo, payoutRon, payoutNoten } from './payout';
+import { calcRoundedScore } from '../score/score';
 import { createInitialPlayerState } from '../components/Player';
 
 function setupPlayers() {
@@ -31,6 +32,21 @@ describe('payoutTsumo', () => {
     expect(updated[1].score).toBe(players[1].score - 2200);
     for (let i = 2; i < 4; i++) {
       expect(updated[i].score).toBe(players[i].score - 1200);
+    }
+  });
+
+  it('handles dealer tsumo payouts correctly', () => {
+    const players = setupPlayers();
+    const han = 3;
+    const fu = 60;
+    // 基本点 60 * 2^(3 + 2) = 1920 で、親ツモは2倍支払いなので
+    // 各子から 1920 * 2 = 3840 を100点単位に切り上げて3900点ずつ受け取る
+    const childPts = calcRoundedScore(han, fu, true, 'tsumo');
+    const updated = payoutTsumo(players, 0, childPts, childPts, 0);
+    expect(childPts).toBe(3900);
+    expect(updated[0].score).toBe(players[0].score + 3 * childPts);
+    for (let i = 1; i < 4; i++) {
+      expect(updated[i].score).toBe(players[i].score - childPts);
     }
   });
 });


### PR DESCRIPTION
## Summary
- correct child payment calculation when dealer wins by tsumo
- test dealer tsumo payout amounts

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687df11cbb90832a82499eae19e3af7e