### PR TITLE
fix: halt round after tsumo win

### DIFF
--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -1072,7 +1072,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
     logRef.current = [...logRef.current, { type: 'tsumo', player: idx, tile: p[idx].drawnTile as Tile }];
     setMessage(`${p[idx].name} の和了！`);
     setTsumoOption(false);
-    setWinResult({
+    const result: WinResult = {
       players: newPlayers,
       winner: idx,
       winType: 'tsumo',
@@ -1085,7 +1085,9 @@ const handleCallAction = (action: MeldType | 'pass') => {
       points,
       dora,
       uraDora: ura,
-    });
+    };
+    winResultRef.current = result;
+    setWinResult(result);
     setTenhouUrl(buildTenhouUrl());
   };
 
@@ -1156,7 +1158,7 @@ const handleCallAction = (action: MeldType | 'pass') => {
     setLog(prev => [...prev, { type: 'ron', player: winner, tile, from }]);
     logRef.current = [...logRef.current, { type: 'ron', player: winner, tile, from }];
     setMessage(`${p[winner].name} のロン！`);
-    setWinResult({
+    const result: WinResult = {
       players: updated,
       winner,
       winType: 'ron',
@@ -1169,7 +1171,9 @@ const handleCallAction = (action: MeldType | 'pass') => {
       points,
       dora,
       uraDora: ura,
-    });
+    };
+    winResultRef.current = result;
+    setWinResult(result);
     setTenhouUrl(buildTenhouUrl());
   };
 

--- a/src/game/tsumoEndsRound.test.ts
+++ b/src/game/tsumoEndsRound.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useGame } from './store';
+import { createInitialPlayerState } from '../components/Player';
+import type { Tile } from '../types/mahjong';
+
+// Ensure that a tsumo win halts further draws
+
+describe('tsumo end-of-round handling', () => {
+  it('does not allow further draws after a tsumo', async () => {
+    vi.useFakeTimers();
+    const { result, unmount } = renderHook(() => useGame('tonpu'));
+    let id = 1;
+    const t = (suit: Tile['suit'], rank: number): Tile => ({ suit, rank, id: `t${id++}` });
+    const chi = [t('sou', 2), t('sou', 3), t('sou', 4)];
+    const player = createInitialPlayerState('自分', false, 0);
+    player.hand = [
+      t('man', 2),
+      t('man', 4),
+      t('man', 5),
+      t('man', 5),
+      t('man', 5),
+      t('pin', 4),
+      t('pin', 4),
+    ];
+    player.melds = [{ type: 'chi', tiles: chi, fromPlayer: 1, calledTileId: chi[0].id }];
+
+    const drawTile = t('man', 3);
+    const extraDraw = t('pin', 1); // would be drawn by next player if round continued
+    const board = {
+      players: [
+        player,
+        createInitialPlayerState('ai1', true, 1),
+        createInitialPlayerState('ai2', true, 2),
+        createInitialPlayerState('ai3', true, 3),
+      ],
+      wall: [drawTile, extraDraw],
+      deadWall: [],
+      dora: [],
+      turn: 3,
+      kyoku: 1,
+      riichiPool: 0,
+      honba: 0,
+    };
+
+    act(() => {
+      result.current.setBoardInput(JSON.stringify(board));
+    });
+    act(() => {
+      result.current.handleLoadBoard();
+    });
+    act(() => {
+      result.current.nextTurn();
+    });
+    try {
+      await act(async () => {
+        vi.advanceTimersByTime(600); // draw winning tile
+      });
+      act(() => {
+        result.current.handleTsumo();
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(1000); // allow any scheduled actions
+      });
+      vi.runAllTimers();
+      const lastEntry = result.current.log[result.current.log.length - 1];
+      expect(lastEntry.type).toBe('tsumo');
+    } finally {
+      unmount();
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/game/winTimeout.test.ts
+++ b/src/game/winTimeout.test.ts
@@ -8,20 +8,25 @@ import { useGame } from './store';
 describe('useGame win timeout clearing', () => {
   it('stops scheduled actions on tsumo', () => {
     vi.useFakeTimers();
-    const { result } = renderHook(() => useGame('tonpu'));
-    // schedule nextTurn to create a pending timeout
-    act(() => {
-      result.current.nextTurn();
-    });
-    // Perform tsumo before the timeout triggers
-    act(() => {
-      result.current.handleTsumo();
-    });
-    const currentTurnAfterWin = result.current.turn;
-    // advance timers to check if nextTurn was cancelled
-    vi.advanceTimersByTime(600);
-    expect(result.current.turn).toBe(currentTurnAfterWin);
-    expect(result.current.winResult?.winType).toBe('tsumo');
-    vi.useRealTimers();
+    const { result, unmount } = renderHook(() => useGame('tonpu'));
+    try {
+      // schedule nextTurn to create a pending timeout
+      act(() => {
+        result.current.nextTurn();
+      });
+      // Perform tsumo before the timeout triggers
+      act(() => {
+        result.current.handleTsumo();
+      });
+      const currentTurnAfterWin = result.current.turn;
+      // advance timers to check if nextTurn was cancelled
+      vi.advanceTimersByTime(600);
+      vi.runAllTimers();
+      expect(result.current.turn).toBe(currentTurnAfterWin);
+      expect(result.current.winResult?.winType).toBe('tsumo');
+    } finally {
+      unmount();
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/utils/ai.test.ts
+++ b/src/utils/ai.test.ts
@@ -210,7 +210,7 @@ describe('chooseAIDiscardTile', () => {
       ...data.filter(d => d.value === min).map(d => d.ukeire),
     );
     expect(evaluate(chosen).ukeire).toBe(bestUkeire);
-  });
+  }, 10000);
 
   it('uses synergy tie-breaker when advanced mode is off', () => {
     const hand: Tile[] = [


### PR DESCRIPTION
## Summary
- ensure win results are recorded immediately to stop further draws after tsumo/ron
- add regression test for tsumo not advancing the round
- stabilize timer-based tests and extend slow AI test timeout

## Testing
- `npm run lint --if-present`
- `npm run type-check --if-present`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689898c97604832a921b13ca1fe7ae5d