### PR TITLE
Fix claimMeld drawnTile handling

### DIFF
--- a/src/components/DiscardUtil.test.ts
+++ b/src/components/DiscardUtil.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { findRonWinner } from './DiscardUtil';
-import { Tile } from '../types/mahjong';
-import { createInitialPlayerState } from './Player';
+import { Tile, PlayerState } from '../types/mahjong';
+import { createInitialPlayerState, claimMeld, discardTile } from './Player';
 
 const t = (suit: Tile['suit'], rank: number, id: string): Tile => ({ suit, rank, id });
 
@@ -181,6 +181,29 @@ describe('findRonWinner', () => {
     };
     const players = [p1, p2];
     const idx = findRonWinner(players, 0, discard, 1);
+    expect(idx).toBe(1);
+  });
+
+  it('identifies ron after a melded player discards', () => {
+    const callTile = t('man', 1, 'mc');
+    let caller: PlayerState = {
+      ...createInitialPlayerState('caller', false),
+      hand: [t('man', 1, 'ma'), t('man', 1, 'mb'), winningTile],
+    };
+    caller = claimMeld(
+      caller,
+      [t('man', 1, 'ma'), t('man', 1, 'mb'), callTile],
+      'pon',
+      0,
+      callTile.id,
+    );
+    caller = discardTile(caller, winningTile.id);
+    const winner = {
+      ...createInitialPlayerState('winner', false, 1),
+      hand: winningBase,
+    };
+    const players = [caller, winner];
+    const idx = findRonWinner(players, 0, caller.discard[0], 1);
     expect(idx).toBe(1);
   });
 });

--- a/src/components/Player.test.ts
+++ b/src/components/Player.test.ts
@@ -229,6 +229,28 @@ describe('claimMeld', () => {
     expect(fromOpposite.melds[0].tiles[3].id).toBe('a');
     expect(fromLeft.melds[0].tiles[3].id).toBe('a');
   });
+
+  it('clears drawnTile when calling a meld', () => {
+    const t = (suit: Tile['suit'], rank: number, id: string): Tile => ({
+      suit,
+      rank,
+      id,
+    });
+    const hand: Tile[] = [t('man', 1, 'a'), t('man', 1, 'b'), t('pin', 5, 'p')];
+    const player: PlayerState = {
+      ...createInitialPlayerState('Bob', false),
+      hand,
+      drawnTile: hand[0],
+    };
+    const updated = claimMeld(
+      player,
+      [t('man', 1, 'a'), t('man', 1, 'b'), t('man', 1, 'c')],
+      'pon' as MeldType,
+      1,
+      'c',
+    );
+    expect(updated.drawnTile).toBeNull();
+  });
 });
 
 describe('incrementDiscardCount', () => {

--- a/src/components/Player.ts
+++ b/src/components/Player.ts
@@ -145,6 +145,7 @@ export function claimMeld(
       ...player.melds,
       { type, tiles: meldTiles, fromPlayer, calledTileId, kanType },
     ],
+    drawnTile: null,
   };
 }
 


### PR DESCRIPTION
## Summary
- reset `drawnTile` when calling a meld
- test `claimMeld` to ensure the drawn tile clears
- test `findRonWinner` with discard after a meld call

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6880d95e61d4832a87ebaf35e0523d34