### PR TITLE
Fix pinfu detection for tanki wait

### DIFF
--- a/src/components/DiscardUtil.ts
+++ b/src/components/DiscardUtil.ts
@@ -33,6 +33,7 @@ export function findRonWinner(
           isRiichi: players[i].isRiichi,
           doubleRiichi: players[i].doubleRiichi,
           ippatsu: players[i].ippatsu,
+          winTile: tile,
         },
       );
       const hasBaseYaku = yaku.some(y => y.name !== 'Ura Dora');

--- a/src/components/ScoreQuiz.test.tsx
+++ b/src/components/ScoreQuiz.test.tsx
@@ -4,8 +4,8 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { ScoreQuiz } from './ScoreQuiz';
 
-// SAMPLE_HANDS[0] を親でロン和了すると 4翻30符で
-// 基本点1920 ×6 = 11520 -> 11600点になる
+// SAMPLE_HANDS[0] を親でロン和了すると 3翻30符で
+// 基本点960 ×6 = 5760 -> 5800点になる
 
 afterEach(() => cleanup());
 
@@ -13,7 +13,7 @@ describe('ScoreQuiz', () => {
   it('shows "正解！" when the guess is correct', () => {
     render(<ScoreQuiz initialIndex={0} initialWinType="ron" initialSeatWind={1} />);
     const input = screen.getByPlaceholderText('点数を入力');
-    fireEvent.change(input, { target: { value: '11600' } });
+    fireEvent.change(input, { target: { value: '5800' } });
     const button = screen.getByText('答える');
     fireEvent.click(button);
     expect(screen.getByText('正解！')).toBeTruthy();
@@ -27,7 +27,7 @@ describe('ScoreQuiz', () => {
     fireEvent.change(input, { target: { value: '1000' } });
     const button = screen.getByText('答える');
     fireEvent.click(button);
-    expect(screen.getByText('不正解。正解: 11600 (4翻 30符)')).toBeTruthy();
+    expect(screen.getByText('不正解。正解: 5800 (3翻 30符)')).toBeTruthy();
     expect(screen.getByText('Tanyao (1翻)')).toBeTruthy();
     expect(screen.getByText('基本符20')).toBeTruthy();
   });
@@ -42,7 +42,7 @@ describe('ScoreQuiz', () => {
     const childInput = screen.getByPlaceholderText('子の支払い');
     const parentInput = screen.getByPlaceholderText('親の支払い');
     fireEvent.change(childInput, { target: { value: '2000' } });
-    fireEvent.change(parentInput, { target: { value: '4000' } });
+    fireEvent.change(parentInput, { target: { value: '3900' } });
     fireEvent.click(screen.getByText('答える'));
     expect(screen.getByText('正解！')).toBeTruthy();
   });

--- a/src/components/ScoreQuiz.tsx
+++ b/src/components/ScoreQuiz.tsx
@@ -41,6 +41,7 @@ export const ScoreQuiz: React.FC<ScoreQuizProps> = ({ initialIndex, initialWinTy
       isTsumo: winType === 'tsumo',
       seatWind,
       roundWind,
+      winTile: question.winningTile,
     });
     const { han, fu } = calculateScore(
       question.hand,
@@ -51,6 +52,7 @@ export const ScoreQuiz: React.FC<ScoreQuizProps> = ({ initialIndex, initialWinTy
         seatWind,
         roundWind,
         winType,
+        winTile: question.winningTile,
       },
     );
     const base = calcBase(han, fu);

--- a/src/components/UIBoard.tsx
+++ b/src/components/UIBoard.tsx
@@ -249,6 +249,7 @@ export const UIBoard: React.FC<UIBoardProps> = ({
                   isTsumo: true,
                   seatWind,
                   roundWind,
+                  winTile: me.drawnTile!,
                 }).length > 0;
               return hasYaku ? <>和了可能</> : <>役なし</>;
             }

--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -670,6 +670,7 @@ export const useGame = (gameLength: GameLength, red = 1) => {
         isTsumo: true,
         seatWind,
         roundWind,
+        winTile: p[currentIndex].drawnTile!,
       });
       const hasBaseYaku = yaku.some(y => y.name !== 'Ura Dora');
       if (hasBaseYaku) {
@@ -1013,6 +1014,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
       seatWind,
       roundWind,
       uraDoraIndicators: ura,
+      winTile: p[idx].drawnTile!,
     });
     const baseYaku = yaku.filter(y => y.name !== 'Ura Dora');
     if (baseYaku.length === 0) {
@@ -1024,7 +1026,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
       p[idx].melds,
       yaku,
       dora,
-      { seatWind, roundWind, winType: 'tsumo' },
+      { seatWind, roundWind, winType: 'tsumo', winTile: p[idx].drawnTile! },
     );
     const points = calcRoundedScore(han, fu, seatWind === 1, 'tsumo');
     const childPts = calcRoundedScore(han, fu, seatWind === 1, 'tsumo');
@@ -1108,6 +1110,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
       seatWind,
       roundWind,
       uraDoraIndicators: ura,
+      winTile: tile,
     });
     const baseYaku = yaku.filter(y => y.name !== 'Ura Dora');
     if (baseYaku.length === 0) {
@@ -1119,7 +1122,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
       p[winner].melds,
       yaku,
       dora,
-      { seatWind, roundWind, winType: 'ron' },
+      { seatWind, roundWind, winType: 'ron', winTile: tile },
     );
     let updated = payoutRon(p, winner, from, points, honbaRef.current).map((pl, i) =>
       i === winner ? { ...pl, ippatsu: false } : pl,

--- a/src/score/score.ts
+++ b/src/score/score.ts
@@ -97,12 +97,13 @@ function decomposeHand(tiles: Tile[]): { pair: Tile[]; melds: ParsedMeld[] } | n
 export function calculateFu(
   hand: Tile[],
   melds: Meld[] = [],
-  opts?: { seatWind?: number; roundWind?: number; winType?: 'ron' | 'tsumo' },
+  opts?: { seatWind?: number; roundWind?: number; winType?: 'ron' | 'tsumo'; winTile?: Tile },
 ): number {
   const allTiles = [...hand, ...melds.flatMap(m => m.tiles)];
   const yaku = detectYaku(hand, melds, {
     seatWind: opts?.seatWind,
     roundWind: opts?.roundWind,
+    winTile: opts?.winTile,
   });
   if (yaku.some(y => y.name === 'Chiitoitsu')) {
     return 25; // 七対子は固定25符
@@ -205,7 +206,7 @@ export function calculateScore(
   melds: Meld[],
   yaku: ScoreYaku[],
   doraIndicators: Tile[] = [],
-  opts?: { seatWind?: number; roundWind?: number; winType?: 'ron' | 'tsumo' },
+  opts?: { seatWind?: number; roundWind?: number; winType?: 'ron' | 'tsumo'; winTile?: Tile },
 ): { han: number; fu: number; points: number } {
   const allTiles = [...hand, ...melds.flatMap(m => m.tiles)];
   const dora = countDora(allTiles, doraIndicators);

--- a/src/score/yaku.test.ts
+++ b/src/score/yaku.test.ts
@@ -123,6 +123,19 @@ describe('Yaku detection', () => {
     expect(yaku.some(y => y.name === 'Pinfu')).toBe(true);
   });
 
+  it('does not count Pinfu on tanki wait', () => {
+    // 456678m 1234p 567s +4p tanki
+    const hand: Tile[] = [
+      t('man',4,'m4'),t('man',5,'m5'),t('man',6,'m6a'),
+      t('man',6,'m6b'),t('man',7,'m7'),t('man',8,'m8'),
+      t('pin',1,'p1'),t('pin',2,'p2'),t('pin',3,'p3'),
+      t('pin',4,'p4a'),t('pin',4,'p4b'),
+      t('sou',5,'s5'),t('sou',6,'s6'),t('sou',7,'s7'),
+    ];
+    const yaku = detectYaku(hand, [], { winTile: hand[10] });
+    expect(yaku.some(y => y.name === 'Pinfu')).toBe(false);
+  });
+
   it('detects Iipeiko', () => {
     const hand: Tile[] = [
       t('man',2,'m2a'),t('man',3,'m3a'),t('man',4,'m4a'),

--- a/src/score/yaku.ts
+++ b/src/score/yaku.ts
@@ -217,12 +217,16 @@ function decomposeHand(tiles: Tile[]): { pair: Tile[]; melds: ParsedMeld[] } | n
   return null;
 }
 
-function isPinfuHand(tiles: Tile[]): boolean {
+function isPinfuHand(tiles: Tile[], winTile?: Tile): boolean {
   const parsed = decomposeHand(tiles);
   if (!parsed) return false;
   if (parsed.melds.some(m => m.type !== 'chi')) return false;
   const pairSuit = parsed.pair[0].suit;
   if (pairSuit === 'dragon' || pairSuit === 'wind') return false;
+  if (winTile && tileKey(winTile) === tileKey(parsed.pair[0])) {
+    // tanki wait is not allowed for pinfu
+    return false;
+  }
   return true;
 }
 
@@ -525,6 +529,7 @@ export function detectYaku(
     chiihou?: boolean;
     renhou?: boolean;
     uraDoraIndicators?: Tile[];
+    winTile?: Tile;
   },
 ): ScoreYaku[] {
   const allTiles = [...concealed, ...melds.flatMap(m => m.tiles)];
@@ -587,7 +592,7 @@ export function detectYaku(
   } else if (parsed && isChanta(parsed)) {
     result.push({ name: 'Chanta', han: isClosed ? 2 : 1 });
   }
-  if (isClosed && isPinfuHand(allTiles)) {
+  if (isClosed && isPinfuHand(allTiles, opts?.winTile)) {
     result.push({ name: 'Pinfu', han: 1 });
   }
   if (isClosed && isIipeikoHand(allTiles)) {


### PR DESCRIPTION
## Summary
- handle tanki wait in `isPinfuHand`
- pass winning tile through scoring helpers
- adjust score calculation & tests for new logic

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688aa4089fb0832abcf811e76d85b483