### PR TITLE
Fix ryuukyoku handling for last tile

### DIFF
--- a/devutils/tenhou-validator.py
+++ b/devutils/tenhou-validator.py
@@ -10,7 +10,7 @@ class ValidationError(Exception):
 
 # Allowed end reasons
 END_REASONS = {
-    "和了", "流局", "全員不聴", "九種九牌", "四槓散了", "四家立直", "不明"
+    "和了", "流局", "全員聴牌", "全員不聴", "九種九牌", "四槓散了", "四家立直", "不明"
 }
 
 # Tile codes

--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -619,7 +619,10 @@ export const useGame = (gameLength: GameLength, red = 1) => {
     const { players: updated, changes } = payoutNoten(playersRef.current, tenpai);
     setPlayers(updated);
     playersRef.current = updated;
-    endInfoRef.current = { result: '流局', diffs: changes };
+    const allTenpai = tenpai.every(t => t);
+    const allNoten = tenpai.every(t => !t);
+    const resultStr = allTenpai ? '全員聴牌' : allNoten ? '全員不聴' : '流局';
+    endInfoRef.current = { result: resultStr, diffs: changes };
     const results: RoundResult = {
       results: updated.map((p, idx) => ({
         name: p.name,
@@ -630,7 +633,7 @@ export const useGame = (gameLength: GameLength, red = 1) => {
     };
     setRoundResult(results);
     setTenhouUrl(buildTenhouUrl());
-    setMessage('牌山が尽きました。流局です。');
+    setMessage(`牌山が尽きました。${resultStr}です。`);
   };
 
   // ツモ処理
@@ -692,7 +695,8 @@ export const useGame = (gameLength: GameLength, red = 1) => {
       return;
     }
     if (last) {
-      handleWallExhaustion();
+      // Exhaustion is handled after the final discard so that the
+      // river (kawa) contains the last tile.
       return;
     }
 

--- a/src/utils/tenhouExport.test.ts
+++ b/src/utils/tenhouExport.test.ts
@@ -516,6 +516,25 @@ describe('exportTenhouLog', () => {
     const json = exportTenhouLog(start, log, scores, end, [t], 0, 1, 1);
     expect(json.log[0][0]).toEqual([1, 1, 1]);
     writeFileSync('tmp.tenhou.json', JSON.stringify(json));
+  execSync('python devutils/tenhou-validator.py tmp.tenhou.json');
+  });
+
+  it('uses "全員聴牌" when everyone is tenpai', () => {
+    const t = makeTile(1);
+    const start: RoundStartInfo = {
+      hands: Array(4)
+        .fill(0)
+        .map(() => Array(13).fill(t)),
+      dealer: 0,
+      doraIndicator: t,
+      kyoku: 1,
+    };
+    const log: LogEntry[] = [{ type: 'startRound', kyoku: 1 }];
+    const end: RoundEndInfo = { result: '全員聴牌', diffs: [0, 0, 0, 0] };
+    const scores = [25000, 25000, 25000, 25000];
+    const json = exportTenhouLog(start, log, scores, end, [t], 0, 0, 0);
+    expect(json.log[0][16][0]).toBe('全員聴牌');
+    writeFileSync('tmp.tenhou.json', JSON.stringify(json));
     execSync('python devutils/tenhou-validator.py tmp.tenhou.json');
   });
 

--- a/src/utils/tenhouExport.ts
+++ b/src/utils/tenhouExport.ts
@@ -3,7 +3,7 @@ import { calcBase, calcRoundedScore } from '../score/score';
 import { toTenhouName } from './tenhouYakuNames';
 
 export interface RoundEndInfo {
-  result: '和了' | '流局';
+  result: '和了' | '流局' | '全員聴牌' | '全員不聴';
   diffs: number[];
   winner?: number;
   loser?: number;


### PR DESCRIPTION
## Summary
- keep last discard before wall exhaustion
- report `全員聴牌` when everyone is tenpai
- allow validator to accept this string
- test new tenhou log output

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_688abd26e010832aaf1233eee034da6b