### PR TITLE
Fix Yakuhai name in Tenhou export

### DIFF
--- a/docs/tenhou-json.md
+++ b/docs/tenhou-json.md
@@ -88,8 +88,8 @@ the limit name (`満貫`, `跳満`, `倍満`, `三倍満`, `役満`). Example:
 `満貫12000点`.
 
 After the value string, each yaku is listed in the form
-`YAKU_NAME(han飜)`.  For Yakuhai, the specific value tile is used in
-place of `役牌`, e.g. `白(1飜)` or `自風 東(1飜)`.
+`YAKU_NAME(han飜)` (e.g. `立直(1飜)`).  For Yakuhai, Tenhou prefixes
+`役牌` before the tile name, e.g. `役牌 白(1飜)` or `役牌 自風 東(1飜)`.
 
 The result array therefore looks like the following:
 

--- a/src/utils/tenhouExport.test.ts
+++ b/src/utils/tenhouExport.test.ts
@@ -133,7 +133,7 @@ describe('exportTenhouLog', () => {
     const scores = [25000, 25000, 25000, 25000];
     const json = exportTenhouLog(start, log, scores, end);
     const yakuStrings = json.log[0][16][2].slice(4);
-    expect(yakuStrings).toEqual(['白(1飜)']);
+    expect(yakuStrings).toEqual(['役牌 白(1飜)']);
     writeFileSync('tmp.tenhou.json', JSON.stringify(json));
     execSync('python devutils/tenhou-validator.py tmp.tenhou.json');
   });

--- a/src/utils/tenhouExport.ts
+++ b/src/utils/tenhouExport.ts
@@ -237,7 +237,9 @@ export function exportTenhouLog(
     const yaku =
       end.yakuList?.map(y => {
         const name =
-          y.name === 'Yakuhai' && y.detail ? y.detail : toTenhouName(y.name);
+          y.name === 'Yakuhai' && y.detail
+            ? `役牌 ${y.detail}`
+            : toTenhouName(y.name);
         return `${name}(${y.han}飜)`;
       }) ?? [];
     resultArr.push([end.winner, end.loser ?? end.winner, end.winner, pointStr, ...yaku]);


### PR DESCRIPTION
## Summary
- prefix Yakuhai details with `役牌` when exporting Tenhou logs
- document the `役牌` prefix in Tenhou JSON spec
- update tests for new Yakuhai string

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ababb6760832a8e2f4045fac6adfc