### PR TITLE
Guard draws after round resolution

### DIFF
--- a/src/game/store.test.ts
+++ b/src/game/store.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useGame } from './store';
 import type { Tile, MeldType } from '../types/mahjong';
@@ -81,5 +81,22 @@ describe('game store', () => {
       t('man', 5, 'm5a'), t('man', 5, 'm5b'),
     ];
     expect(isWinningHand(hand, [kan])).toBe(true);
+  });
+
+  it('does not log a draw when a win result is present before next turn', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useGame('tonpu'));
+    act(() => {
+      result.current.setWinResult({} as any);
+    });
+    const before = result.current.log.length;
+    act(() => {
+      result.current.nextTurn();
+    });
+    act(() => {
+      vi.runAllTimers();
+    });
+    expect(result.current.log.length).toBe(before);
+    vi.useRealTimers();
   });
 });

--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -638,6 +638,7 @@ export const useGame = (gameLength: GameLength, red = 1) => {
 
   // ツモ処理
   const drawForCurrentPlayer = () => {
+    if (winResultRef.current) return;
     if (wallRef.current.length === 0) {
       handleWallExhaustion();
       return;


### PR DESCRIPTION
## Summary
- avoid logging a draw after a win by exiting `drawForCurrentPlayer` early when a win result exists
- add regression test to ensure no draw log is created when `nextTurn` is called with a pending win

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_6895bfeac460832a83ef807de706fb25